### PR TITLE
fix(win32): spawn npm/corepack/pnpm .cmd shims correctly; fix dark-mode button contrast

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -133,7 +133,7 @@ const CSS = `
 .dshm-top{position:absolute;right:18px;bottom:18px;z-index:20;width:38px;height:38px;border-radius:99px;border:1px solid var(--dsw-alias-border-l1,#e5e7eb);background:var(--dsw-alias-bg-layer-1,#fff);color:var(--dsw-alias-label-secondary,#6b7280);font-size:16px;cursor:pointer;box-shadow:0 4px 14px rgba(0,0,0,.12)}
 .dshm-top:hover{color:var(--dsw-alias-brand-primary,#4f6ef7)}
 .dshm-chip{font:inherit;font-size:12px;border:1px solid var(--dsw-alias-border-l1,#e5e7eb);background:var(--dsw-alias-bg-layer-1,#fff);border-radius:99px;padding:3px 11px;cursor:pointer;color:var(--dsw-alias-label-secondary,#6b7280)}
-.dshm-chip.on{background:var(--dsw-alias-brand-primary,#4f6ef7);border-color:var(--dsw-alias-brand-primary,#4f6ef7);color:#fff}
+.dshm-chip.on{background:var(--dsw-alias-button-primary-fill,#4f6ef7);border-color:var(--dsw-alias-button-primary-fill,#4f6ef7);color:var(--dsw-alias-label-primary-foreground,#fff)}
 .dshm-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:10px}
 .dshm-card{background:var(--dsw-alias-bg-layer-1,#fff);border:1px solid var(--dsw-alias-border-l1,#e5e7eb);border-radius:10px;padding:12px 14px;display:flex;flex-direction:column;gap:6px}
 .dshm-row1{display:flex;align-items:center;gap:9px;min-width:0}
@@ -147,7 +147,7 @@ const CSS = `
 .dshm-src{font-size:11px;color:var(--dsw-alias-label-secondary,#9ca3af);text-decoration:none}
 .dshm-src:hover{color:var(--dsw-alias-brand-primary,#4f6ef7)}
 .dshm-btn{border:none;border-radius:7px;padding:5px 14px;font:inherit;font-size:12px;cursor:pointer;font-weight:600}
-.dshm-btn.install{background:var(--dsw-alias-brand-primary,#4f6ef7);color:#fff}
+.dshm-btn.install{background:var(--dsw-alias-button-primary-fill,#4f6ef7);color:var(--dsw-alias-label-primary-foreground,#fff)}
 .dshm-btn.busy{opacity:.65;cursor:default}
 .dshm-btn.done{background:transparent;color:var(--dsw-alias-state-success-primary,#16a34a);cursor:default}
 .dshm-btn.ghost{background:var(--dsw-alias-bg-layer-2,#f3f4f6);color:var(--dsw-alias-label-secondary,#6b7280)}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,7 +7,8 @@
  */
 
 import { spawn } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import type { ChildProcess, SpawnOptions } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
@@ -62,13 +63,69 @@ interface InstallResult {
   stderr: string
 }
 
+type ToolResolution =
+  | { type: 'shell'; name: string }
+  | { type: 'path'; file: string }
+  | { type: 'cmdshim'; file: string }
+
+/**
+ * Locate a CLI tool on Windows. `npm`/`corepack`/`pnpm` ship as `.cmd` shims
+ * (no `.exe`), which node:child_process cannot exec directly and which a bare
+ * `spawn` cannot find when the Node install dir isn't on PATH. Lookup order:
+ * the Node install directory (shims live next to node.exe), then PATH dirs.
+ */
+function resolveTool(name: string): ToolResolution {
+  if (process.platform !== 'win32') return { type: 'shell', name }
+  const candidates = [join(dirname(process.execPath), `${name}.cmd`)]
+  for (const dir of (process.env.Path ?? process.env.PATH ?? '').split(';')) {
+    if (dir !== '') candidates.push(join(dir, `${name}.cmd`), join(dir, `${name}.exe`))
+  }
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return /\.exe$/i.test(candidate)
+        ? { type: 'path', file: candidate }
+        : { type: 'cmdshim', file: candidate }
+    }
+  }
+  return { type: 'shell', name }
+}
+
+/**
+ * Spawn a CLI tool that node:child_process could otherwise not start on
+ * Windows: `.cmd`/`.bat` shims must run through cmd.exe, and a shim path
+ * containing spaces needs the outer-quote wrapper because cmd /c strips the
+ * first and last quote of the line.
+ */
+function spawnTool(name: string, args: string[], options: SpawnOptions = {}): ChildProcess {
+  const resolved = resolveTool(name)
+  if (process.platform !== 'win32' || resolved.type === 'path') {
+    return spawn(resolved.type === 'path' ? resolved.file : resolved.name, args, options)
+  }
+  const argLine = args.map((arg) => /[ \t&|<>^()"]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg).join(' ')
+  const cmdline = resolved.type === 'cmdshim'
+    ? (argLine === '' ? `""${resolved.file}""` : `""${resolved.file}" ${argLine}"`)
+    : (argLine === '' ? resolved.name : `${resolved.name} ${argLine}`)
+  return spawn('cmd.exe', ['/d', '/s', '/c', cmdline], { ...options, windowsVerbatimArguments: true })
+}
+
+/** Kill a spawned child and, on Windows, its whole process tree. */
+function killChild(child: ChildProcess): void {
+  if (process.platform === 'win32' && child.pid !== undefined) {
+    try {
+      spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore' })
+    } catch { /* best effort */ }
+  } else {
+    child.kill('SIGKILL')
+  }
+}
+
 /** Whether `pnpm` resolves on PATH; success is cached, absence is re-probed. */
 let pnpmReady = false
 
 function probePnpm(): Promise<boolean> {
   if (pnpmReady) return Promise.resolve(true)
   return new Promise((resolvePromise) => {
-    const child = spawn('pnpm', ['--version'], { stdio: 'ignore' })
+    const child = spawnTool('pnpm', ['--version'], { stdio: 'ignore' })
     child.on('error', () => resolvePromise(false))
     child.on('close', (code) => {
       pnpmReady = code === 0
@@ -79,9 +136,9 @@ function probePnpm(): Promise<boolean> {
 
 function runQuiet(file: string, args: string[], timeoutMs: number): Promise<{ code: number | null; output: string }> {
   return new Promise((resolvePromise) => {
-    const child = spawn(file, args, { env: { ...process.env, CI: 'true' }, stdio: ['ignore', 'pipe', 'pipe'] })
+    const child = spawnTool(file, args, { env: { ...process.env, CI: 'true' }, stdio: ['ignore', 'pipe', 'pipe'] })
     let output = ''
-    const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs)
+    const timer = setTimeout(() => killChild(child), timeoutMs)
     const collect = (chunk: Buffer): void => { output = (output + chunk.toString()).slice(-8 * 1024) }
     child.stdout.on('data', collect)
     child.stderr.on('data', collect)
@@ -142,7 +199,7 @@ function runDshPlugin(profile: string, pluginArgs: string[]): Promise<InstallRes
     let timedOut = false
     const timer = setTimeout(() => {
       timedOut = true
-      child.kill('SIGKILL')
+      killChild(child)
     }, INSTALL_TIMEOUT_MS)
     child.stdout.on('data', (chunk: Buffer) => {
       const text = chunk.toString()


### PR DESCRIPTION
## Summary

Fixes two bugs found on Windows (v1.0.2):

1. **`setup-pnpm` always fails on Windows — `spawn corepack/npm ENOENT`** (fixes #2)
   On Windows, `npm`/`corepack`/`pnpm` ship as `.cmd` shims (no `.exe`). `node:child_process.spawn('npm', ...)` cannot execute a `.cmd` file without a shell, so `probePnpm()` / `provisionPnpm()` always failed with `spawn npm ENOENT` — even when pnpm was already installed. The UI then permanently showed the "one small component is needed" banner and one-click installs never worked.

   Fix:
   - `resolveTool()` — locate a tool as the Node install dir's `.cmd` shim, a PATH `.exe`, or fall back to shell PATH resolution.
   - `spawnTool()` — run `.cmd`/`.bat` shims through `cmd.exe /d /s /c` with the outer-quote wrapper (cmd `/c` strips the first/last quote of the line, so a shim path containing spaces — e.g. `C:\Program Files\nodejs\npm.cmd` — must be double-wrapped).
   - `killChild()` — on timeout, use `taskkill /pid <pid> /t /f` so the whole process tree (including pnpm children of the `dsh plugin` CLI) is terminated instead of only the wrapper.

   Verified on Windows: `pnpm --version` → 11.5.2 (exit 0), `npm --version` → 10.9.3 (exit 0), `corepack --version` → 0.34.0 (exit 0), all previously ENOENT.

2. **Primary buttons are invisible in dark mode** (`安装`, `自动装好`, selected category chip)
   DSH's dark theme resolves `--dsw-alias-brand-primary` to *white* (inverted brand). The market CSS used it as the button background with a hardcoded `color: #fff`, producing white-on-white buttons in dark mode.

   Fix: use the same token pair as DSH's own primary buttons — `--dsw-alias-button-primary-fill` (background) + `--dsw-alias-label-primary-foreground` (text). Light mode is unchanged (dark fill / light text); dark mode becomes white fill / dark text, matching the rest of the shell.

   Verified in the live web UI (dark theme): `安装` buttons and the selected category chip now compute to `rgb(249,250,251)` background / `rgb(15,17,21)` text.

## Files changed

- `client/client.js` — dark-mode contrast fix (2 CSS rules, `.dshm-btn.install` and `.dshm-chip.on`)
- `src/routes.ts` — Windows `.cmd` shim spawning + process-tree kill on timeout

No `lib/` build output is committed (it is generated from `src/` by `npm run build`).
