### PR TITLE
fix: spawn pnpm/corepack/npm via a shell on Windows

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -65,10 +65,16 @@ interface InstallResult {
 /** Whether `pnpm` resolves on PATH; success is cached, absence is re-probed. */
 let pnpmReady = false
 
+/**
+ * Windows npm/corepack/pnpm are `.cmd` shims. Node's `spawn` without a shell
+ * cannot start them (ENOENT / EINVAL). Same pattern as dsh's `plugin` forwarder.
+ */
+const winCmdShim = process.platform === 'win32'
+
 function probePnpm(): Promise<boolean> {
   if (pnpmReady) return Promise.resolve(true)
   return new Promise((resolvePromise) => {
-    const child = spawn('pnpm', ['--version'], { stdio: 'ignore' })
+    const child = spawn('pnpm', ['--version'], { stdio: 'ignore', shell: winCmdShim })
     child.on('error', () => resolvePromise(false))
     child.on('close', (code) => {
       pnpmReady = code === 0
@@ -79,7 +85,11 @@ function probePnpm(): Promise<boolean> {
 
 function runQuiet(file: string, args: string[], timeoutMs: number): Promise<{ code: number | null; output: string }> {
   return new Promise((resolvePromise) => {
-    const child = spawn(file, args, { env: { ...process.env, CI: 'true' }, stdio: ['ignore', 'pipe', 'pipe'] })
+    const child = spawn(file, args, {
+      env: { ...process.env, CI: 'true' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: winCmdShim,
+    })
     let output = ''
     const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs)
     const collect = (chunk: Buffer): void => { output = (output + chunk.toString()).slice(-8 * 1024) }


### PR DESCRIPTION
## Summary

Fixes #2 and #3.

On Windows, `probePnpm()` and `provisionPnpm()` spawn bare `pnpm` / `corepack` / `npm` without a shell. Those commands are `.cmd` shims, so Node 20+ `spawn` fails:

- `spawn('npm')` → `ENOENT`
- `spawn('npm.cmd')` → `EINVAL`
- `spawn('npm', …, { shell: true })` → works

The market then reports `pnpm: false`, shows the “one small component” banner, and the one-click setup button cannot recover. Install/update via `dshArgv()` (`process.execPath`) is a different path and was already fine.

This matches the dsh CLI plugin forwarder:

```js
shell: process.platform === "win32"
```

Args passed through these two helpers are fixed (`--version`, `enable pnpm`, `install -g pnpm`), so the Windows `shell: true` surface is the same as dsh's own `plugin` command.

## 中文摘要

Windows 上 `npm` / `corepack` / `pnpm` 只有 `.cmd` 垫片。市场探测和「自动准备」用无 shell 的 `spawn`，会得到 `ENOENT`，界面一直提示还差小组件。这里与官方 `dsh plugin` 对齐，仅在 win32 上打开 `shell`。

## Test plan

- [x] Reproduced on win32 x64 / Node v24.14.1: bare `spawn('pnpm'|'corepack'|'npm')` → `ENOENT`; `shell: true` → versions print (`pnpm` 11.21.0, `corepack` 0.34.6, `npm` 11.11.0).
- [ ] After merge + publish: `GET /dsh-market/status` returns `"pnpm": true` on Windows when pnpm is already on PATH.
- [ ] “Set up automatically” no longer logs `setup-pnpm: … spawn … ENOENT`.
- [ ] Linux/macOS unchanged (`shell` stays false).