### PR TITLE
Closes #20: pass -w to pnpm for update too (workspace-root profiles)

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -176,7 +176,7 @@ function runDshPlugin(profile: string, pluginArgs: string[]): Promise<InstallRes
   const { file, args, cwd, viaShell } = dshArgv()
   // pnpm 9 refuses to add at a workspace root without -w (#17); pnpm 10/11
   // accept the flag as a no-op there, so it is safe to pass always.
-  if (pluginArgs[0] === 'add' || pluginArgs[0] === 'remove') {
+  if (pluginArgs[0] === 'add' || pluginArgs[0] === 'remove' || pluginArgs[0] === 'update') {
     pluginArgs = [pluginArgs[0], '-w', ...pluginArgs.slice(1)]
   }
   const target = pluginArgs[pluginArgs.length - 1] ?? ''


### PR DESCRIPTION
## Summary

Fixes #20. The install/update/remove flow on a **workspace-root profile** (the default  profile template, whose  has ) fails because  only passed  for /, not .

- pnpm 9 refuses // at a workspace root without  → .
- pnpm 10/11 accept the flag as a no-op there, so passing it always is safe.

## Change

```ts
-  if (pluginArgs[0] === 'add' || pluginArgs[0] === 'remove') {
+  if (pluginArgs[0] === 'add' || pluginArgs[0] === 'remove' || pluginArgs[0] === 'update') {
```

## Verification

- `npm run typecheck` ✅ (tsc -p tsconfig.json + tsconfig.client.json)
- `npm run build` ✅
- `node scripts/preflight.mjs` ✅
- `node scripts/smoke-spawn.mjs` ✅

One-line change, the update route goes through the same `runDshPlugin` path as add/remove, so this closes the remaining gap on workspace-root profiles without touching non-workspace flows.