### PR TITLE
chore: refresh registry snapshot from awesome-dsh-plugin.com

### DIFF
--- a/data/registry-snapshot.json
+++ b/data/registry-snapshot.json
@@ -2,8 +2,8 @@
  "name": "awesome-dsh-plugin",
  "url": "https://awesome-dsh-plugin.com",
  "source": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin",
- "updated": "2026-08-14",
- "count": 237,
+ "updated": "2026-08-15",
+ "count": 457,
  "categories": {
   "ui": {
    "en": "UI Enhancements",
@@ -52,44 +52,287 @@
  },
  "plugins": [
   {
+   "name": "dsh-plugin-tts",
+   "owner": "1624318455",
+   "url": "https://github.com/1624318455/dsh-plugin-tts",
+   "page": "https://awesome-dsh-plugin.com/p/1624318455/dsh-plugin-tts/",
+   "category": "ui",
+   "description": {
+    "en": "Reads assistant replies aloud via free Edge TTS: per-message read-aloud buttons, an auto-read toggle, and a voice settings panel.",
+    "zh": "用免费 Edge TTS 朗读 AI 回复：消息朗读按钮、自动朗读开关与语音设置面板。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:1624318455/dsh-plugin-tts",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-client-ui-writing",
+   "owner": "x2802490130-prog",
+   "url": "https://github.com/x2802490130-prog/dsh-client-ui-writing",
+   "page": "https://awesome-dsh-plugin.com/p/x2802490130-prog/dsh-client-ui-writing/",
+   "category": "ui",
+   "description": {
+    "en": "Client-side writing panel for the Web UI: project volumes and stats, corpus library, full-text search, evolution version-chain diffs, and an SVG thread graph, shown only in writing-preset sessions.",
+    "zh": "Web 客户端「写作」面板：项目分卷与统计、书库与全文检索、设定演化版本链 diff、线索 SVG 图谱，仅在写作预设会话显示。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:x2802490130-prog/dsh-client-ui-writing",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-global-rules",
+   "owner": "badai147",
+   "url": "https://github.com/badai147/dsh-global-rules",
+   "page": "https://awesome-dsh-plugin.com/p/badai147/dsh-global-rules/",
+   "category": "ui",
+   "description": {
+    "en": "Edit the global ~/.dsh/AGENTS.md rules from the web settings panel, live on save.",
+    "zh": "在设置面板中编辑 ~/.dsh/AGENTS.md 全局规则，保存后实时生效。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:badai147/dsh-global-rules",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-web-mobile-fix",
+   "owner": "AcidGr",
+   "url": "https://github.com/AcidGr/dsh-web-mobile-fix",
+   "page": "https://awesome-dsh-plugin.com/p/AcidGr/dsh-web-mobile-fix/",
+   "category": "ui",
+   "description": {
+    "en": "Mobile layout fixes for the Web UI on narrow screens: full-screen settings panel, one-row plugin nav, full-screen sidebar, centered popups, icon-only session-log button.",
+    "zh": "Web UI 移动端布局修复：窄屏下设置面板全屏化、插件导航单行排满、侧边栏全屏、弹层居中、会话日志按钮图标化。"
+   },
+   "npm": "dsh-web-mobile-fix",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-web-mobile-fix",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-web-mobile",
+   "owner": "mexiaosqwq",
+   "url": "https://github.com/mexiaosqwq/dsh-web-mobile",
+   "page": "https://awesome-dsh-plugin.com/p/mexiaosqwq/dsh-web-mobile/",
+   "category": "ui",
+   "description": {
+    "en": "Mobile-adaptive layout for the DSH Web UI: the sidebar becomes a content-hugging overlay drawer, the conversation gets the full width, and the settings panel becomes a near-full-width sheet.",
+    "zh": "DSH Web UI 移动端适配：窄屏下侧边栏变为贴合内容的 overlay 抽屉、会话独占全宽，设置面板改为近全宽 sheet。"
+   },
+   "npm": null,
+   "stars": 5,
+   "install": "dsh plugin --profile web add github:mexiaosqwq/dsh-web-mobile",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-web-lan-access",
+   "owner": "AcidGr",
+   "url": "https://github.com/AcidGr/dsh-web-lan-access",
+   "page": "https://awesome-dsh-plugin.com/p/AcidGr/dsh-web-lan-access/",
+   "category": "ui",
+   "description": {
+    "en": "LAN/remote access for the Web UI: injects a crypto.randomUUID polyfill on plain-HTTP origins so the frontend survives LAN or Tailscale IP direct links.",
+    "zh": "Web UI 局域网/远程访问：为纯 HTTP 非安全上下文注入 crypto.randomUUID polyfill，局域网/Tailscale IP 直连时前端不再崩溃。"
+   },
+   "npm": "dsh-web-lan-access",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-web-lan-access",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-mobile-gate",
+   "owner": "Bernardxu123",
+   "url": "https://github.com/Bernardxu123/dsh-mobile-gate",
+   "page": "https://awesome-dsh-plugin.com/p/Bernardxu123/dsh-mobile-gate/",
+   "category": "ui",
+   "description": {
+    "en": "LAN mobile gateway: isolated child-process reverse proxy with first-visit approval, per-device token binding, rate limiting, and mobile layout injection (compact composer pills, randomUUID polyfill).",
+    "zh": "局域网手机访问网关：独立子进程反向代理 + 首次访问审批 + 设备令牌绑定 + 限流 + 手机端紧凑排版注入（输入区权限/模型小胶囊、randomUUID polyfill）。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:Bernardxu123/dsh-mobile-gate",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-hub",
+   "owner": "Noob-stupid",
+   "url": "https://github.com/Noob-stupid/dsh-plugin-hub",
+   "page": "https://awesome-dsh-plugin.com/p/Noob-stupid/dsh-plugin-hub/",
+   "category": "ui",
+   "description": {
+    "en": "A plugin management panel: one-click enable/disable for installed plugins plus a GitHub dsh-plugin marketplace with details and one-click installs.",
+    "zh": "插件管理面板：已安装插件一键启用/停用，内置 GitHub dsh-plugin 插件市场，支持详情查看与一键安装。"
+   },
+   "npm": null,
+   "stars": 18,
+   "install": "dsh plugin --profile web add github:Noob-stupid/dsh-plugin-hub",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-usage-stats",
+   "owner": "Make0209",
+   "url": "https://github.com/Make0209/dsh-usage-stats",
+   "page": "https://awesome-dsh-plugin.com/p/Make0209/dsh-usage-stats/",
+   "category": "ui",
+   "description": {
+    "en": "GitHub-style usage heatmap dashboard: per-workspace turn counts and token spend (with cache-hit rate), DeepSeek account balance, and workspace aliases.",
+    "zh": "GitHub 风格用量热力图看板：按工作区统计使用次数与 Token 花费（含缓存命中率）、DeepSeek 账户余额查询、工作区别名管理。"
+   },
+   "npm": null,
+   "stars": 8,
+   "install": "dsh plugin --profile web add github:Make0209/dsh-usage-stats",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-usage-stats",
+   "owner": "Ychris12138",
+   "url": "https://github.com/Ychris12138/dsh-usage-stats",
+   "page": "https://awesome-dsh-plugin.com/p/Ychris12138/dsh-usage-stats/",
+   "category": "ui",
+   "description": {
+    "en": "Multi-provider usage dashboard with provider/model token breakdowns, calendar drill-downs, account balances, and OpenCode Go / Z.ai subscription quota tracking.",
+    "zh": "多供应商用量看板：按供应商/模型统计 Token 与日期下钻，统一展示账户余额，并追踪 OpenCode Go / Z.ai 订阅额度。"
+   },
+   "npm": null,
+   "stars": 20,
+   "install": "dsh plugin --profile web add github:Ychris12138/dsh-usage-stats",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-usage-meter",
+   "owner": "V-dev-388",
+   "url": "https://github.com/V-dev-388/dsh-usage-meter",
+   "page": "https://awesome-dsh-plugin.com/p/V-dev-388/dsh-usage-meter/",
+   "category": "ui",
+   "description": {
+    "en": "Settings-page usage dashboard: per-provider/model token summary across all sessions, with today/7-day/30-day CSS-bar trends and a cache-hit rate.",
+    "zh": "设置页用量仪表盘：按服务商/模型汇总全部会话 token 用量，含今日/近 7 天/近 30 天趋势柱状图与缓存命中率。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:V-dev-388/dsh-usage-meter",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-cost-balance",
+   "owner": "zoumutou",
+   "url": "https://github.com/zoumutou/dsh-cost-balance",
+   "page": "https://awesome-dsh-plugin.com/p/zoumutou/dsh-cost-balance/",
+   "category": "ui",
+   "description": {
+    "en": "Collapsible iOS-style stats pill under the composer: session cost, DeepSeek account balance, cache-hit rate, and token usage in a frosted panel.",
+    "zh": "输入框下方的 iOS 风格统计条：一键展开查看会话花费、DeepSeek 账户余额、缓存命中率与 Token 用量。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:zoumutou/dsh-cost-balance",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-context",
+   "owner": "bowenliang123",
+   "url": "https://github.com/bowenliang123/dsh-context",
+   "page": "https://awesome-dsh-plugin.com/p/bowenliang123/dsh-context/",
+   "category": "ui",
+   "description": {
+    "en": "Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.",
+    "zh": "上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。"
+   },
+   "npm": "dsh-context",
+   "stars": 32,
+   "install": "dsh plugin --profile web add dsh-context",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-web-default-session",
+   "owner": "wjy9902",
+   "url": "https://github.com/wjy9902/dsh-web-default-session",
+   "page": "https://awesome-dsh-plugin.com/p/wjy9902/dsh-web-default-session/",
+   "category": "ui",
+   "description": {
+    "en": "The generic New Session action opens a default-directory workspace instead of requiring a folder pick, and the workspace picker lists that workspace as a no-folder choice.",
+    "zh": "点「新会话」默认打开绑定宿主启动目录的「默认目录」工作区（无需选文件夹），工作区选择菜单中也可选该项。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:wjy9902/dsh-web-default-session",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-prompt-enhancer",
+   "owner": "Fishsb",
+   "url": "https://github.com/Fishsb/dsh-prompt-enhancer",
+   "page": "https://awesome-dsh-plugin.com/p/Fishsb/dsh-prompt-enhancer/",
+   "category": "ui",
+   "description": {
+    "en": "One-click prompt enhancement: an independent LLM call rewrites your rough draft in the composer, fully undoable.",
+    "zh": "一键提示词增强：独立 LLM 调用把模糊草稿改写为更强的提示词，不满意可撤回。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:Fishsb/dsh-prompt-enhancer",
+   "added": "2026-08-14"
+  },
+  {
    "name": "dsh-tianshu-tui",
    "owner": "huiliyi37",
    "url": "https://github.com/huiliyi37/dsh-tianshu-tui",
+   "page": "https://awesome-dsh-plugin.com/p/huiliyi37/dsh-tianshu-tui/",
    "category": "ui",
    "description": {
     "en": "A terminal UI (TUI) for DeepSeek Harness.",
     "zh": "DeepSeek Harness 的终端 UI（TUI）。"
    },
-   "npm": null,
-   "stars": 110,
-   "install": "dsh plugin --profile web add github:huiliyi37/dsh-tianshu-tui",
+   "npm": "@huiliyi37/dsh-tianshu-tui",
+   "stars": 139,
+   "install": "dsh plugin --profile web add @huiliyi37/dsh-tianshu-tui",
    "added": "2026-08-13"
   },
   {
    "name": "deepseek-harness-tui",
    "owner": "openma-ai",
    "url": "https://github.com/openma-ai/deepseek-harness-tui",
+   "page": "https://awesome-dsh-plugin.com/p/openma-ai/deepseek-harness-tui/",
    "category": "ui",
    "description": {
     "en": "A Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.",
     "zh": "Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。"
    },
    "npm": null,
-   "stars": 11,
+   "stars": 21,
    "install": "dsh plugin --profile web add github:openma-ai/deepseek-harness-tui",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-input-plus",
+   "owner": "WhitePlusMS",
+   "url": "https://github.com/WhitePlusMS/dsh-input-plus",
+   "page": "https://awesome-dsh-plugin.com/p/WhitePlusMS/dsh-input-plus/",
+   "category": "ui",
+   "description": {
+    "en": "Search and insert workspace file and directory paths with `@`, plus a `/h` menu for reusing prompts from the current session.",
+    "zh": "在组合框中使用 `@` 搜索并插入工作区文件和目录路径，并通过 `/h` 菜单复用当前会话的问题。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:WhitePlusMS/dsh-input-plus",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-at-file",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-at-file",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-at-file/",
    "category": "ui",
    "description": {
     "en": "Codex-style `@file` mentions: search workspace files in the composer and attach their contents to prompts.",
     "zh": "Codex 风格的 `@file` 文件引用，输入框里直接搜索并引用工作区文件。"
    },
    "npm": null,
-   "stars": 98,
+   "stars": 147,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-at-file",
    "added": "2026-08-13"
   },
@@ -97,27 +340,59 @@
    "name": "ui-status-label",
    "owner": "alingalingling",
    "url": "https://github.com/alingalingling/ui-status-label",
+   "page": "https://awesome-dsh-plugin.com/p/alingalingling/ui-status-label/",
    "category": "ui",
    "description": {
     "en": "Customize the \"deep diving\" thinking status label to anything you like.",
     "zh": "把鲸鱼娘思考时的 \"deep diving\" 状态文案自定义成任意你想要的样子。"
    },
    "npm": null,
-   "stars": 26,
+   "stars": 31,
    "install": "dsh plugin --profile web add github:alingalingling/ui-status-label",
    "added": "2026-08-13"
+  },
+  {
+   "name": "dsh-whale-animation",
+   "owner": "LeemanCheung",
+   "url": "https://github.com/LeemanCheung/dsh-whale-animation",
+   "page": "https://awesome-dsh-plugin.com/p/LeemanCheung/dsh-whale-animation/",
+   "category": "ui",
+   "description": {
+    "en": "Persistent black whale-dive animation beside the DSH Web turn status, with a reduced-motion fallback and a seamless closed loop.",
+    "zh": "DSH Web 状态文字旁的持久化黑色鲸鱼深潜动画，提供减少动态效果回退与无缝闭环。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:LeemanCheung/dsh-whale-animation",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-status-rotator",
+   "owner": "01Virex",
+   "url": "https://github.com/01Virex/dsh-status-rotator",
+   "page": "https://awesome-dsh-plugin.com/p/01Virex/dsh-status-rotator/",
+   "category": "ui",
+   "description": {
+    "en": "Replaces the \"Deep diving...\" turn-status label with rotating meme-worthy phrases, with typewriter and gradient effects.",
+    "zh": "把回合状态那句 \"Deep diving...\" 替换成更有梗的自定义文案，按阶段轮换，支持打字机与流动渐变。"
+   },
+   "npm": null,
+   "stars": 8,
+   "install": "dsh plugin --profile web add github:01Virex/dsh-status-rotator",
+   "added": "2026-08-14"
   },
   {
    "name": "dsh-openpencil",
    "owner": "ZSeven-W",
    "url": "https://github.com/ZSeven-W/dsh-openpencil",
+   "page": "https://awesome-dsh-plugin.com/p/ZSeven-W/dsh-openpencil/",
    "category": "ui",
    "description": {
     "en": "OpenPencil design preview and editing plugin.",
     "zh": "OpenPencil 设计预览与编辑插件。"
    },
    "npm": "@zseven-w/dsh-openpencil",
-   "stars": 61,
+   "stars": 67,
    "install": "dsh plugin --profile web add @zseven-w/dsh-openpencil",
    "added": "2026-08-13"
   },
@@ -125,13 +400,14 @@
    "name": "dsh-visualize",
    "owner": "Nagi-ovo",
    "url": "https://github.com/Nagi-ovo/dsh-visualize",
+   "page": "https://awesome-dsh-plugin.com/p/Nagi-ovo/dsh-visualize/",
    "category": "ui",
    "description": {
     "en": "In-conversation generative UI: the model renders interactive HTML cards into the chat stream, with streaming preview and sandboxed rendering.",
     "zh": "对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览与沙箱渲染。"
    },
    "npm": null,
-   "stars": 67,
+   "stars": 86,
    "install": "dsh plugin --profile web add github:Nagi-ovo/dsh-visualize",
    "added": "2026-08-13"
   },
@@ -139,27 +415,44 @@
    "name": "dsh-side-panel",
    "owner": "ccq1",
    "url": "https://github.com/ccq1/dsh-side-panel",
+   "page": "https://awesome-dsh-plugin.com/p/ccq1/dsh-side-panel/",
    "category": "ui",
    "description": {
     "en": "Side panel with file browser, terminal, and Git review for quick file previews.",
     "zh": "侧边栏集成文件浏览器、终端和 Git 审查，方便预览文件。"
    },
    "npm": null,
-   "stars": 16,
+   "stars": 17,
    "install": "dsh plugin --profile web add github:ccq1/dsh-side-panel",
    "added": "2026-08-13"
+  },
+  {
+   "name": "dsh-agfs",
+   "owner": "openAGFS",
+   "url": "https://github.com/openAGFS/dsh-agfs",
+   "page": "https://awesome-dsh-plugin.com/p/openAGFS/dsh-agfs/",
+   "category": "ui",
+   "description": {
+    "en": "File-browser web app for DSH: React frontend and REST API served by the host webserver, a /dsh-agfs command that opens at the current session workspace, and a browse_files model tool.",
+    "zh": "文件浏览器 Web 应用：React 前端与 REST API 由宿主 webserver 托管，/dsh-agfs 命令自动定位当前工作区，附 browse_files 模型工具。"
+   },
+   "npm": "@open-agfs/dsh-agfs",
+   "stars": 0,
+   "install": "dsh plugin --profile web add @open-agfs/dsh-agfs",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-focus-chat",
    "owner": "dingyi222666",
    "url": "https://github.com/dingyi222666/dsh-focus-chat",
+   "page": "https://awesome-dsh-plugin.com/p/dingyi222666/dsh-focus-chat/",
    "category": "ui",
    "description": {
     "en": "A \"focus chat\" minimal view that shows only final outputs.",
     "zh": "「聚焦会话」精简视图，只关注最终产出结果。"
    },
    "npm": null,
-   "stars": 11,
+   "stars": 16,
    "install": "dsh plugin --profile web add github:dingyi222666/dsh-focus-chat",
    "added": "2026-08-13"
   },
@@ -167,13 +460,14 @@
    "name": "dsh-genui",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-genui",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-genui/",
    "category": "ui",
    "description": {
     "en": "Interactive UI components rendered inline in replies: layout, charts, forms, quizzes, mermaid, 3D scenes, and an action event loop back to the model.",
     "zh": "助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景与回传事件循环。"
    },
    "npm": null,
-   "stars": 60,
+   "stars": 81,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-genui",
    "added": "2026-08-13"
   },
@@ -181,13 +475,14 @@
    "name": "dsh-annotation",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-annotation",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-annotation/",
    "category": "ui",
    "description": {
     "en": "Select text → annotate → send with your message; replies map back to each annotation.",
     "zh": "选中文字→批注→随消息发送，回复按批注逐条对照。"
    },
    "npm": null,
-   "stars": 27,
+   "stars": 43,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-annotation",
    "added": "2026-08-13"
   },
@@ -195,13 +490,14 @@
    "name": "dsh-navbar",
    "owner": "vlln",
    "url": "https://github.com/vlln/dsh-navbar",
+   "page": "https://awesome-dsh-plugin.com/p/vlln/dsh-navbar/",
    "category": "ui",
    "description": {
     "en": "Conversation node navigation bar for quick jumps between user messages.",
     "zh": "对话节点导航条，右缘节点串快速跳转 user 消息。"
    },
    "npm": null,
-   "stars": 12,
+   "stars": 19,
    "install": "dsh plugin --profile web add github:vlln/dsh-navbar",
    "added": "2026-08-13"
   },
@@ -209,27 +505,44 @@
    "name": "dsh-message-preview",
    "owner": "asukasec",
    "url": "https://github.com/asukasec/dsh-message-preview",
+   "page": "https://awesome-dsh-plugin.com/p/asukasec/dsh-message-preview/",
    "category": "ui",
    "description": {
     "en": "Right-edge user-message navigator with an adaptive block layout that fits the available height, plus hover previews, keyboard controls, and click-to-jump navigation.",
     "zh": "右侧用户消息导航条，根据消息数量与可用高度自适应排布导航块，并支持悬停预览、键盘操作与点击跳转。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:asukasec/dsh-message-preview",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-chat-timeline",
+   "owner": "jjxjjjjiik-bot",
+   "url": "https://github.com/jjxjjjjiik-bot/dsh-chat-timeline",
+   "page": "https://awesome-dsh-plugin.com/p/jjxjjjjiik-bot/dsh-chat-timeline/",
+   "category": "ui",
+   "description": {
+    "en": "1:1 port of DeepSeek's official web right-side chat navigation rail (ScrollNav): hover-expandable rail, reading-position highlight, click-to-jump.",
+    "zh": "1:1 复刻 DeepSeek 官网右侧对话导航栏（ScrollNav）：悬停展开面板、阅读位置高亮、点击跳转。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:jjxjjjjiik-bot/dsh-chat-timeline",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-task-status",
    "owner": "vlln",
    "url": "https://github.com/vlln/dsh-task-status",
+   "page": "https://awesome-dsh-plugin.com/p/vlln/dsh-task-status/",
    "category": "ui",
    "description": {
     "en": "Background task status bar: progress plus live output tail on the chat page.",
     "zh": "后台任务状态条：对话页任务进度 + 实时输出 tail。"
    },
    "npm": null,
-   "stars": 7,
+   "stars": 8,
    "install": "dsh plugin --profile web add github:vlln/dsh-task-status",
    "added": "2026-08-13"
   },
@@ -237,13 +550,14 @@
    "name": "dsh-answer-pet",
    "owner": "Nanki-nn",
    "url": "https://github.com/Nanki-nn/dsh-answer-pet",
+   "page": "https://awesome-dsh-plugin.com/p/Nanki-nn/dsh-answer-pet/",
    "category": "ui",
    "description": {
     "en": "Animated blue-whale desktop pet with per-session response progress, model activity and tool-call traces, token counts, output speed, elapsed time, and collapsible multi-session status cards.",
     "zh": "蓝鲸桌面宠物：按会话实时展示回答进度、模型动作与工具调用轨迹、token、输出速率与耗时，并支持多会话状态卡片展开和收起。"
    },
    "npm": null,
-   "stars": null,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:Nanki-nn/dsh-answer-pet",
    "added": "2026-08-14"
   },
@@ -251,6 +565,7 @@
    "name": "dsh-web-archive",
    "owner": "renat3u",
    "url": "https://github.com/renat3u/dsh-web-archive",
+   "page": "https://awesome-dsh-plugin.com/p/renat3u/dsh-web-archive/",
    "category": "ui",
    "description": {
     "en": "Collapse noisy messages (Think, Bash, etc.) in conversations.",
@@ -265,27 +580,59 @@
    "name": "dsh-spotlight",
    "owner": "0xsline",
    "url": "https://github.com/0xsline/dsh-spotlight",
+   "page": "https://awesome-dsh-plugin.com/p/0xsline/dsh-spotlight/",
    "category": "ui",
    "description": {
     "en": "Keyboard-first command palette for the DSH Web UI.",
     "zh": "键盘优先的命令面板（command palette）。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:0xsline/dsh-spotlight",
    "added": "2026-08-13"
+  },
+  {
+   "name": "arcana",
+   "owner": "GooodWei",
+   "url": "https://github.com/GooodWei/arcana",
+   "page": "https://awesome-dsh-plugin.com/p/GooodWei/arcana/",
+   "category": "ui",
+   "description": {
+    "en": "A floating command deck that lists every slash command in DeepSeek Harness as runnable buttons, sorted by usage.",
+    "zh": "DeepSeek Harness 的悬浮命令甲板：把所有斜杠命令列成可执行按钮，悬停看介绍，按使用次数排序。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:GooodWei/arcana",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "context-vista",
+   "owner": "GooodWei",
+   "url": "https://github.com/GooodWei/context-vista",
+   "page": "https://awesome-dsh-plugin.com/p/GooodWei/context-vista/",
+   "category": "ui",
+   "description": {
+    "en": "A right-side floating panel and /context command for DeepSeek Harness — a live donut chart of context token usage, allocation, and estimated cost.",
+    "zh": "为 DeepSeek Harness 提供右侧悬浮栏以及 /context 命令，用环形图实时展示当前上下文 token 用量与分配及消费估算。"
+   },
+   "npm": "context-vista",
+   "stars": 4,
+   "install": "dsh plugin --profile web add context-vista",
+   "added": "2026-08-14"
   },
   {
    "name": "dsh-101",
    "owner": "bill9109",
    "url": "https://github.com/bill9109/dsh-101",
+   "page": "https://awesome-dsh-plugin.com/p/bill9109/dsh-101/",
    "category": "ui",
    "description": {
     "en": "Document reading mode for DSH.",
     "zh": "DSH 文档阅读模式。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:bill9109/dsh-101",
    "added": "2026-08-13"
   },
@@ -293,20 +640,52 @@
    "name": "dsh-drag-and-drop",
    "owner": "bill9109",
    "url": "https://github.com/bill9109/dsh-drag-and-drop",
+   "page": "https://awesome-dsh-plugin.com/p/bill9109/dsh-drag-and-drop/",
    "category": "ui",
    "description": {
     "en": "Cross-platform file drag-and-drop with raw path insertion, no file copying.",
     "zh": "跨平台文件拖拽与原始路径插入，无需复制文件。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:bill9109/dsh-drag-and-drop",
    "added": "2026-08-13"
+  },
+  {
+   "name": "dsh-drop-file-to-path",
+   "owner": "GLFzr",
+   "url": "https://github.com/GLFzr/dsh-drop-file-to-path",
+   "page": "https://awesome-dsh-plugin.com/p/GLFzr/dsh-drop-file-to-path/",
+   "category": "ui",
+   "description": {
+    "en": "Codex-style drag-drop: drag any file into the DSH web GUI, it lands in ~/.dsh-dropbox, and the path is inserted into the composer as a whole blue chip.",
+    "zh": "Codex 式拖拽：把任意文件拖入 DSH Web 界面，文件存入 ~/.dsh-dropbox，路径以整块蓝色 chip 插入输入框。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:GLFzr/dsh-drop-file-to-path",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-files",
+   "owner": "taxueseek",
+   "url": "https://github.com/taxueseek/dsh-files",
+   "page": "https://awesome-dsh-plugin.com/p/taxueseek/dsh-files/",
+   "category": "ui",
+   "description": {
+    "en": "File upload with color-coded attachment cards (session-isolated storage, sha256 dedup, TTL sweep) plus a content-sniffing read_document tool for PDF/DOCX/XLSX/TXT.",
+    "zh": "文件上传（彩色附件卡片、会话隔离存储、sha256 去重、TTL 清扫）+ 内容嗅探的 read_document 文档读取（PDF/DOCX/XLSX/TXT）。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:taxueseek/dsh-files",
+   "added": "2026-08-14"
   },
   {
    "name": "dsh-file-uploads",
    "owner": "l541402398",
    "url": "https://github.com/l541402398/dsh-file-uploads",
+   "page": "https://awesome-dsh-plugin.com/p/l541402398/dsh-file-uploads/",
    "category": "ui",
    "description": {
     "en": "Upload arbitrary local files from the Web composer, show pending cards, and manage stored files in Settings.",
@@ -321,6 +700,7 @@
    "name": "dsh-deeplink",
    "owner": "qyw233",
    "url": "https://github.com/qyw233/dsh-deeplink",
+   "page": "https://awesome-dsh-plugin.com/p/qyw233/dsh-deeplink/",
    "category": "ui",
    "description": {
     "en": "Deep links: open a specific session or workspace via `?session=` / `?workspace=`.",
@@ -335,13 +715,14 @@
    "name": "dsh-diff-viewer",
    "owner": "lehhair",
    "url": "https://github.com/lehhair/dsh-diff-viewer",
+   "page": "https://awesome-dsh-plugin.com/p/lehhair/dsh-diff-viewer/",
    "category": "ui",
    "description": {
     "en": "PiUI-style diff viewer replacing the stock DiffBlock for write/edit tool calls.",
     "zh": "PiUI 风格 diff 查看器，替换 write/edit 工具调用的默认 DiffBlock。"
    },
    "npm": null,
-   "stars": 5,
+   "stars": 9,
    "install": "dsh plugin --profile web add github:lehhair/dsh-diff-viewer",
    "added": "2026-08-13"
   },
@@ -349,13 +730,14 @@
    "name": "ex-setting",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/ex-setting",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/ex-setting/",
    "category": "ui",
    "description": {
     "en": "Settings extensions for DSH.",
     "zh": "DSH 的设置扩展。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:omdsh-dev/ex-setting",
    "added": "2026-08-13"
   },
@@ -363,13 +745,14 @@
    "name": "web-components",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/web-components",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/web-components/",
    "category": "ui",
    "description": {
     "en": "Web Components support.",
     "zh": "Web Components 支持。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:omdsh-dev/web-components",
    "added": "2026-08-13"
   },
@@ -377,6 +760,7 @@
    "name": "dsh-turn-navigator",
    "owner": "vibeinging",
    "url": "https://github.com/vibeinging/dsh-turn-navigator",
+   "page": "https://awesome-dsh-plugin.com/p/vibeinging/dsh-turn-navigator/",
    "category": "ui",
    "description": {
     "en": "Turn navigation for the DSH Web UI.",
@@ -391,13 +775,14 @@
    "name": "dsh-milestone",
    "owner": "SnowCrescenter-tech",
    "url": "https://github.com/SnowCrescenter-tech/dsh-milestone",
+   "page": "https://awesome-dsh-plugin.com/p/SnowCrescenter-tech/dsh-milestone/",
    "category": "ui",
    "description": {
     "en": "Right-side dot-timeline rail: jump between user messages.",
     "zh": "右侧圆点时间轴导航条，点击跳转到任意用户消息。"
    },
    "npm": null,
-   "stars": 7,
+   "stars": 12,
    "install": "dsh plugin --profile web add github:SnowCrescenter-tech/dsh-milestone",
    "added": "2026-08-13"
   },
@@ -405,13 +790,14 @@
    "name": "dsh-balance-meter",
    "owner": "Ghost011118",
    "url": "https://github.com/Ghost011118/dsh-balance-meter",
+   "page": "https://awesome-dsh-plugin.com/p/Ghost011118/dsh-balance-meter/",
    "category": "ui",
    "description": {
     "en": "DeepSeek account balance and session cost in the composer dock, with auto-fetched official pricing and peak/off-peak support.",
     "zh": "输入框 dock 显示 DeepSeek 账户余额与会话花费，自动拉取官方定价，支持高峰/低谷计价。"
    },
    "npm": null,
-   "stars": 11,
+   "stars": 12,
    "install": "dsh plugin --profile web add github:Ghost011118/dsh-balance-meter",
    "added": "2026-08-14"
   },
@@ -419,27 +805,44 @@
    "name": "dsh-opencode-go-usage",
    "owner": "v587d",
    "url": "https://github.com/v587d/dsh-opencode-go-usage",
+   "page": "https://awesome-dsh-plugin.com/p/v587d/dsh-opencode-go-usage/",
    "category": "ui",
    "description": {
     "en": "OpenCode Go subscription usage (rolling/weekly/monthly windows with reset countdowns) in the composer dock, with a built-in credential editor.",
     "zh": "在输入框上方 dock 显示 OpenCode Go 订阅用量（5h 滚动/每周/每月窗口与重置倒计时），内置凭据编辑器。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:v587d/dsh-opencode-go-usage",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-opencode-go-quota",
+   "owner": "GLFzr",
+   "url": "https://github.com/GLFzr/dsh-opencode-go-quota",
+   "page": "https://awesome-dsh-plugin.com/p/GLFzr/dsh-opencode-go-quota/",
+   "category": "ui",
+   "description": {
+    "en": "OpenCode Go quota ring: click-to-cycle progress ring (5h/weekly/monthly) left of the model selector, colored by urgency, with reset countdowns on hover.",
+    "zh": "模型选择器左侧的 OpenCode Go 额度圆环：点击循环切换 5 小时/每周/每月用量窗口，按紧急程度着色（绿/蓝/橙/红），悬停显示百分比与重置倒计时。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:GLFzr/dsh-opencode-go-quota",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-cost-meter",
    "owner": "Han-1413141",
    "url": "https://github.com/Han-1413141/dsh-cost-meter",
+   "page": "https://awesome-dsh-plugin.com/p/Han-1413141/dsh-cost-meter/",
    "category": "ui",
    "description": {
     "en": "Per-session and daily API cost, budget with usage %, official balance, history dashboard, and one-click official price sync with peak/off-peak pricing.",
     "zh": "会话与当日 API 费用统计、预算图框（已用%）、官方余额、历史看板，支持峰谷计价与官方价格一键同步。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 12,
    "install": "dsh plugin --profile web add github:Han-1413141/dsh-cost-meter",
    "added": "2026-08-14"
   },
@@ -447,6 +850,7 @@
    "name": "dsh-plugin-deepseek-balance",
    "owner": "fishxcode",
    "url": "https://github.com/fishxcode/dsh-plugin-deepseek-balance",
+   "page": "https://awesome-dsh-plugin.com/p/fishxcode/dsh-plugin-deepseek-balance/",
    "category": "ui",
    "description": {
     "en": "DeepSeek API balance, balance trend, and daily usage charts in DSH Web settings.",
@@ -461,6 +865,7 @@
    "name": "ds-api-usage",
    "owner": "Sev7een",
    "url": "https://github.com/Sev7een/ds-api-usage",
+   "page": "https://awesome-dsh-plugin.com/p/Sev7een/ds-api-usage/",
    "category": "ui",
    "description": {
     "en": "DeepSeek API balance and 24-hour usage dashboard in Settings, with estimated spend, token counts, request counts, and an hourly timeline.",
@@ -475,48 +880,127 @@
    "name": "dsh-spend",
    "owner": "nonewind",
    "url": "https://github.com/nonewind/dsh-spend",
+   "page": "https://awesome-dsh-plugin.com/p/nonewind/dsh-spend/",
    "category": "ui",
    "description": {
     "en": "Token usage and estimated spend for the dsh web UI: floating panel with per-model, per-day, and per-session stats.",
     "zh": "DSH Web 用量与费用统计插件：右下角悬浮窗，按模型/按天/按会话多维聚合与预计花费。"
    },
    "npm": "dsh-spend",
-   "stars": 0,
+   "stars": 4,
    "install": "dsh plugin --profile web add dsh-spend",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-balance-plugin",
+   "owner": "stevenx65",
+   "url": "https://github.com/stevenx65/dsh-balance-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/stevenx65/dsh-balance-plugin/",
+   "category": "ui",
+   "description": {
+    "en": "DeepSeek balance and token usage in the web sidebar, with a today/all-time toggle and provider filtering.",
+    "zh": "dsh 网页侧边栏的 DeepSeek 余额与 token 用量监控：今日/累计切换，并按 provider 过滤其他厂商。"
+   },
+   "npm": null,
+   "stars": 5,
+   "install": "dsh plugin --profile web add github:stevenx65/dsh-balance-plugin",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-balance",
+   "owner": "LemCAE",
+   "url": "https://github.com/LemCAE/dsh-balance",
+   "page": "https://awesome-dsh-plugin.com/p/LemCAE/dsh-balance/",
+   "category": "ui",
+   "description": {
+    "en": "DeepSeek account balance and current-session spend estimate in a top-bar chip and settings card, with pause-aware auto-refresh, an editable official price table, a `deepseek_balance` model tool, and a bilingual UI.",
+    "zh": "顶栏徽章与设置卡片展示 DeepSeek 账户余额与当前会话预估花费：暂停感知的自动刷新、可编辑官方价格表、`deepseek_balance` 模型工具与中英文界面。"
+   },
+   "npm": "@lemcae/dsh-balance",
+   "stars": 3,
+   "install": "dsh plugin --profile web add @lemcae/dsh-balance",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-balance-tide",
+   "owner": "huanyuLv",
+   "url": "https://github.com/huanyuLv/dsh-balance-tide",
+   "page": "https://awesome-dsh-plugin.com/p/huanyuLv/dsh-balance-tide/",
+   "category": "ui",
+   "description": {
+    "en": "DeepSeek account balance and session cost under the composer, with a live peak/off-peak pricing badge (Beijing time), a countdown to the next pricing switch, hover price tables, and usage advice.",
+    "zh": "输入框下方显示 DeepSeek 账户余额与本会话花费，余额前带峰/谷价格徽章（北京时间）与距切换倒计时，悬停看两档单价明细与使用建议。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:huanyuLv/dsh-balance-tide",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-TUI",
    "owner": "ccch1mneyyy",
    "url": "https://github.com/ccch1mneyyy/dsh-TUI",
+   "page": "https://awesome-dsh-plugin.com/p/ccch1mneyyy/dsh-TUI/",
    "category": "ui",
    "description": {
     "en": "Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion.",
     "zh": "Claude Code 风格全屏终端 UI：像素鲸鱼顶栏、实时工作状态行、思考流式展开。"
    },
-   "npm": null,
-   "stars": 684,
-   "install": "dsh plugin --profile web add github:ccch1mneyyy/dsh-TUI",
+   "npm": "@deepseek-harness-tui/dsh-tui",
+   "stars": 962,
+   "install": "dsh plugin --profile web add @deepseek-harness-tui/dsh-tui",
    "added": "2026-08-14"
   },
   {
    "name": "DSH-better-sidebar",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/DSH-better-sidebar",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/DSH-better-sidebar/",
    "category": "ui",
    "description": {
     "en": "Full sidebar workbench with file rendering and editing, terminal, Git, and subagents; third-party plugins can register new tabs.",
     "zh": "侧边栏完整工作台：内置文件渲染编辑、终端、Git 与子代理，支持三方插件注册新 Tab。"
    },
+   "npm": "dsh-better-sidebar",
+   "stars": 834,
+   "install": "dsh plugin --profile web add dsh-better-sidebar",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-workspace-search",
+   "owner": "tsonglew",
+   "url": "https://github.com/tsonglew/dsh-workspace-search",
+   "page": "https://awesome-dsh-plugin.com/p/tsonglew/dsh-workspace-search/",
+   "category": "ui",
+   "description": {
+    "en": "VS Code-style workspace keyword search tab for dsh-better-sidebar: matches file names and content, grouped by file with line numbers, opens in the sidebar editor.",
+    "zh": "VS Code 式工作区关键词搜索 Tab（better-sidebar 扩展）：同时匹配文件名与文件内容，结果按文件分组带行号，点击在侧栏编辑器打开。"
+   },
    "npm": null,
-   "stars": 591,
-   "install": "dsh plugin --profile web add github:omdsh-dev/DSH-better-sidebar",
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:tsonglew/dsh-workspace-search",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-media-preview",
+   "owner": "tsonglew",
+   "url": "https://github.com/tsonglew/dsh-media-preview",
+   "page": "https://awesome-dsh-plugin.com/p/tsonglew/dsh-media-preview/",
+   "category": "ui",
+   "description": {
+    "en": "Audio/video FileViewer for dsh-better-sidebar: native inline playback for mp4/webm/mkv/mov and mp3/flac/wav, served by a Range-capable streaming media route.",
+    "zh": "better-sidebar 音视频预览器：原生播放器内联播放 mp4/webm/mkv/mov 等视频与 mp3/flac/wav 等音频，自带支持 HTTP Range 拖动的流式媒体路由。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:tsonglew/dsh-media-preview",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-sticky-disclosure",
    "owner": "Han-1413141",
    "url": "https://github.com/Han-1413141/dsh-sticky-disclosure",
+   "page": "https://awesome-dsh-plugin.com/p/Han-1413141/dsh-sticky-disclosure/",
    "category": "ui",
    "description": {
     "en": "One-click collapse of every expanded section (Think rows, tool cards) with a live-count pill and a customizable hotkey.",
@@ -531,13 +1015,14 @@
    "name": "dsh-sticky-note",
    "owner": "Meredith2328",
    "url": "https://github.com/Meredith2328/dsh-sticky-note",
+   "page": "https://awesome-dsh-plugin.com/p/Meredith2328/dsh-sticky-note/",
    "category": "ui",
    "description": {
     "en": "Quick sticky notes on the composer toolbar: jot ideas or TODOs, auto-saved as Markdown, one click to send into the chat.",
     "zh": "编辑框工具栏便签，随手记点子和 TODO，自动保存为 Markdown，一键发送到对话。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:Meredith2328/dsh-sticky-note",
    "added": "2026-08-14"
   },
@@ -545,55 +1030,74 @@
    "name": "dsh-web-attention-badge",
    "owner": "Luaphes",
    "url": "https://github.com/Luaphes/dsh-web-attention-badge",
+   "page": "https://awesome-dsh-plugin.com/p/Luaphes/dsh-web-attention-badge/",
    "category": "ui",
    "description": {
     "en": "Attention reminders: frame badge, tab-title count, and a status-colored whale favicon for sessions waiting for input or finished unopened.",
     "zh": "会话需要你时三处同时亮起：角标、标签页标题计数、按状态换色的鲸鱼 favicon。"
    },
    "npm": "dsh-web-attention-badge",
-   "stars": 2,
+   "stars": 4,
    "install": "dsh plugin --profile web add dsh-web-attention-badge",
    "added": "2026-08-14"
   },
   {
-   "name": "dsh-web-ui",
+   "name": "dsh-web-ui#packages/dsh-web-ui-all",
    "owner": "zhu1090093659",
-   "url": "https://github.com/zhu1090093659/dsh-web-ui",
+   "url": "https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-web-ui-all",
+   "page": "https://awesome-dsh-plugin.com/p/zhu1090093659/dsh-web-ui--packages-dsh-web-ui-all/",
    "category": "ui",
    "description": {
     "en": "Plugin and skin collection for the DSH Web UI: task board, Git graph, right-side panel, remote mobile UI, pet, live token stats, and a skin center.",
     "zh": "DSH Web UI 插件与皮肤合集：任务看板、git 图、右侧面板、远程移动端 UI、桌宠、实时 token 统计与皮肤中心。"
    },
-   "npm": null,
-   "stars": 1446,
-   "install": "dsh plugin --profile web add github:zhu1090093659/dsh-web-ui",
+   "npm": "@linxin666/dsh-web-ui-all",
+   "stars": 2078,
+   "install": "dsh plugin --profile web add @linxin666/dsh-web-ui-all",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-pet",
    "owner": "zealot00",
    "url": "https://github.com/zealot00/dsh-pet",
+   "page": "https://awesome-dsh-plugin.com/p/zealot00/dsh-pet/",
    "category": "ui",
    "description": {
     "en": "Desktop pet for the DSH Web UI: sprite-sheet animation, agent state linkage, drag, alarm (daily/one-shot) and pomodoro widgets, skin picker with preview.",
     "zh": "DSH Web UI 桌面宠物：精灵图动画、agent 状态联动、拖拽、闹钟（每天/一次）与番茄钟，皮肤下拉选择 + 预览。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:zealot00/dsh-pet",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-desktop-pet",
+   "owner": "sereinmono",
+   "url": "https://github.com/sereinmono/dsh-desktop-pet",
+   "page": "https://awesome-dsh-plugin.com/p/sereinmono/dsh-desktop-pet/",
+   "category": "ui",
+   "description": {
+    "en": "A plugin that adds a desktop pet to your DeepSeek Harness, supporting the Codex pet format, you can use hatch-pet or Petdex to add your pets.",
+    "zh": "DeepSeek Harness 桌面宠物：完全支持 Codex 桌宠格式，可使用 hatch-pet Skill 创建宠物，或通过 Petdex 导入宠物。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:sereinmono/dsh-desktop-pet",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-builtin-toggles",
    "owner": "Starfie1d1272",
    "url": "https://github.com/Starfie1d1272/dsh-builtin-toggles",
+   "page": "https://awesome-dsh-plugin.com/p/Starfie1d1272/dsh-builtin-toggles/",
    "category": "ui",
    "description": {
     "en": "Adds a built-in plugin catalog to DSH Web with search, status explanations, and safe toggles for audited UI plugins.",
     "zh": "为 DSH Web 添加官方内置插件目录、搜索与状态说明，并提供经过审核的安全 UI 插件开关。"
    },
    "npm": "dsh-builtin-toggles",
-   "stars": 2,
+   "stars": 6,
    "install": "dsh plugin --profile web add dsh-builtin-toggles",
    "added": "2026-08-14"
   },
@@ -601,13 +1105,14 @@
    "name": "dsh-ux",
    "owner": "jiangnanquan",
    "url": "https://github.com/jiangnanquan/dsh-ux",
+   "page": "https://awesome-dsh-plugin.com/p/jiangnanquan/dsh-ux/",
    "category": "ui",
    "description": {
     "en": "Solarized light theme, compact layout, think/tool-chain collapse capsules, and balance, session cost, and usage dashboards for the DSH web UI.",
     "zh": "Solarized 浅色主题、紧凑布局、思考/工具链折叠胶囊，以及余额、本轮成本与用量看板的 DSH Web 界面增强插件。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:jiangnanquan/dsh-ux",
    "added": "2026-08-14"
   },
@@ -615,13 +1120,14 @@
    "name": "dsh-hud",
    "owner": "a903067276-rgb",
    "url": "https://github.com/a903067276-rgb/dsh-hud",
+   "page": "https://awesome-dsh-plugin.com/p/a903067276-rgb/dsh-hud/",
    "category": "ui",
    "description": {
     "en": "HUD status panel: Git status, MCP servers, skills, model and token usage in a floating side panel.",
     "zh": "HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:a903067276-rgb/dsh-hud",
    "added": "2026-08-14"
   },
@@ -629,20 +1135,22 @@
    "name": "dsh-plugins#turn-scrubber",
    "owner": "wsxwj123",
    "url": "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber",
+   "page": "https://awesome-dsh-plugin.com/p/wsxwj123/dsh-plugins--packages-turn-scrubber/",
    "category": "ui",
    "description": {
     "en": "Compact right-edge turn rail with hover summaries and click-to-jump navigation.",
     "zh": "右侧紧凑回合刻度条，悬停显示回合摘要，点击跳转到对应用户回合。"
    },
    "npm": null,
-   "stars": null,
-   "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins/tree/main/packages/turn-scrubber",
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins#path:/packages/turn-scrubber",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-cost-meter",
    "owner": "Sttrevens",
    "url": "https://github.com/Sttrevens/dsh-cost-meter",
+   "page": "https://awesome-dsh-plugin.com/p/Sttrevens/dsh-cost-meter/",
    "category": "ui",
    "description": {
     "en": "Per-turn USD cost badge in the Web UI: session total in the header and per-turn cost in each message footer, with a hover breakdown.",
@@ -657,13 +1165,14 @@
    "name": "dsh-file-mentions",
    "owner": "a903067276-rgb",
    "url": "https://github.com/a903067276-rgb/dsh-file-mentions",
+   "page": "https://awesome-dsh-plugin.com/p/a903067276-rgb/dsh-file-mentions/",
    "category": "ui",
    "description": {
     "en": "Clickable file paths in DSH replies: Codex-style inline open, reveal in file manager, and a mentioned-files chip list at the turn tail.",
     "zh": "DSH 回复中的文件路径可点击：Codex 风格行内打开、文件管理器定位、回合尾部文件 chip 列表。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:a903067276-rgb/dsh-file-mentions",
    "added": "2026-08-14"
   },
@@ -671,13 +1180,14 @@
    "name": "dsh-calculator",
    "owner": "bobcat848",
    "url": "https://github.com/bobcat848/dsh-calculator",
+   "page": "https://awesome-dsh-plugin.com/p/bobcat848/dsh-calculator/",
    "category": "ui",
    "description": {
     "en": "DeepSeek API spend (current session and all sessions) and account balance in the aside panel, with official pricing and peak/off-peak support.",
     "zh": "右侧面板展示 DeepSeek API 费用（当前会话 + 全部会话累计）与账户余额，内置官方计价与峰谷计价支持。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:bobcat848/dsh-calculator",
    "added": "2026-08-14"
   },
@@ -685,13 +1195,14 @@
    "name": "dsh-deepseek-billing",
    "owner": "Jolly-J",
    "url": "https://github.com/Jolly-J/dsh-deepseek-billing",
+   "page": "https://awesome-dsh-plugin.com/p/Jolly-J/dsh-deepseek-billing/",
    "category": "ui",
    "description": {
     "en": "DeepSeek account balance and per-session cost card in the sidebar foot.",
     "zh": "侧边栏底部 DeepSeek 账户余额显示与会话费用估算卡片。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:Jolly-J/dsh-deepseek-billing",
    "added": "2026-08-14"
   },
@@ -699,13 +1210,14 @@
    "name": "dsh-drag-and-drop",
    "owner": "AKIRACOD",
    "url": "https://github.com/AKIRACOD/dsh-drag-and-drop",
+   "page": "https://awesome-dsh-plugin.com/p/AKIRACOD/dsh-drag-and-drop/",
    "category": "ui",
    "description": {
     "en": "File-drag fork: drop documents as removable chips above the composer, send without typing.",
     "zh": "拖放 fork：文档以可删除「文件芯片」挂在输入框上方，不打字也能发送。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:AKIRACOD/dsh-drag-and-drop",
    "added": "2026-08-14"
   },
@@ -713,13 +1225,14 @@
    "name": "dsh-auto-continue",
    "owner": "HsiangNianian",
    "url": "https://github.com/HsiangNianian/dsh-auto-continue",
+   "page": "https://awesome-dsh-plugin.com/p/HsiangNianian/dsh-auto-continue/",
    "category": "ui",
    "description": {
     "en": "Auto-resumes interrupted DSH Web requests: sends a queued 「继续」 after network, timeout or host-crash failures, with error classification, adaptive backoff, templated continue text and browser notifications.",
     "zh": "DSH Web 请求中断自动续跑：网络、超时或宿主崩溃等非人为失败后自动发送「继续」，支持错误分类、自适应退避、模板化继续文本与浏览器通知。"
    },
    "npm": "dsh-client-auto-continue",
-   "stars": null,
+   "stars": 12,
    "install": "dsh plugin --profile web add dsh-client-auto-continue",
    "added": "2026-08-14"
   },
@@ -727,13 +1240,14 @@
    "name": "dsh-chat-outline",
    "owner": "liliuCourier",
    "url": "https://github.com/liliuCourier/dsh-chat-outline",
+   "page": "https://awesome-dsh-plugin.com/p/liliuCourier/dsh-chat-outline/",
    "category": "ui",
    "description": {
     "en": "Persistent left-hand conversation outline: questions and final replies per turn, keyword filter, one-click jump.",
     "zh": "对话栏左侧常驻大纲：按轮次列出提问与最后回复，支持关键词过滤与一键跳转。"
    },
    "npm": "dsh-chat-outline",
-   "stars": null,
+   "stars": 2,
    "install": "dsh plugin --profile web add dsh-chat-outline",
    "added": "2026-08-14"
   },
@@ -741,27 +1255,404 @@
    "name": "dsh-token-usage",
    "owner": "LaoYueHanNi",
    "url": "https://github.com/LaoYueHanNi/dsh-token-usage",
+   "page": "https://awesome-dsh-plugin.com/p/LaoYueHanNi/dsh-token-usage/",
    "category": "ui",
    "description": {
     "en": "Per-request model token usage tracked to per-day JSONL files, with a stats page in Web settings: daily trend chart, per-model breakdown, and date/model filters.",
     "zh": "按请求持久化模型 token 用量，Web 设置「Token 用量」统计页：按日趋势图、按模型明细表、日期/模型筛选。"
    },
    "npm": null,
-   "stars": null,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:LaoYueHanNi/dsh-token-usage",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-mic-input",
+   "owner": "QT-Chen",
+   "url": "https://github.com/QT-Chen/dsh-mic-input",
+   "page": "https://awesome-dsh-plugin.com/p/QT-Chen/dsh-mic-input/",
+   "category": "ui",
+   "description": {
+    "en": "Microphone voice input for the composer: browser Web Speech API live transcription, dedupe/auto-continue, smart punctuation, language and auto-send settings.",
+    "zh": "输入框麦克风语音输入：浏览器 Web Speech API 实时转写，自动去重/续听、智能标点，支持语言与自动发送设置。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:QT-Chen/dsh-mic-input",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-task-dag",
+   "owner": "LeemanCheung",
+   "url": "https://github.com/LeemanCheung/dsh-task-dag",
+   "page": "https://awesome-dsh-plugin.com/p/LeemanCheung/dsh-task-dag/",
+   "category": "ui",
+   "description": {
+    "en": "Displays a Session's subagents and durable workflow runs as a live DAG with status, navigation, and restart-safe history.",
+    "zh": "将会话子代理与持久工作流运行展示为实时 DAG，支持状态展示、节点导航与重启后历史恢复。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:LeemanCheung/dsh-task-dag",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "widget-dock",
+   "owner": "MorGogh",
+   "url": "https://github.com/MorGogh/widget-dock",
+   "page": "https://awesome-dsh-plugin.com/p/MorGogh/widget-dock/",
+   "category": "ui",
+   "description": {
+    "en": "Draggable workbench of mini-cards (API balance, token usage, session stats, goal, cost) on the blank areas beside the conversation, with size tiers and official DeepSeek pricing.",
+    "zh": "对话两侧空白区的可拖动卡片工作台：余额、Token 用量、会话统计、目标、成本估算等小组件，支持 S/M/L/XL 尺寸档位与官方定价成本估算。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:MorGogh/widget-dock",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-reasoning-slider",
+   "owner": "qjcnmd",
+   "url": "https://github.com/qjcnmd/dsh-reasoning-slider",
+   "page": "https://awesome-dsh-plugin.com/p/qjcnmd/dsh-reasoning-slider/",
+   "category": "ui",
+   "description": {
+    "en": "Codex-style reasoning-effort slider embedded in the model selector.",
+    "zh": "Codex 风格推理等级滑块，内嵌于模型选择器，拖动切换推理档位。"
+   },
+   "npm": "reasoning-slider",
+   "stars": 1,
+   "install": "dsh plugin --profile web add reasoning-slider",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-sampling-sliders",
+   "owner": "Semidia",
+   "url": "https://github.com/Semidia/dsh-sampling-sliders",
+   "page": "https://awesome-dsh-plugin.com/p/Semidia/dsh-sampling-sliders/",
+   "category": "ui",
+   "description": {
+    "en": "Model sampling sliders (temperature / maxTokens) in the composer: override every model request for all providers via the agent/request hook, with hot/persist modes.",
+    "zh": "对话输入区的模型采样滑杆（temperature / maxTokens）：通过 agent/request 钩子对所有供应商的每次请求生效，支持热调/持久化两种模式。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:Semidia/dsh-sampling-sliders",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-pomodoro",
+   "owner": "causebefore",
+   "url": "https://github.com/causebefore/dsh-pomodoro",
+   "page": "https://awesome-dsh-plugin.com/p/causebefore/dsh-pomodoro/",
+   "category": "ui",
+   "description": {
+    "en": "Pomodoro focus-and-break timer for DSH Web with configurable cycles, a draggable mini panel, and in-app, sound, and browser notifications.",
+    "zh": "DSH Web 番茄钟：提供可配置专注/休息循环、可拖动迷你面板，以及站内提醒、提示音和浏览器通知。"
+   },
+   "npm": "dsh-pomodoro",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-pomodoro",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-terminal",
+   "owner": "siberiah2o",
+   "url": "https://github.com/siberiah2o/dsh-plugin-terminal",
+   "page": "https://awesome-dsh-plugin.com/p/siberiah2o/dsh-plugin-terminal/",
+   "category": "ui",
+   "description": {
+    "en": "Bottom multi-tab terminal panel (node-pty + xterm.js) pinned to the viewport bottom, always below the input box.",
+    "zh": "底部多标签终端面板（node-pty + xterm.js）：贴底全宽，输入框始终在终端上方。"
+   },
+   "npm": "dsh-plugin-terminal",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-plugin-terminal",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-outline",
+   "owner": "urzeye",
+   "url": "https://github.com/urzeye/dsh-outline",
+   "page": "https://awesome-dsh-plugin.com/p/urzeye/dsh-outline/",
+   "category": "ui",
+   "description": {
+    "en": "Real-time outline panel for the DSH Web session page: user questions plus a Markdown heading tree (H1–H6) that updates live during streaming, with click-to-locate highlighting, expand-depth control, search, and per-session favorites.",
+    "zh": "DSH Web 会话页实时大纲面板：「用户问题 + Markdown 标题（1~6 级）」大纲树，流式生成时实时更新，点击节点滚动定位并高亮，支持展开深度调节、搜索与会话级收藏。"
+   },
+   "npm": "dsh-outline",
+   "stars": 5,
+   "install": "dsh plugin --profile web add dsh-outline",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-heatmap",
+   "owner": "283Gawin",
+   "url": "https://github.com/283Gawin/dsh-heatmap",
+   "page": "https://awesome-dsh-plugin.com/p/283Gawin/dsh-heatmap/",
+   "category": "ui",
+   "description": {
+    "en": "Activity heatmap in the DSH Web sidebar: GitHub-style grid of daily commits, token usage, and estimated spend, with a today stats line for all-session token totals, cache hit rate, and per-model auto-priced cost.",
+    "zh": "DSH Web 侧边栏活动热力图：GitHub 风格网格展示每日提交、Token 用量与估算花费，今日统计行显示全会话 Token 总量、缓存命中率与按模型自动计价的花费。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:283Gawin/dsh-heatmap",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-usage-chart",
+   "owner": "Max-Samson",
+   "url": "https://github.com/Max-Samson/dsh-usage-chart",
+   "page": "https://awesome-dsh-plugin.com/p/Max-Samson/dsh-usage-chart/",
+   "category": "ui",
+   "description": {
+    "en": "Token, cost, and balance dashboard under the composer: live indicator plus zero-dependency SVG charts for per-turn usage, estimated cost, and DeepSeek account balance.",
+    "zh": "输入框下方的用量/成本/余额仪表盘：实时指标指示器 + 零依赖 SVG 用量图表，按轮次统计用量、估算成本并实时查询 DeepSeek 账户余额。"
+   },
+   "npm": "dsh-usage-chart",
+   "stars": 4,
+   "install": "dsh plugin --profile web add dsh-usage-chart",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-desktop-windowos#plugin",
+   "owner": "RAFOLIE",
+   "url": "https://github.com/RAFOLIE/dsh-desktop-windowos/tree/main/plugin",
+   "page": "https://awesome-dsh-plugin.com/p/RAFOLIE/dsh-desktop-windowos--plugin/",
+   "category": "ui",
+   "description": {
+    "en": "Windows tray desktop shell for DSH: auto-installs the exe from GitHub Releases, creates a desktop shortcut, and adds a desktop_launch tool to start it from chat.",
+    "zh": "DSH 的 Windows 托盘桌面壳：自动从 GitHub Releases 安装 exe、创建桌面快捷方式，并提供 desktop_launch 工具在对话中一键启动。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:RAFOLIE/dsh-desktop-windowos#path:/plugin",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-window#plugin",
+   "owner": "ZichengGurrr",
+   "url": "https://github.com/ZichengGurrr/dsh-window/tree/main/plugin",
+   "page": "https://awesome-dsh-plugin.com/p/ZichengGurrr/dsh-window--plugin/",
+   "category": "ui",
+   "description": {
+    "en": "Native Windows desktop window (WebView2) for DSH: one-command install, auto-fetches the app zip from GitHub Releases, creates a desktop shortcut, and adds a desktop_launch tool to start it from chat.",
+    "zh": "DSH 的 Windows 原生窗口（WebView2）：一键安装，自动从 GitHub Releases 下载应用 zip、创建桌面快捷方式，并提供 desktop_launch 工具在对话中一键启动。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:ZichengGurrr/dsh-window#path:/plugin",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-workshop",
+   "owner": "yyyyukari",
+   "url": "https://github.com/yyyyukari/dsh-plugin-workshop",
+   "page": "https://awesome-dsh-plugin.com/p/yyyyukari/dsh-plugin-workshop/",
+   "category": "ui",
+   "description": {
+    "en": "Steam Workshop-style in-app plugin browser: search, hot/newest/trending (7/30/90-day) sorting, Chinese keyword mapping, bilingual descriptions and README translation, plugin-signature filtering, and one-click install/update.",
+    "zh": "创意工坊式插件浏览器：侧栏常驻入口，搜索/最热/最新/近 7-90 天飙升榜、中文关键词映射、描述与 README 机翻、插件特征验证过滤、一键安装/更新。"
+   },
+   "npm": null,
+   "stars": 17,
+   "install": "dsh plugin --profile web add github:yyyyukari/dsh-plugin-workshop",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-web-preview",
+   "owner": "zoumutou",
+   "url": "https://github.com/zoumutou/dsh-web-preview",
+   "page": "https://awesome-dsh-plugin.com/p/zoumutou/dsh-web-preview/",
+   "category": "ui",
+   "description": {
+    "en": "Side web-preview panel: local static hosting, Markdown/code/image preview, one-click run of non-static projects (Cargo/npm/Go/Python) with live logs, web element mark & annotate, and link-click takeover into the side panel.",
+    "zh": "侧边网页预览面板：本地静态托管、Markdown/代码/图片预览、非静态项目一键运行（Cargo/npm/Go/Python）实时日志、网页元素标记批注、链接点击接管到侧边预览。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:zoumutou/dsh-web-preview",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-llm-balance",
+   "owner": "FengHuoLinShan",
+   "url": "https://github.com/FengHuoLinShan/dsh-plugin-llm-balance",
+   "page": "https://awesome-dsh-plugin.com/p/FengHuoLinShan/dsh-plugin-llm-balance/",
+   "category": "ui",
+   "description": {
+    "en": "Draggable floating card showing the balance/quota of your most recently used providers (DeepSeek/Moonshot/Kimi For Coding): auto-discovery, color-coded tiers, live refresh.",
+    "zh": "可拖动的 API 余额/配额悬浮卡片：自动显示最近使用的 provider 余额/配额（DeepSeek/Moonshot/Kimi For Coding），按余额分档变色、实时刷新。"
+   },
+   "npm": "dsh-plugin-llm-balance",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-plugin-llm-balance",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-balance-float",
+   "owner": "x2802490130-prog",
+   "url": "https://github.com/x2802490130-prog/dsh-balance-float",
+   "page": "https://awesome-dsh-plugin.com/p/x2802490130-prog/dsh-balance-float/",
+   "category": "ui",
+   "description": {
+    "en": "A floating balance widget for the Web UI: live DeepSeek account balance with manual refresh and a Y/N-confirmed graceful exit.",
+    "zh": "Web UI 右上角悬浮窗：实时显示 DeepSeek 余额，支持手动刷新与一键优雅退出（Y/N 快捷键确认）。"
+   },
+   "npm": "dsh-balance-float",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-balance-float",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-session-manager",
+   "owner": "Semidia",
+   "url": "https://github.com/Semidia/dsh-session-manager",
+   "page": "https://awesome-dsh-plugin.com/p/Semidia/dsh-session-manager/",
+   "category": "ui",
+   "description": {
+    "en": "Right-click session menu and sidebar session manager: pin, rename, archive, fork, export, copy cwd/id/deep link, and open in explorer or a new window.",
+    "zh": "会话行右键菜单与侧边栏会话管理：置顶、重命名、归档、分叉、导出、复制工作目录/会话 ID/深链，在资源管理器或新窗口打开。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:Semidia/dsh-session-manager",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-lan-pass",
+   "owner": "x2802490130-prog",
+   "url": "https://github.com/x2802490130-prog/dsh-lan-pass",
+   "page": "https://awesome-dsh-plugin.com/p/x2802490130-prog/dsh-lan-pass/",
+   "category": "ui",
+   "description": {
+    "en": "A LAN password gate for the Web UI: phones and tablets on the same network log in with a shared key and see the same sessions in real time, with a built-in randomUUID polyfill for plain-HTTP origins.",
+    "zh": "Web UI 局域网密码门禁：同网手机/平板输共享密钥登录，会话与电脑实时同步，内置 randomUUID polyfill。"
+   },
+   "npm": "dsh-lan-pass",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-lan-pass",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-turn-marks",
+   "owner": "magicOF2",
+   "url": "https://github.com/magicOF2/dsh-turn-marks",
+   "page": "https://awesome-dsh-plugin.com/p/magicOF2/dsh-turn-marks/",
+   "category": "ui",
+   "description": {
+    "en": "Left-edge turn-marks strip in chat: one bar per user message, click to jump to that message, hover for a preview, active bar turns white.",
+    "zh": "会话左侧消息标记条：每发一条消息多一根条条，点击跳转到该消息、悬停预览内容，当前消息对应的条条变白。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:magicOF2/dsh-turn-marks",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-chat-width-customizer",
+   "owner": "magicOF2",
+   "url": "https://github.com/magicOF2/dsh-chat-width-customizer",
+   "page": "https://awesome-dsh-plugin.com/p/magicOF2/dsh-chat-width-customizer/",
+   "category": "ui",
+   "description": {
+    "en": "Session-header button that cycles the conversation width (748-1600px), widening the chat column, composer, and user bubbles together.",
+    "zh": "会话标题栏按钮循环切换对话宽度（748–1600px），消息区、输入框、用户气泡同步加宽。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:magicOF2/dsh-chat-width-customizer",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-plugins#plugins/dsh-balance-plugin",
+   "owner": "luokai-demo",
+   "url": "https://github.com/luokai-demo/dsh-plugins/tree/main/plugins/dsh-balance-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/luokai-demo/dsh-plugins--plugins-dsh-balance-plugin/",
+   "category": "ui",
+   "description": {
+    "en": "DeepSeek wallet balance at the sidebar foot: a credit-card icon with the amount tinted by remaining balance (green over ¥2, amber ¥0–2, red below), refreshed on mount, per turn-end, and on click; a signed delta floats up and fades on each balance change.",
+    "zh": "侧边栏底部的 DeepSeek 钱包余额：信用卡图标配余额数字，按剩余额度着色（≥ ¥2 绿色、¥0–2 黄色、≤ ¥0 红色），挂载时、每轮对话结束和点击时刷新；余额变动时带符号差额上飘淡出。"
+   },
+   "npm": "dsh-balance-plugin",
+   "stars": 1,
+   "install": "dsh plugin --profile web add dsh-balance-plugin",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-plugins#dsh-plugin-setting-mcp",
+   "owner": "Ceelog",
+   "url": "https://github.com/Ceelog/dsh-plugins/tree/main/src/plugins/dsh-plugin-setting-mcp",
+   "page": "https://awesome-dsh-plugin.com/p/Ceelog/dsh-plugins--src-plugins-dsh-plugin-setting-mcp/",
+   "category": "ui",
+   "description": {
+    "en": "Manage MCP servers from the Web settings panel: view, add, edit, remove, enable or disable them, with hot reload on save.",
+    "zh": "在 Web 设置面板中查看、添加、编辑、删除、启用或停用 MCP 服务器，保存后热重载。"
+   },
+   "npm": "@opendsh/dsh-plugin-setting-mcp",
+   "stars": 4,
+   "install": "dsh plugin --profile web add @opendsh/dsh-plugin-setting-mcp",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-opencodego-usage",
+   "owner": "BeiZi6",
+   "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
+   "page": "https://awesome-dsh-plugin.com/p/BeiZi6/dsh-opencodego-usage/",
+   "category": "ui",
+   "description": {
+    "en": "OpenCodeGo quota monitor for the DSH Web GUI: a breathing indicator at the input's bottom-right (green/yellow/red by remaining share), a liquid-glass panel with rolling/weekly/monthly usage windows and reset times, auto-refreshing every 30 s; API key read from DSH credentials.",
+    "zh": "OpenCodeGo 剩余额度监视器：输入框右下角呼吸指示灯（按剩余额度绿/黄/红），液态玻璃面板显示滚动/周/月用量窗口与重置时间，每 30 秒自动刷新，API Key 自动读取 DSH 凭据。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:BeiZi6/dsh-opencodego-usage",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-smooth-stream",
+   "owner": "SpookySandwich",
+   "url": "https://github.com/SpookySandwich/dsh-smooth-stream",
+   "page": "https://awesome-dsh-plugin.com/p/SpookySandwich/dsh-smooth-stream/",
+   "category": "ui",
+   "description": {
+    "en": "Better streaming text animation for DeepSeek Harness.",
+    "zh": "给 DeepSeek Harness 加入更好的流式文字动画。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:SpookySandwich/dsh-smooth-stream",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-mobile-css",
+   "owner": "ook826092-cloud",
+   "url": "https://github.com/ook826092-cloud/dsh-mobile-css",
+   "page": "https://awesome-dsh-plugin.com/p/ook826092-cloud/dsh-mobile-css/",
+   "category": "ui",
+   "description": {
+    "en": "Mobile adaptation for the DSH Web UI: compact typography, full-width composer with caret fix, drawer sidebar with overlay-close, two-page settings flow, responsive tables and stats, safe touch targets.",
+    "zh": "DSH Web UI 移动端适配：紧凑排版、全宽输入卡（含光标修复）、抽屉式侧边栏（点击遮罩关闭）、两页式设置流程、响应式表格与统计、安全触控目标。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:ook826092-cloud/dsh-mobile-css",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-skin",
    "owner": "KinGao294",
    "url": "https://github.com/KinGao294/dsh-skin",
+   "page": "https://awesome-dsh-plugin.com/p/KinGao294/dsh-skin/",
    "category": "theme",
    "description": {
     "en": "Codex-style skin switcher plus a custom wallpaper layer with opacity and blur controls.",
     "zh": "Codex 风格皮肤切换器 + 自定义壁纸层，可调透明度与模糊。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 10,
    "install": "dsh plugin --profile web add github:KinGao294/dsh-skin",
    "added": "2026-08-14"
   },
@@ -769,13 +1660,14 @@
    "name": "dsh-deep-whale",
    "owner": "Small-tailqwq",
    "url": "https://github.com/Small-tailqwq/dsh-deep-whale",
+   "page": "https://awesome-dsh-plugin.com/p/Small-tailqwq/dsh-deep-whale/",
    "category": "theme",
    "description": {
     "en": "Whale-girl skin series for the DSH Web UI (maid-atelier).",
     "zh": "DSH Web 鲸鱼娘皮肤系列（深海女仆工坊 maid-atelier）。"
    },
    "npm": null,
-   "stars": 416,
+   "stars": 652,
    "install": "dsh plugin --profile web add github:Small-tailqwq/dsh-deep-whale",
    "added": "2026-08-14"
   },
@@ -783,83 +1675,344 @@
    "name": "dsh-plugins#theme-gallery",
    "owner": "wsxwj123",
    "url": "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/theme-gallery",
+   "page": "https://awesome-dsh-plugin.com/p/wsxwj123/dsh-plugins--packages-theme-gallery/",
    "category": "theme",
    "description": {
     "en": "Fifteen curated theme families with complete light and dark palettes that follow the native Light, Dark, and Follow system modes.",
     "zh": "15 个精选主题家族，浅深配色完整，跟随 DSH 原生浅色/深色/跟随系统模式。"
    },
    "npm": null,
-   "stars": null,
-   "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins/tree/main/packages/theme-gallery",
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins#path:/packages/theme-gallery",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-client-ui-skin-claude",
+   "owner": "PAKIKNOWLEDGE",
+   "url": "https://github.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude",
+   "page": "https://awesome-dsh-plugin.com/p/PAKIKNOWLEDGE/dsh-client-ui-skin-claude/",
+   "category": "theme",
+   "description": {
+    "en": "Claude-style skin with a warm-black canvas, clay accent, and serif UI that follows the native light and dark themes.",
+    "zh": "Claude 风格皮肤：暖黑画布、陶橙点缀、衬线 UI，跟随原生亮/暗主题。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:PAKIKNOWLEDGE/dsh-client-ui-skin-claude",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-font",
+   "owner": "tianyhjg-lab",
+   "url": "https://github.com/tianyhjg-lab/dsh-font",
+   "page": "https://awesome-dsh-plugin.com/p/tianyhjg-lab/dsh-font/",
+   "category": "theme",
+   "description": {
+    "en": "Font switcher for the DSH Web GUI: 99 UI fonts and 31 code fonts with CJK-Latin pairing stacks, instant apply and localStorage persistence.",
+    "zh": "DSH Web GUI 字体切换器：99 个界面字体与 31 个代码字体，中西文自动搭配，即选即生效，localStorage 持久化。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:tianyhjg-lab/dsh-font",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-blue-whale",
+   "owner": "starslittle",
+   "url": "https://github.com/starslittle/dsh-blue-whale",
+   "page": "https://awesome-dsh-plugin.com/p/starslittle/dsh-blue-whale/",
+   "category": "theme",
+   "description": {
+    "en": "Replicates DeepSeek Chat's own blue-whale palette (#4D6BFE); light and dark follow the built-in appearance.",
+    "zh": "复刻 DeepSeek Chat 的蓝鲸配色（主色 #4D6BFE），亮色/深色跟随系统外观。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:starslittle/dsh-blue-whale",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-wallpaper",
+   "owner": "chinaRXQ",
+   "url": "https://github.com/chinaRXQ/dsh-wallpaper",
+   "page": "https://awesome-dsh-plugin.com/p/chinaRXQ/dsh-wallpaper/",
+   "category": "theme",
+   "description": {
+    "en": "Wallpaper skin for the DSH Web UI: image background with opacity, mask and blur controls.",
+    "zh": "DSH Web 壁纸皮肤：图片背景，可调透明度、压暗遮罩与模糊。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:chinaRXQ/dsh-wallpaper",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-client-ui-theme-xp",
+   "owner": "SamizuHM",
+   "url": "https://github.com/SamizuHM/dsh-client-ui-theme-xp",
+   "page": "https://awesome-dsh-plugin.com/p/SamizuHM/dsh-client-ui-theme-xp/",
+   "category": "theme",
+   "description": {
+    "en": "Windows XP Luna desktop for the DSH Web UI: a floating window manager with taskbar and desktop icons, plus the era-accurate Luna skin.",
+    "zh": "Windows XP Luna 桌面化主题：浮动窗口管理器（任务栏、桌面图标）加上还原度很高的 Luna 皮肤。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:SamizuHM/dsh-client-ui-theme-xp",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-theme-cyberpunk2077",
+   "owner": "Tommy00748",
+   "url": "https://github.com/Tommy00748/dsh-theme-cyberpunk2077",
+   "page": "https://awesome-dsh-plugin.com/p/Tommy00748/dsh-theme-cyberpunk2077/",
+   "category": "theme",
+   "description": {
+    "en": "Cyberpunk 2077 / Night City theme: NC yellow and neon cyan identity, CRT scanlines, Kiroshi hover lock-on, combat-state HUD, synthesized typewriter and message SFX, and hidden easter eggs (relic / johnny).",
+    "zh": "Cyberpunk 2077 / 夜之城主题：NC 黄 × 霓虹青配色、CRT 扫描线、Kiroshi 悬停锁定、战斗状态 HUD、合成打字机与消息音效，以及隐藏彩蛋（relic / johnny）。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:Tommy00748/dsh-theme-cyberpunk2077",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-any-background",
+   "owner": "Tkingxiao",
+   "url": "https://github.com/Tkingxiao/dsh-any-background",
+   "page": "https://awesome-dsh-plugin.com/p/Tkingxiao/dsh-any-background/",
+   "category": "theme",
+   "description": {
+    "en": "A DeepSeek Harness appearance plugin that lets you fully customize the Web UI with a custom theme color, background wallpaper, and fine-grained opacity controls.",
+    "zh": "自定义外观插件：换背景图（可调大小和位置）、用色轮自定义主题色，主界面和设置界面的透明度都能单独调。"
+   },
+   "npm": "dsh-any-background",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-any-background",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-theme-plugin",
+   "owner": "BeiZi6",
+   "url": "https://github.com/BeiZi6/dsh-theme-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/BeiZi6/dsh-theme-plugin/",
+   "category": "theme",
+   "description": {
+    "en": "Theme studio for the DSH Web GUI: five built-in presets plus fully customizable light/dark palettes (accent, background, foreground, UI and code fonts, translucent sidebar, contrast), hot-swapped instantly and persisted in localStorage.",
+    "zh": "DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），即时热切换并持久化到 localStorage。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:BeiZi6/dsh-theme-plugin",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "Catppuccin-dsh-theme",
+   "owner": "zhijun-dai",
+   "url": "https://github.com/zhijun-dai/Catppuccin-dsh-theme",
+   "page": "https://awesome-dsh-plugin.com/p/zhijun-dai/Catppuccin-dsh-theme/",
+   "category": "theme",
+   "description": {
+    "en": "Catppuccin theme plugin: Latte, Frappé, Macchiato, and Mocha skins for the DSH Web theme runtime.",
+    "zh": "Catppuccin 主题插件：为 DSH Web 主题运行时提供 Latte、Frappé、Macchiato、Mocha 四套皮肤。"
+   },
+   "npm": "dsh-catppuccin",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-catppuccin",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "Solarized-dsh-theme",
+   "owner": "zhijun-dai",
+   "url": "https://github.com/zhijun-dai/Solarized-dsh-theme",
+   "page": "https://awesome-dsh-plugin.com/p/zhijun-dai/Solarized-dsh-theme/",
+   "category": "theme",
+   "description": {
+    "en": "Solarized and Selenized theme plugin: four faithful palettes registered with the DSH Web theme runtime.",
+    "zh": "Solarized 与 Selenized 主题插件：向 DSH Web 主题运行时注册四套忠实色板。"
+   },
+   "npm": "@yuquexianzhou/solarized-dsh-theme",
+   "stars": 0,
+   "install": "dsh plugin --profile web add @yuquexianzhou/solarized-dsh-theme",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-queue-plus",
+   "owner": "starslittle",
+   "url": "https://github.com/starslittle/dsh-queue-plus",
+   "page": "https://awesome-dsh-plugin.com/p/starslittle/dsh-queue-plus/",
+   "category": "session",
+   "description": {
+    "en": "Unified Web prompt queue with edit, remove, steer, drag reorder, clear-all, and a 10-second undo.",
+    "zh": "统一的 Web 排队消息面板，支持编辑、删除、插话、拖拽排序、清空全部和 10 秒撤销。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:starslittle/dsh-queue-plus",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-solo-thinking",
+   "owner": "fredalxin",
+   "url": "https://github.com/fredalxin/dsh-solo-thinking",
+   "page": "https://awesome-dsh-plugin.com/p/fredalxin/dsh-solo-thinking/",
+   "category": "session",
+   "description": {
+    "en": "Visual branch brainstorming that creates an isolated Session for each direction, automates parent, sibling, checkpoint, and return Handoffs, and provides a full tree tab with an optional Better Sidebar view.",
+    "zh": "可视化分支头脑风暴：为每个方向创建独立 Session，自动处理父子继承、兄弟感知、进展与回传 Handoff，并提供完整树形 Tab 与可选 Better Sidebar 右栏。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:fredalxin/dsh-solo-thinking",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-agent-team-room",
+   "owner": "ishuowang",
+   "url": "https://github.com/ishuowang/dsh-agent-team-room",
+   "page": "https://awesome-dsh-plugin.com/p/ishuowang/dsh-agent-team-room/",
+   "category": "session",
+   "description": {
+    "en": "Persistent rooms for independent DSH Agent sessions, with explicit membership, direct and broadcast messages, tracked tasks, and a shared Web timeline.",
+    "zh": "面向独立 DSH Agent 会话的持久化协作房间，支持显式成员管理、定向与广播消息、任务跟踪和共享 Web 时间线。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:ishuowang/dsh-agent-team-room",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-webchatlike",
+   "owner": "cindyguyuehu123",
+   "url": "https://github.com/cindyguyuehu123/dsh-webchatlike",
+   "page": "https://awesome-dsh-plugin.com/p/cindyguyuehu123/dsh-webchatlike/",
+   "category": "session",
+   "description": {
+    "en": "Bring the deepseek.com web/app chat experience to DSH: edit your prompt and regenerate answers in place, with a per-message <i/N> version pager (tree model, stable across conversations).",
+    "zh": "更贴近 deepseek 网页版/App 的聊天体验：原位编辑提问、重新生成回复、每条消息带 <i/N> 版本翻页器（树状版本模型，跨对话保持稳定）。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:cindyguyuehu123/dsh-webchatlike",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-bookmarks",
+   "owner": "penguin-oo",
+   "url": "https://github.com/penguin-oo/dsh-bookmarks",
+   "page": "https://awesome-dsh-plugin.com/p/penguin-oo/dsh-bookmarks/",
+   "category": "session",
+   "description": {
+    "en": "Bookmark assistant replies with notes and tags; browse every bookmark in one cross-session center and export to Markdown.",
+    "zh": "收藏 AI 回复（备注/标签），跨会话收藏中心（搜索/筛选/跳回会话），一键导出 Markdown。"
+   },
+   "npm": "dsh-bookmarks",
+   "stars": 4,
+   "install": "dsh plugin --profile web add dsh-bookmarks",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-turn-rewind",
    "owner": "Anionex",
    "url": "https://github.com/Anionex/dsh-turn-rewind",
+   "page": "https://awesome-dsh-plugin.com/p/Anionex/dsh-turn-rewind/",
    "category": "session",
    "description": {
     "en": "Rewind conversation and workspace state, powered by a persistent Change Ledger.",
     "zh": "对话回退：基于持久 Change Ledger 回滚会话与工作区状态。"
    },
-   "npm": null,
-   "stars": 33,
-   "install": "dsh plugin --profile web add github:Anionex/dsh-turn-rewind",
+   "npm": "@anionex/dsh-turn-rewind",
+   "stars": 43,
+   "install": "dsh plugin --profile web add @anionex/dsh-turn-rewind",
    "added": "2026-08-13"
   },
   {
    "name": "dsh-crosstalk",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-crosstalk",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-crosstalk/",
    "category": "session",
    "description": {
     "en": "Cross-session messaging for DSH: any session on the machine can list and message any other, Claude Code-style, via a local heartbeat registry and inbox.",
     "zh": "跨会话消息：本机任意会话都可像 Claude Code 一样列出并互发消息，基于本地心跳注册表与收件箱。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:Jesse-njx/dsh-crosstalk",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "task-passport",
+   "owner": "dongsheng123132",
+   "url": "https://github.com/dongsheng123132/task-passport",
+   "page": "https://awesome-dsh-plugin.com/p/dongsheng123132/task-passport/",
+   "category": "session",
+   "description": {
+    "en": "Carry durable task state across DeepSeek Harness, WorkBuddy, Claude Code and Codex with machine-readable checkpoints and optimistic locking.",
+    "zh": "通过机器可读检查点与乐观锁，在 DeepSeek Harness、WorkBuddy、Claude Code 和 Codex 之间交接持久任务状态。"
+   },
+   "npm": "task-passport",
+   "stars": 5,
+   "install": "dsh plugin --profile web add task-passport",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-task-relay",
+   "owner": "LeslieWylie",
+   "url": "https://github.com/LeslieWylie/dsh-task-relay",
+   "page": "https://awesome-dsh-plugin.com/p/LeslieWylie/dsh-task-relay/",
+   "category": "session",
+   "description": {
+    "en": "Cross-session task queue with handoff notes: sessions and subagents push, claim, complete and cancel tasks on a shared file-backed queue, and leave a handoff summary for whoever picks up next.",
+    "zh": "跨会话任务队列与交接摘要：会话与子 agent 在共享的文件队列上投递、认领、完成、取消任务，并留下交接摘要供后续会话查看。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:LeslieWylie/dsh-task-relay",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-share",
    "owner": "hellodigua",
    "url": "https://github.com/hellodigua/dsh-share",
+   "page": "https://awesome-dsh-plugin.com/p/hellodigua/dsh-share/",
    "category": "session",
    "description": {
     "en": "Share your conversations with one click.",
     "zh": "一键分享你的对话。"
    },
-   "npm": null,
-   "stars": 15,
-   "install": "dsh plugin --profile web add github:hellodigua/dsh-share",
+   "npm": "dsh-share",
+   "stars": 17,
+   "install": "dsh plugin --profile web add dsh-share",
    "added": "2026-08-13"
   },
   {
    "name": "dsh-message-edit",
    "owner": "Moeblack",
    "url": "https://github.com/Moeblack/dsh-message-edit",
+   "page": "https://awesome-dsh-plugin.com/p/Moeblack/dsh-message-edit/",
    "category": "session",
    "description": {
     "en": "Branch-based message editing, reroll, retry, and a version timeline.",
     "zh": "基于分支的消息编辑、reroll、重试与版本时间线。"
    },
-   "npm": null,
-   "stars": 16,
-   "install": "dsh plugin --profile web add github:Moeblack/dsh-message-edit",
+   "npm": "dsh-message-edit",
+   "stars": 18,
+   "install": "dsh plugin --profile web add dsh-message-edit",
    "added": "2026-08-13"
   },
   {
    "name": "dsh-sidechain",
    "owner": "Buyi-wsgzg",
    "url": "https://github.com/Buyi-wsgzg/dsh-sidechain",
+   "page": "https://awesome-dsh-plugin.com/p/Buyi-wsgzg/dsh-sidechain/",
    "category": "session",
    "description": {
     "en": "`/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.",
     "zh": "`/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行、不写入主会话历史。"
    },
    "npm": null,
-   "stars": 3,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:Buyi-wsgzg/dsh-sidechain",
    "added": "2026-08-13"
   },
@@ -867,6 +2020,7 @@
    "name": "dsh-conversation-share",
    "owner": "bill9109",
    "url": "https://github.com/bill9109/dsh-conversation-share",
+   "page": "https://awesome-dsh-plugin.com/p/bill9109/dsh-conversation-share/",
    "category": "session",
    "description": {
     "en": "Share any excerpt of a conversation.",
@@ -881,13 +2035,14 @@
    "name": "dsh-explain",
    "owner": "yuezengwu",
    "url": "https://github.com/yuezengwu/dsh-explain",
+   "page": "https://awesome-dsh-plugin.com/p/yuezengwu/dsh-explain/",
    "category": "session",
    "description": {
     "en": "Local-first learning mode: cross-session learning threads with per-source explanations.",
     "zh": "本地优先学习模式：跨会话全局学习线程、按来源讲解。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 10,
    "install": "dsh plugin --profile web add github:yuezengwu/dsh-explain",
    "added": "2026-08-13"
   },
@@ -895,6 +2050,7 @@
    "name": "dsh-prompt-studio",
    "owner": "Moeblack",
    "url": "https://github.com/Moeblack/dsh-prompt-studio",
+   "page": "https://awesome-dsh-plugin.com/p/Moeblack/dsh-prompt-studio/",
    "category": "session",
    "description": {
     "en": "Edit user and built-in system-prompt sections with live preview.",
@@ -909,41 +2065,59 @@
    "name": "dsh-peer-link",
    "owner": "czm15053",
    "url": "https://github.com/czm15053/dsh-peer-link",
+   "page": "https://awesome-dsh-plugin.com/p/czm15053/dsh-peer-link/",
    "category": "session",
    "description": {
     "en": "Let dsh and Claude Code sessions message each other directly; comes with a clickable peer list card (sort/search/send/refresh).",
     "zh": "让 dsh 和 Claude Code 会话直接互发消息，附带可点击的会话列表卡片（搜索/刷新/弹窗发送）。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:czm15053/dsh-peer-link",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-session-link",
+   "owner": "PwnKY",
+   "url": "https://github.com/PwnKY/dsh-session-link",
+   "page": "https://awesome-dsh-plugin.com/p/PwnKY/dsh-session-link/",
+   "category": "session",
+   "description": {
+    "en": "Copy and open `dsh://` session deep links, or paste them into another conversation to inject a bounded, read-only snapshot of the referenced session.",
+    "zh": "复制、打开 `dsh://` 会话深链，或将其粘贴到另一对话中，注入被引用会话的受限只读快照。"
+   },
+   "npm": "dsh-session-link",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-session-link",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-chat-import",
    "owner": "Nwflower",
    "url": "https://github.com/Nwflower/dsh-chat-import",
+   "page": "https://awesome-dsh-plugin.com/p/Nwflower/dsh-chat-import/",
    "category": "session",
    "description": {
-    "en": "Import Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode chat histories as resumable DeepSeek Harness sessions.",
-    "zh": "把 Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode 的聊天记录全保真导入为可续聊的 DSH 会话。"
+    "en": "Import full-fidelity chat histories from 13 coding agents (Claude Code, Codex, ChatGPT, Cursor, Gemini, opencode, and more) as resumable DeepSeek Harness sessions, with reverse export back to Claude Code.",
+    "zh": "把 13 家 coding agent（Claude Code、Codex、ChatGPT、Cursor、Gemini、opencode 等）的完整对话历史导入为可续聊的 DeepSeek Harness 会话，并支持反向导出回 Claude Code。"
    },
-   "npm": null,
-   "stars": 16,
-   "install": "dsh plugin --profile web add github:Nwflower/dsh-chat-import",
+   "npm": "dsh-chat-import",
+   "stars": 30,
+   "install": "dsh plugin --profile web add dsh-chat-import",
    "added": "2026-08-13"
   },
   {
    "name": "dsh-file-claim",
    "owner": "Nwflower",
    "url": "https://github.com/Nwflower/dsh-file-claim",
+   "page": "https://awesome-dsh-plugin.com/p/Nwflower/dsh-file-claim/",
    "category": "session",
    "description": {
     "en": "File claim/release protection for parallel DSH sessions on the same workspace (heartbeat stale takeover, pending 3-way merge area).",
     "zh": "同一工作区并行多会话的文件认领与写入保护（claim/release、心跳 stale 接管、pending 三路合并）。"
    },
    "npm": "dsh-file-claim",
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add dsh-file-claim",
    "added": "2026-08-14"
   },
@@ -951,27 +2125,44 @@
    "name": "dsh-interconnect",
    "owner": "Chinesezjc",
    "url": "https://github.com/Chinesezjc/dsh-interconnect",
+   "page": "https://awesome-dsh-plugin.com/p/Chinesezjc/dsh-interconnect/",
    "category": "session",
    "description": {
     "en": "Cross-instance message and event handoff between DSH instances via an interconnect server.",
     "zh": "跨实例互联：经 interconnect 服务在多个 DSH 实例间转发消息与事件。"
    },
    "npm": null,
-   "stars": 22,
+   "stars": 26,
    "install": "dsh plugin --profile web add github:Chinesezjc/dsh-interconnect",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-inline-images",
+   "owner": "3403473060",
+   "url": "https://github.com/3403473060/dsh-inline-images",
+   "page": "https://awesome-dsh-plugin.com/p/3403473060/dsh-inline-images/",
+   "category": "session",
+   "description": {
+    "en": "Render local image paths from assistant replies inline in the message body (9 formats, click-to-zoom lightbox, adjustable size).",
+    "zh": "对话内联图片：LLM 回复中输出的本地图片路径在消息正文直接渲染为图片（9 种格式、点击放大灯箱、可调尺寸）。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:3403473060/dsh-inline-images",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-prompt-stash",
    "owner": "Wine-Red",
    "url": "https://github.com/Wine-Red/dsh-prompt-stash",
+   "page": "https://awesome-dsh-plugin.com/p/Wine-Red/dsh-prompt-stash/",
    "category": "session",
    "description": {
     "en": "Local, per-session LIFO prompt stash for temporarily setting aside unfinished composer text and safely restoring it later.",
     "zh": "本地、按会话隔离的 LIFO 输入暂存：临时收起未完成的输入，之后安全恢复并继续编辑。"
    },
    "npm": "dsh-prompt-stash",
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add dsh-prompt-stash",
    "added": "2026-08-14"
   },
@@ -979,20 +2170,232 @@
    "name": "dsh-side-chat",
    "owner": "heartmove",
    "url": "https://github.com/heartmove/dsh-side-chat",
+   "page": "https://awesome-dsh-plugin.com/p/heartmove/dsh-side-chat/",
    "category": "session",
    "description": {
     "en": "Select part of a conversation and ask about it in a right-side side chat; bring AI replies back to the main chat directly or as a summary.",
     "zh": "选中对话片段，在右侧面板的侧边聊天中提问（按会话隔离）；AI 回复可原文或摘要后带回主会话。"
    },
    "npm": null,
-   "stars": null,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:heartmove/dsh-side-chat",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-session-export",
+   "owner": "bwndlct",
+   "url": "https://github.com/bwndlct/dsh-session-export",
+   "page": "https://awesome-dsh-plugin.com/p/bwndlct/dsh-session-export/",
+   "category": "session",
+   "description": {
+    "en": "Export the current session to portable, schema-versioned Markdown and JSON files via the `session_export` tool and slash commands, with cross-platform-safe filenames.",
+    "zh": "把当前会话导出为可移植、带 schema 版本的 Markdown 与 JSON 文件，提供 `session_export` 工具与斜杠命令两种入口，文件名跨平台安全。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:bwndlct/dsh-session-export",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-token-usage",
+   "owner": "LeemanCheung",
+   "url": "https://github.com/LeemanCheung/dsh-token-usage",
+   "page": "https://awesome-dsh-plugin.com/p/LeemanCheung/dsh-token-usage/",
+   "category": "session",
+   "description": {
+    "en": "Persistent per-session Token usage records and a settings dashboard with provider/model breakdowns and a 52-week activity heatmap.",
+    "zh": "持久化记录每个会话的 Token 用量，在设置页提供 provider/model 统计与最近 52 周活跃度热力图。"
+   },
+   "npm": null,
+   "stars": 5,
+   "install": "dsh plugin --profile web add github:LeemanCheung/dsh-token-usage",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-suite#plugin-session-export",
+   "owner": "whyihaveyou",
+   "url": "https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export",
+   "page": "https://awesome-dsh-plugin.com/p/whyihaveyou/dsh-suite--packages-plugins-plugin-session-export/",
+   "category": "session",
+   "description": {
+    "en": "Export the append-only session log as human-readable Markdown or HTML, grouped by trajectory source.",
+    "zh": "把 append-only 会话日志导出为按轨迹来源分组的可读 Markdown 或 HTML。"
+   },
+   "npm": null,
+   "stars": 19,
+   "install": "dsh plugin --profile web add github:whyihaveyou/dsh-suite#path:/packages/plugins/plugin-session-export",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-session-search-pro",
+   "owner": "LeslieWylie",
+   "url": "https://github.com/LeslieWylie/dsh-session-search-pro",
+   "page": "https://awesome-dsh-plugin.com/p/LeslieWylie/dsh-session-search-pro/",
+   "category": "session",
+   "description": {
+    "en": "Search, list and read past and current sessions through the harness's own `sessionQuery` service: uses the SQLite FTS5 index where a deployment enables it, and falls back to a bounded newest-first scan where it does not.",
+    "zh": "通过 harness 自带的 `sessionQuery` 服务搜索、列出、读取历史与当前会话：部署启用了 SQLite FTS5 索引时走索引，未启用时回退到有上限的倒序扫描。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:LeslieWylie/dsh-session-search-pro",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-session-delete",
+   "owner": "lsz-asd",
+   "url": "https://github.com/lsz-asd/dsh-plugin-session-delete",
+   "page": "https://awesome-dsh-plugin.com/p/lsz-asd/dsh-plugin-session-delete/",
+   "category": "session",
+   "description": {
+    "en": "Delete DSH sessions from the web UI and desktop client: header danger button and session-row menu item with a risk-consent dialog; host endpoint and agent tool remove the session log, projection cache, and workspace accounting.",
+    "zh": "在 Web UI 与桌面客户端中删除 DSH 会话：头部危险按钮 + 会话行菜单项，风险确认弹窗，宿主端点与 agent 工具同步清理会话日志、投影缓存与工作区记账。"
+   },
+   "npm": null,
+   "stars": 8,
+   "install": "dsh plugin --profile web add github:lsz-asd/dsh-plugin-session-delete",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-session-import",
+   "owner": "huguangyu666",
+   "url": "https://github.com/huguangyu666/dsh-plugin-session-import",
+   "page": "https://awesome-dsh-plugin.com/p/huguangyu666/dsh-plugin-session-import/",
+   "category": "session",
+   "description": {
+    "en": "Import claude-code / codex / reasonix / zcode chat history into dsh sessions: workspace binding, tool calls preserved, oversized-session protection, zcode compaction restore.",
+    "zh": "把 claude-code / codex / reasonix / zcode 的聊天历史导入为 dsh 会话：工作区绑定、工具调用保留、超长会话保护、zcode 压缩还原。"
+   },
+   "npm": "dsh-plugin-session-import",
+   "stars": 4,
+   "install": "dsh plugin --profile web add dsh-plugin-session-import",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-companion",
+   "owner": "beijingwahw",
+   "url": "https://github.com/beijingwahw/dsh-companion",
+   "page": "https://awesome-dsh-plugin.com/p/beijingwahw/dsh-companion/",
+   "category": "session",
+   "description": {
+    "en": "Four-module session companion: smart conversation export (Markdown/PDF/JSON/PNG long-image with privacy redaction and batch ZIP), context handoff summaries with template save/import, API cost optimization (live official pricing, peak/off-peak scheduling, daily/monthly budgets, model routing), and global conversation search with in-chat find (Ctrl+F, CSS Custom Highlight API).",
+    "zh": "四模块会话伴侣：对话智能导出（Markdown/PDF/JSON/PNG 长图、隐私脱敏、批量 ZIP）、上下文交接摘要（模板保存与导入继承）、API 成本优化（官方动态计价、峰谷调度、日/月双档预算、模型路由）、全局对话检索与对话内搜索（Ctrl+F、CSS Custom Highlight API）。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:beijingwahw/dsh-companion",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-sideband",
+   "owner": "ishuowang",
+   "url": "https://github.com/ishuowang/dsh-sideband",
+   "page": "https://awesome-dsh-plugin.com/p/ishuowang/dsh-sideband/",
+   "category": "session",
+   "description": {
+    "en": "Asynchronous, LLM-summarized context relay between DSH Sessions and authorized Agent Team Rooms, with instant snapshots and scheduled digests.",
+    "zh": "在 DSH Session 与已授权 Agent Team Room 之间异步传递 LLM 总结的上下文，支持即时快照与定时摘要。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:ishuowang/dsh-sideband",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-session-doctor",
+   "owner": "mayf3",
+   "url": "https://github.com/mayf3/dsh-session-doctor",
+   "page": "https://awesome-dsh-plugin.com/p/mayf3/dsh-session-doctor/",
+   "category": "session",
+   "description": {
+    "en": "Diagnose, unstick, and read DSH sessions: list sessions with agent status, read conversations, diagnose stuck agents, recover them with cancel+keepInbox, and send messages to other sessions.",
+    "zh": "会话医生：列出会话（含 agent 运行状态）、读取会话记录、诊断卡死的 agent、解卡（cancel + keepInbox 保留排队消息）、向其他会话发送消息。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:mayf3/dsh-session-doctor",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-archived-sessions",
+   "owner": "MuWinds",
+   "url": "https://github.com/MuWinds/dsh-archived-sessions",
+   "page": "https://awesome-dsh-plugin.com/p/MuWinds/dsh-archived-sessions/",
+   "category": "session",
+   "description": {
+    "en": "Archived-session management: browse archived sessions, unarchive them, or clear them out.",
+    "zh": "归档会话管理：浏览已归档会话，支持恢复（取消归档）与清空。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:MuWinds/dsh-archived-sessions",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-assistant-message-forge",
+   "owner": "anweat",
+   "url": "https://github.com/anweat/dsh-assistant-message-forge",
+   "page": "https://awesome-dsh-plugin.com/p/anweat/dsh-assistant-message-forge/",
+   "category": "session",
+   "description": {
+    "en": "Create/modify/inject test assistant messages and import/repair session.jsonl(.zstd) session logs into new sessions.",
+    "zh": "消息锻造台：创建/修改/注入测试用 assistant 消息，导入识别并安全修复 session.jsonl(.zstd) 会话日志为新会话。"
+   },
+   "npm": "dsh-assistant-message-forge",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-assistant-message-forge",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-session-export",
+   "owner": "yangyongzhen",
+   "url": "https://github.com/yangyongzhen/dsh-session-export",
+   "page": "https://awesome-dsh-plugin.com/p/yangyongzhen/dsh-session-export/",
+   "category": "session",
+   "description": {
+    "en": "Export sessions to Markdown/JSON for review, replay, and per-session cost summaries.",
+    "zh": "会话导出为 Markdown/JSON，便于复盘、重放与单会话成本汇总。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:yangyongzhen/dsh-session-export",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-session-report",
+   "owner": "yangyongzhen",
+   "url": "https://github.com/yangyongzhen/dsh-session-report",
+   "page": "https://awesome-dsh-plugin.com/p/yangyongzhen/dsh-session-report/",
+   "category": "session",
+   "description": {
+    "en": "Per-session cost & usage report cards: tokens, cache hits, duration.",
+    "zh": "会话成本与耗时报表：tokens / 缓存命中 / 耗时。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:yangyongzhen/dsh-session-report",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-enter-customizer",
+   "owner": "Boliban",
+   "url": "https://github.com/Boliban/dsh-enter-customizer",
+   "page": "https://awesome-dsh-plugin.com/p/Boliban/dsh-enter-customizer/",
+   "category": "session",
+   "description": {
+    "en": "Take over the system input shortcuts for the chat input box and configure behavior independently for each shortcut.",
+    "zh": "接管聊天输入框的回车等快捷键，每个快捷键的行为都能单独配置。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:Boliban/dsh-enter-customizer",
+   "added": "2026-08-15"
   },
   {
    "name": "distill",
    "owner": "LoserFox",
    "url": "https://github.com/LoserFox/distill",
+   "page": "https://awesome-dsh-plugin.com/p/LoserFox/distill/",
    "category": "memory",
    "description": {
     "en": "Automatic conversation distillation: background subagent reflection + skill create/update.",
@@ -1007,41 +2410,44 @@
    "name": "dsh-mnemon",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-mnemon",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-mnemon/",
    "category": "memory",
    "description": {
-    "en": "Deep Mnemon integration: local three-tier memory (Runtime Memory, retrievable Documents, supervised Memory Spaces).",
-    "zh": "Mnemon 深度集成：本地三层记忆（Runtime Memory、可检索 Documents、受监督 Memory Spaces）。"
+    "en": "Cross-agent, local-first persistent memory plugin for DeepSeek Harness (DSH), powered by Mnemon. It shares long-term memory across Mnemon-enabled agents and adds runtime memory, searchable project documents, semantic recall, knowledge graph, and a Sidebar UI.",
+    "zh": "由 Mnemon 驱动的 DeepSeek Harness（DSH）跨 Agent、本地优先的持久记忆插件。它可在支持 Mnemon 的 Agent 之间共享长期记忆，并提供运行时记忆、可检索项目档案、语义召回、知识图谱和 Sidebar UI。"
    },
    "npm": "dsh-mnemon",
-   "stars": 7,
+   "stars": 18,
    "install": "dsh plugin --profile web add dsh-mnemon",
    "added": "2026-08-13"
   },
   {
-   "name": "dsh-mneme",
+   "name": "dsh-mneme#dsh-mneme",
    "owner": "modusensus",
-   "url": "https://github.com/modusensus/dsh-mneme",
+   "url": "https://github.com/modusensus/dsh-mneme/tree/main/dsh-mneme",
+   "page": "https://awesome-dsh-plugin.com/p/modusensus/dsh-mneme--dsh-mneme/",
    "category": "memory",
    "description": {
-    "en": "Cross-session memory: SQLite with a human-editable Markdown mirror, background consolidation (dedup, merge, conflict resolution), and six memory tools.",
-    "zh": "跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，后台自动巩固（去重/合并/冲突裁决），提供 6 个记忆工具。"
+    "en": "Cross-session memory for DSH: SQLite + human-editable Markdown mirror, autoDream consolidation, six memory tools, and fully-offline semantic search (local embeddings, reranking, clustering).",
+    "zh": "跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，autoDream 后台自动巩固（去重/合并/冲突裁决），6 个记忆工具，完全离线语义检索（本地向量 / 精排 / 聚类）。"
    },
    "npm": null,
-   "stars": 7,
-   "install": "dsh plugin --profile web add github:modusensus/dsh-mneme",
+   "stars": 9,
+   "install": "dsh plugin --profile web add github:modusensus/dsh-mneme#path:/dsh-mneme",
    "added": "2026-08-14"
   },
   {
    "name": "nowledge-mem-deepseek-harness",
    "owner": "nowledge-co",
    "url": "https://github.com/nowledge-co/nowledge-mem-deepseek-harness",
+   "page": "https://awesome-dsh-plugin.com/p/nowledge-co/nowledge-mem-deepseek-harness/",
    "category": "memory",
    "description": {
     "en": "One memory layer for every AI tool and agent: Context Bundle injection, prompt-time recall, MCP tools, and turn-end DSH thread capture.",
     "zh": "给所有 AI 工具和 Agent 共用的一层记忆：注入 Context Bundle、提示时检索、MCP 工具与回合结束 DSH 线程捕获。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:nowledge-co/nowledge-mem-deepseek-harness",
    "added": "2026-08-14"
   },
@@ -1049,6 +2455,7 @@
    "name": "dsh-memory",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-memory",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-memory/",
    "category": "memory",
    "description": {
     "en": "Cited memory over DSH's lossless session log: distilled facts carry `(sessionId, eventRange)` citations that expand back to the exact original log excerpt.",
@@ -1063,20 +2470,22 @@
    "name": "dsh-memory",
    "owner": "flymysql",
    "url": "https://github.com/flymysql/dsh-memory",
+   "page": "https://awesome-dsh-plugin.com/p/flymysql/dsh-memory/",
    "category": "memory",
    "description": {
     "en": "Cross-session memory vault: remember / recall / forget tools, per-turn prompt injection, and a settings-page entry browser.",
     "zh": "跨会话记忆库：remember / recall / forget 工具、每轮提示注入与设置页条目浏览。"
    },
-   "npm": null,
+   "npm": "dsh-memory-vault",
    "stars": 0,
-   "install": "dsh plugin --profile web add github:flymysql/dsh-memory",
+   "install": "dsh plugin --profile web add dsh-memory-vault",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-plugin-asmemory",
    "owner": "Xplore-LAB",
    "url": "https://github.com/Xplore-LAB/dsh-plugin-asmemory",
+   "page": "https://awesome-dsh-plugin.com/p/Xplore-LAB/dsh-plugin-asmemory/",
    "category": "memory",
    "description": {
     "en": "Action-state time memory: record typed states and actions, then analyze trends, anomalies, and causality.",
@@ -1091,20 +2500,37 @@
    "name": "dsh-memento",
    "owner": "PerryLink",
    "url": "https://github.com/PerryLink/dsh-memento",
+   "page": "https://awesome-dsh-plugin.com/p/PerryLink/dsh-memento/",
    "category": "memory",
    "description": {
     "en": "Bounded, layered, approval-gated, auditable cross-session memory: a typed `ctx.memory` seam with a zero-dependency SQLite provider, a `memory` tool, and frozen snapshot injection; every write passes the approval gate and stays reconstructable from the session log.",
     "zh": "有界、分层、带审批门、可审计的跨会话记忆：`ctx.memory` 服务 + 零依赖 SQLite 存储 + `memory` 工具与冻结快照注入；写入必过审批门，模型可见内容可自会话日志重建。"
    },
-   "npm": null,
-   "stars": 1,
-   "install": "dsh plugin --profile web add github:PerryLink/dsh-memento",
+   "npm": "dsh-memento",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-memento",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-memory-gate",
+   "owner": "GIT121995",
+   "url": "https://github.com/GIT121995/dsh-memory-gate",
+   "page": "https://awesome-dsh-plugin.com/p/GIT121995/dsh-memory-gate/",
+   "category": "memory",
+   "description": {
+    "en": "Bounded local memory with CBDC authority gating: SQLite + FTS5 claims, scoped recall with explainable use/verify/ignore decisions and a full audit trail, /memory commands, ≤3-claim/1200-char injection per call, no extra model call.",
+    "zh": "有界本地记忆 + CBDC 权威门控：SQLite + FTS5 claims，作用域召回并给出可解释的采用/核验/忽略决策与完整审计轨迹，/memory 命令，每次注入 ≤3 条/1200 字符，不增加额外模型调用。"
+   },
+   "npm": "dsh-memory-gate",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-memory-gate",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-file-memory",
    "owner": "ICCuse",
    "url": "https://github.com/ICCuse/dsh-file-memory",
+   "page": "https://awesome-dsh-plugin.com/p/ICCuse/dsh-file-memory/",
    "category": "memory",
    "description": {
     "en": "File-backed working memory: memorize/recall key premises verbatim in a session notes file so they survive context compaction losslessly.",
@@ -1119,6 +2545,7 @@
    "name": "dsh-knowledge",
    "owner": "ICCuse",
    "url": "https://github.com/ICCuse/dsh-knowledge",
+   "page": "https://awesome-dsh-plugin.com/p/ICCuse/dsh-knowledge/",
    "category": "memory",
    "description": {
     "en": "Bridge into a global Markdown knowledge base shared with the Codex kb.cmd CLI: kb_add/kb_search/kb_show/kb_timeline tools with byte-compatible frontmatter.",
@@ -1133,6 +2560,7 @@
    "name": "dsh-premise-guard",
    "owner": "ICCuse",
    "url": "https://github.com/ICCuse/dsh-premise-guard",
+   "page": "https://awesome-dsh-plugin.com/p/ICCuse/dsh-premise-guard/",
    "category": "memory",
    "description": {
     "en": "Post-compaction premise-drift guard: injects a one-shot notice when a compaction summary drops a critical literal anchor.",
@@ -1147,13 +2575,14 @@
    "name": "sgme",
    "owner": "freehul",
    "url": "https://github.com/freehul/sgme",
+   "page": "https://awesome-dsh-plugin.com/p/freehul/sgme/",
    "category": "memory",
    "description": {
     "en": "ShiGuang Memory Engine (SGME) bridge: multi-agent shared long-term memory via HTTP — L0/L1/L1.5/L2 distillation, scenario-based injection, unified search, and proactive care signals (memory_search / wiki_search / signal_pull / signal_claim / signal_ack), installable as `dsh-sgme`.",
     "zh": "拾光记忆引擎（SGME）桥接：多智能体共享长期记忆（HTTP）—— L0/L1/L1.5/L2 分层提炼、按场景注入、统一检索、主动关怀信号（memory_search / wiki_search / signal_pull / signal_claim / signal_ack），npm 包名 `dsh-sgme`。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:freehul/sgme",
    "added": "2026-08-14"
   },
@@ -1161,41 +2590,359 @@
    "name": "dsh-memory-meow",
    "owner": "Phant0Meow",
    "url": "https://github.com/Phant0Meow/dsh-memory-meow",
+   "page": "https://awesome-dsh-plugin.com/p/Phant0Meow/dsh-memory-meow/",
    "category": "memory",
    "description": {
     "en": "Project-scoped cross-session memory: PROJECT.md snapshot injected into the first user message, a memory_remember tool, and auto-reflection after ReAct tasks; each project keeps its own memory file.",
     "zh": "项目级跨会话记忆：PROJECT.md 快照注入首条用户消息（缓存友好）+ memory_remember 工具 + ReAct 任务结束自动反思；各项目独立记忆文件，互不互通。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:Phant0Meow/dsh-memory-meow",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-memoria",
+   "owner": "jiayan-xu",
+   "url": "https://github.com/jiayan-xu/dsh-memoria",
+   "page": "https://awesome-dsh-plugin.com/p/jiayan-xu/dsh-memoria/",
+   "category": "memory",
+   "description": {
+    "en": "Vector + graph memory backend: observe/remember/search/recall tools against a local memoria server, fusing HNSW semantic recall, FTS5 keyword search, and knowledge-graph signals via RRF ranking, with automatic turn-end persistence and per-agent namespace isolation.",
+    "zh": "向量+图记忆后端：observe/remember/search/recall 四个工具对接本地 memoria 服务，HNSW 语义召回 + FTS5 关键词 + 知识图谱信号经 RRF 融合排序，回合结束自动写入，按 Agent 命名空间隔离。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:jiayan-xu/dsh-memoria",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "deepseek-harness-forge-plugins#forge-memory",
+   "owner": "jinguanghai",
+   "url": "https://github.com/jinguanghai/deepseek-harness-forge-plugins/tree/main/plugins/forge-memory",
+   "page": "https://awesome-dsh-plugin.com/p/jinguanghai/deepseek-harness-forge-plugins--plugins-forge-memory/",
+   "category": "memory",
+   "description": {
+    "en": "BM25 keyword-based memory recall.",
+    "zh": "基于 BM25 关键词检索的记忆召回。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:jinguanghai/deepseek-harness-forge-plugins#path:/plugins/forge-memory",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-memory",
+   "owner": "FuRongJun-1999",
+   "url": "https://github.com/FuRongJun-1999/dsh-memory",
+   "page": "https://awesome-dsh-plugin.com/p/FuRongJun-1999/dsh-memory/",
+   "category": "memory",
+   "description": {
+    "en": "Multi-agent spatiotemporal memory graph with cross-session persistence and importance-gated recall.",
+    "zh": "多智能体时空记忆图：跨会话持久化与重要性门控召回。"
+   },
+   "npm": "@furongjun1999/dsh-memory",
+   "stars": 1,
+   "install": "dsh plugin --profile web add @furongjun1999/dsh-memory",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-memoria-extra",
+   "owner": "jiayan-xu",
+   "url": "https://github.com/jiayan-xu/dsh-memoria-extra",
+   "page": "https://awesome-dsh-plugin.com/p/jiayan-xu/dsh-memoria-extra/",
+   "category": "memory",
+   "description": {
+    "en": "Advanced memoria tools: session context injection (profile + recall), recent decisions, health report, namespace allowlist, memory relation graph, and entity search; companion to dsh-memoria.",
+    "zh": "memoria 进阶工具：会话上下文注入（画像+召回）、近期决策、健康报告、命名空间白名单、记忆关系图与实体搜索；dsh-memoria 的伴生插件。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:jiayan-xu/dsh-memoria-extra",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-recall",
+   "owner": "truelove-dreamer",
+   "url": "https://github.com/truelove-dreamer/dsh-plugin-recall",
+   "page": "https://awesome-dsh-plugin.com/p/truelove-dreamer/dsh-plugin-recall/",
+   "category": "memory",
+   "description": {
+    "en": "Cross-session memory for the model: full-text search all past sessions (SQLite FTS5 via ctx.sessionQuery) and bring the strongest matching excerpts back into the current context.",
+    "zh": "跨会话记忆：全文检索所有历史会话（复用 ctx.sessionQuery 的 SQLite FTS5 索引），把最强匹配片段带回当前上下文。"
+   },
+   "npm": "dsh-plugin-recall",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-plugin-recall",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "unified-agent-memory",
+   "owner": "Noelune",
+   "url": "https://github.com/Noelune/unified-agent-memory",
+   "page": "https://awesome-dsh-plugin.com/p/Noelune/unified-agent-memory/",
+   "category": "memory",
+   "description": {
+    "en": "One shared Obsidian vault for every agent: dependency-free Python core (search/promote/adjudicate/forget), vault template, dsh plugin (memory_search/show/submit/status).",
+    "zh": "多 Agent 共享一个 Obsidian vault：零依赖 Python core（检索/晋升/裁决/遗忘）+ vault 模板 + dsh 插件（memory_search/show/submit/status）。"
+   },
+   "npm": "dsh-unified-agent-memory",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-unified-agent-memory",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-handoff",
+   "owner": "FleetingEcho",
+   "url": "https://github.com/FleetingEcho/dsh-handoff",
+   "page": "https://awesome-dsh-plugin.com/p/FleetingEcho/dsh-handoff/",
+   "category": "memory",
+   "description": {
+    "en": "Self-maintaining handoff memory per working directory and git branch: records turns, folds them into concise Markdown, and injects the result into future sessions from ~/.agent/agent-handoff, byte-compatible with pi-handoff.",
+    "zh": "每个工作目录与 git 分支自动维护 handoff.md：记录回合、折叠为简洁 Markdown 并注入后续会话，存储于 ~/.agent/agent-handoff，与 pi-handoff 字节级兼容。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:FleetingEcho/dsh-handoff",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-memory",
+   "owner": "yangyongzhen",
+   "url": "https://github.com/yangyongzhen/dsh-memory",
+   "page": "https://awesome-dsh-plugin.com/p/yangyongzhen/dsh-memory/",
+   "category": "memory",
+   "description": {
+    "en": "Long-term memory injected at session start: preferences/facts/summaries/knowledge in global and per-project scopes, budgeted recall via `agent/pre-step`, durable JSON store.",
+    "zh": "会话开始自动注入的长期记忆：preference/fact/summary/knowledge 四类、global/project 双作用域，`agent/pre-step` 字节预算召回，JSON 原子持久化。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:yangyongzhen/dsh-memory",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-negative-ledger",
+   "owner": "akslcw",
+   "url": "https://github.com/akslcw/dsh-negative-ledger",
+   "page": "https://awesome-dsh-plugin.com/p/akslcw/dsh-negative-ledger/",
+   "category": "memory",
+   "description": {
+    "en": "Evidence-bound negative-knowledge ledger: persists disproven paths (command_failed, file_missing) with their outcome and precondition evidence, then warns or blocks repeat attempts until the evidence changes.",
+    "zh": "证据约束的负面知识账本：记录被证伪的路径（command_failed / file_missing）及其结果与前置条件证据，重复尝试时警告或拦截，证据变化后自动解除。"
+   },
+   "npm": "@akslcw/dsh-negative-ledger",
+   "stars": 2,
+   "install": "dsh plugin --profile web add @akslcw/dsh-negative-ledger",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-tool-writing",
+   "owner": "x2802490130-prog",
+   "url": "https://github.com/x2802490130-prog/dsh-tool-writing",
+   "page": "https://awesome-dsh-plugin.com/p/x2802490130-prog/dsh-tool-writing/",
+   "category": "tools",
+   "description": {
+    "en": "A web-novel writing engine for DeepSeek Harness: parallel drafting, outlining and brainstorming with a separate DeepSeek key, lore and foreshadowing management, semantic vector retrieval, a corpus library, usage ledger, mechanical proofreading, and a local serialization plan.",
+    "zh": "写文引擎：用独立 DeepSeek key 分流并发生成草稿/细纲/点子，设定与伏笔管理、语义向量检索、书库（饲料区）、用量总账、机械校对与本地连载计划。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:x2802490130-prog/dsh-tool-writing",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-writing-remote",
+   "owner": "x2802490130-prog",
+   "url": "https://github.com/x2802490130-prog/dsh-writing-remote",
+   "page": "https://awesome-dsh-plugin.com/p/x2802490130-prog/dsh-writing-remote/",
+   "category": "tools",
+   "description": {
+    "en": "Host-side Typert remote for dsh-tool-writing: serves project volumes, chapter status, corpus library, full-text search, evolution entries, and thread-graph data to the client writing panel.",
+    "zh": "写文引擎的 host 侧数据通道：把项目分卷、章节状态、书库、全文检索、演化条目与线索图谱以 Typert remote 暴露给客户端写作面板。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:x2802490130-prog/dsh-writing-remote",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-plugin-writing-guard",
+   "owner": "xmutfyh",
+   "url": "https://github.com/xmutfyh/dsh-plugin-writing-guard",
+   "page": "https://awesome-dsh-plugin.com/p/xmutfyh/dsh-plugin-writing-guard/",
+   "category": "tools",
+   "description": {
+    "en": "AI paper-writing style guard: scans manuscripts for revision-process residue, defensive writing, and AI-writing tells (em-dash abuse, not-X-but-Y, LLM overused words, rule of three); writing_audit + writing_rules tools with auto-audit on paper file writes.",
+    "zh": "AI 论文写作常见错误守卫：扫描修改过程残留、防御性写作与 AI 写作痕迹（破折号滥用、不是X而是Y、LLM 高频词、三连排比）；提供 writing_audit / writing_rules 工具，论文文件写入后自动审计。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:xmutfyh/dsh-plugin-writing-guard",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "Gemini-Eyes",
+   "owner": "ConsoleSun",
+   "url": "https://github.com/ConsoleSun/Gemini-Eyes",
+   "page": "https://awesome-dsh-plugin.com/p/ConsoleSun/Gemini-Eyes/",
+   "category": "tools",
+   "description": {
+    "en": "MCP bridge to gemini.google.com: vision analysis of images and videos, Imagen image and Veo video generation, and conversation management using the logged-in browser session with no API key.",
+    "zh": "接入 gemini.google.com 的 MCP 桥：图片/视频视觉识别、Imagen 生图、Veo 生视频与历史对话管理，复用浏览器登录态，无需 API Key。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:ConsoleSun/Gemini-Eyes",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-mcp-bridge",
+   "owner": "Edge-Echo",
+   "url": "https://github.com/Edge-Echo/dsh-mcp-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/Edge-Echo/dsh-mcp-bridge/",
+   "category": "tools",
+   "description": {
+    "en": "Curated MCP server bundle: one install brings demo, memory, filesystem, GitHub, Playwright and remote HTTP MCP servers, plus a connectivity verifier tool and CI checks.",
+    "zh": "精选 MCP 服务器全家桶：一键接入演示、记忆、文件系统、GitHub、Playwright、远程 HTTP 等服务器，自带连通性验证工具与 CI 检查。"
+   },
+   "npm": "dsh-mcp-bridge",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-mcp-bridge",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "godot-bridge",
+   "owner": "Smalldy",
+   "url": "https://github.com/Smalldy/godot-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/Smalldy/godot-bridge/",
+   "category": "tools",
+   "description": {
+    "en": "DSH↔Godot engine runtime bridge: launch and drive a running Godot 4.x game through its in-game TCP interaction server — 8 tools (scene/UI inspection, GDScript eval, input simulation, screenshots, headless static ops, script validation), replaces godot-mcp.",
+    "zh": "DSH↔Godot 引擎运行时控制桥：通过游戏内置 TCP 交互服务器启动并操控运行中的 Godot 4.x——8 个工具（场景/UI 检查、GDScript eval、输入模拟、截图、headless 静态操作、脚本编译检查），替代 godot-mcp。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:Smalldy/godot-bridge",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-agent-preset-recommender",
+   "owner": "LeemanCheung",
+   "url": "https://github.com/LeemanCheung/dsh-agent-preset-recommender",
+   "page": "https://awesome-dsh-plugin.com/p/LeemanCheung/dsh-agent-preset-recommender/",
+   "category": "tools",
+   "description": {
+    "en": "Privacy-safe local scanner for Codex, Claude Code, WorkBuddy, and CodeBuddy session/workflow metadata; persists aggregate evidence and recommends built-in DSH agent presets without retaining content, using a network, or changing presets.",
+    "zh": "隐私安全的本地扫描器：汇总 Codex、Claude Code、WorkBuddy、CodeBuddy 的会话/workflow 元数据，持久化聚合证据并推荐 DSH 内置 Agent preset；不保留正文、不联网、不修改 preset。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:LeemanCheung/dsh-agent-preset-recommender",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "blender",
+   "owner": "CheshireJCat",
+   "url": "https://github.com/CheshireJCat/blender",
+   "page": "https://awesome-dsh-plugin.com/p/CheshireJCat/blender/",
+   "category": "tools",
+   "description": {
+    "en": "Blender 3D production plugin with 30 modeling/reconstruction skills, 13 runtime tools, and 26 deterministic helpers for reference fitting, rendering, validation, animation, and portable export; installable as `dsh-blender`.",
+    "zh": "Blender 3D 生产插件：提供 30 个建模/重建 Skill、13 个运行时工具和 26 个确定性 Helper，覆盖参考图拟合、渲染、验证、动画与可移植格式导出；npm 包名 `dsh-blender`。"
+   },
+   "npm": "dsh-blender",
+   "stars": 6,
+   "install": "dsh plugin --profile web add dsh-blender",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-vision-router",
    "owner": "ysr666",
    "url": "https://github.com/ysr666/dsh-vision-router",
+   "page": "https://awesome-dsh-plugin.com/p/ysr666/dsh-vision-router/",
    "category": "tools",
    "description": {
     "en": "Free vision for text-only agents: built-in keyless vision chain plus pixel tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots); paste an image to use it.",
     "zh": "为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用。"
    },
+   "npm": "dsh-vision-router",
+   "stars": 73,
+   "install": "dsh plugin --profile web add dsh-vision-router",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-vision-proxy",
+   "owner": "Flyvhidbwo",
+   "url": "https://github.com/Flyvhidbwo/dsh-vision-proxy",
+   "page": "https://awesome-dsh-plugin.com/p/Flyvhidbwo/dsh-vision-proxy/",
+   "category": "tools",
+   "description": {
+    "en": "DeepSeek brain + automatic image transcription: attach images in the GUI and each one is transcribed to text via any OpenAI-compatible VLM before reaching the text-only DeepSeek — a keyed fast path (default qwen3.7-flash; DashScope/Zhipu/OpenRouter or any OpenAI-compatible endpoint) with your own key, or local Ollama auto-detected with zero config.",
+    "zh": "DeepSeek 大脑 + 自动识图：GUI 附加的每张图片自动经 OpenAI 兼容 VLM 转译成文字，再交给纯文本的 DeepSeek 作答——有 key 自动走快速通道（默认 qwen3.7-flash，支持百炼/智谱/OpenRouter 等任意 OpenAI 兼容端点），无 key 自动探测本地 Ollama（零配置，图片不出本机）。"
+   },
+   "npm": "dsh-vision-proxy",
+   "stars": 7,
+   "install": "dsh plugin --profile web add dsh-vision-proxy",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-vision-bridge",
+   "owner": "ximengxiaolan",
+   "url": "https://github.com/ximengxiaolan/dsh-vision-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/ximengxiaolan/dsh-vision-bridge/",
+   "category": "tools",
+   "description": {
+    "en": "Composer-attached images are transcribed to text by an OpenAI-compatible vision model before reaching text-only DeepSeek models.",
+    "zh": "输入框贴图自动识别：由 OpenAI 兼容视觉模型转成文字描述后，再交给纯文本 DeepSeek 模型处理。"
+   },
    "npm": null,
-   "stars": 17,
-   "install": "dsh plugin --profile web add github:ysr666/dsh-vision-router",
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:ximengxiaolan/dsh-vision-bridge",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-vision",
+   "owner": "linenxi-ctrl",
+   "url": "https://github.com/linenxi-ctrl/dsh-vision",
+   "page": "https://awesome-dsh-plugin.com/p/linenxi-ctrl/dsh-vision/",
+   "category": "tools",
+   "description": {
+    "en": "External vision plugin for DeepSeek Harness: whale-button config panel, image recognition with auto-reply, and agent screenshot/recognize tools.",
+    "zh": "外挂识图插件：鲸鱼按钮配置面板、图片识图自动回传、模型自主截图识图工具。"
+   },
+   "npm": null,
+   "stars": 10,
+   "install": "dsh plugin --profile web add github:linenxi-ctrl/dsh-vision",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-llm-vision-bridge",
+   "owner": "Einskyle",
+   "url": "https://github.com/Einskyle/dsh-llm-vision-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/Einskyle/dsh-llm-vision-bridge/",
+   "category": "tools",
+   "description": {
+    "en": "Native LLM-provider vision bridge: images pasted in the chat are described by a vision model (Qwen3-VL via pi-ai/llama.cpp) and the text description is fed to text-only DeepSeek for the reply — image admission, routing and compaction all run through harness-native mechanisms, with an LRU description cache and 503 retry.",
+    "zh": "DeepSeek 视觉桥接：注册原生 LLM provider，聊天内粘贴的图片自动由视觉模型（pi-ai/llama.cpp 上的 Qwen3-VL）转成文字描述后交给纯文本 DeepSeek 作答——图片准入、路由与会话压缩全部走 harness 原生机制，带 LRU 描述缓存与 503 重试。"
+   },
+   "npm": "dsh-llm-vision-bridge",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-llm-vision-bridge",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-undo-plugin",
    "owner": "lire1131",
    "url": "https://github.com/lire1131/dsh-undo-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/lire1131/dsh-undo-plugin/",
    "category": "tools",
    "description": {
     "en": "Undo/redo & rollback system for DSH: every config change is auto-snapshotted; undo/redo/restore to any version from the WebUI or the offline CLI/GUI tools (works even when DSH fails to boot).",
     "zh": "DSH 撤销/回退系统：配置变更自动存档，一键撤销/恢复/回退到任意版本，支持 WebUI 与离线 CLI/GUI 工具（DSH 启动失败也能救）。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 7,
    "install": "dsh plugin --profile web add github:lire1131/dsh-undo-plugin",
    "added": "2026-08-14"
   },
@@ -1203,69 +2950,149 @@
    "name": "dsh-bash-terminal",
    "owner": "MAXeaglet",
    "url": "https://github.com/MAXeaglet/dsh-bash-terminal",
+   "page": "https://awesome-dsh-plugin.com/p/MAXeaglet/dsh-bash-terminal/",
    "category": "tools",
    "description": {
     "en": "One shell tool for PowerShell / Git Bash / WSL on Windows plus an interactive PTY terminal; the default terminal is chosen by the user in DSH settings.",
     "zh": "一个 shell 工具：Windows 上统一执行 PowerShell / Git Bash / WSL，外加交互式 PTY 终端，默认终端由用户在设置中选择。"
    },
+   "npm": "dsh-bash-terminal",
+   "stars": 1,
+   "install": "dsh plugin --profile web add dsh-bash-terminal",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-download-progress",
+   "owner": "Fro2en12",
+   "url": "https://github.com/Fro2en12/dsh-download-progress",
+   "page": "https://awesome-dsh-plugin.com/p/Fro2en12/dsh-download-progress/",
+   "category": "tools",
+   "description": {
+    "en": "Download progress panel: URL downloader, agent shell/SSH transfer tracking and workspace black-box file-growth monitoring, shown in a draggable floating panel with live bytes, speed, percentage and ETA.",
+    "zh": "下载进度面板：URL 下载器、agent shell/SSH 传输追踪与工作区黑箱文件增长监控，汇聚到可拖拽浮窗实时显示字节、速度、百分比与预计剩余时间。"
+   },
    "npm": null,
    "stars": 1,
-   "install": "dsh plugin --profile web add github:MAXeaglet/dsh-bash-terminal",
+   "install": "dsh plugin --profile web add github:Fro2en12/dsh-download-progress",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-bilibili",
+   "owner": "CZX2244",
+   "url": "https://github.com/CZX2244/dsh-bilibili",
+   "page": "https://awesome-dsh-plugin.com/p/CZX2244/dsh-bilibili/",
+   "category": "tools",
+   "description": {
+    "en": "Bilibili video analysis: metadata, transcript (ASR fallback via Bijian/sherpa-onnx/whisper.cpp), comments, danmaku, and sharp keyframes with optional local vision descriptions.",
+    "zh": "B站视频分析工具：提取元数据、字幕文稿（必剪/本地 ASR 兜底）、评论与弹幕，抓取清晰关键帧并可选本地视觉描述。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:CZX2244/dsh-bilibili",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-vision-toolkit",
    "owner": "Anionex",
    "url": "https://github.com/Anionex/dsh-vision-toolkit",
+   "page": "https://awesome-dsh-plugin.com/p/Anionex/dsh-vision-toolkit/",
    "category": "tools",
    "description": {
     "en": "Vision tasks for text-only models: intent-aware image Q&A, long-screenshot OCR, UI reproduction, grounding, and pixel diff.",
     "zh": "让纯文本模型更好地做视觉任务：带意图的图片问答、长截图 OCR、UI 还原等。"
    },
-   "npm": "@dsh-external/dsh-vision-toolkit",
-   "stars": 283,
-   "install": "dsh plugin --profile web add @dsh-external/dsh-vision-toolkit",
+   "npm": "@anionex/dsh-vision-toolkit",
+   "stars": 361,
+   "install": "dsh plugin --profile web add @anionex/dsh-vision-toolkit",
    "added": "2026-08-13"
+  },
+  {
+   "name": "dsh-codex-tools",
+   "owner": "SPYQWER1",
+   "url": "https://github.com/SPYQWER1/dsh-codex-tools",
+   "page": "https://awesome-dsh-plugin.com/p/SPYQWER1/dsh-codex-tools/",
+   "category": "tools",
+   "description": {
+    "en": "Codex-backed `web_search`, `image_gen`, and `image_vision` tools for DeepSeek Harness, reusing ChatGPT OAuth login state.",
+    "zh": "基于 Codex 的 `web_search`、`image_gen` 与 `image_vision` 工具，复用 ChatGPT OAuth 登录态为 DeepSeek Harness 提供网页搜索、生图与识图能力。"
+   },
+   "npm": "dsh-codex-tools",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-codex-tools",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "deepseek-heartflow",
+   "owner": "yun520-1",
+   "url": "https://github.com/yun520-1/deepseek-heartflow",
+   "page": "https://awesome-dsh-plugin.com/p/yun520-1/deepseek-heartflow/",
+   "category": "tools",
+   "description": {
+    "en": "HeartFlow (心虫) AGI layer-1 discriminator gate as a DSH plugin: 47-dimension rule-based text checking (heartflow_check tool) plus automatic output supervision at tools/post-execute, fail-closed when engine missing.",
+    "zh": "心虫（AGI 第1层辨别门禁）作为 DSH 插件：47 维纯规则文本判别（heartflow_check 工具）+ 工具调用后自动输出监督（fail-closed，引擎缺失时拒绝放行）。"
+   },
+   "npm": "@yun520-1/deepseek-heartflow",
+   "stars": 4,
+   "install": "dsh plugin --profile web add @yun520-1/deepseek-heartflow",
+   "added": "2026-08-14"
   },
   {
    "name": "dsh-custom-tool",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-custom-tool",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-custom-tool/",
    "category": "tools",
    "description": {
     "en": "Create and manage sandboxed JavaScript tools with a Monaco editor and model-driven tool lifecycle.",
     "zh": "用 Monaco 编辑器创建和管理沙箱化的自定义 JavaScript 工具。"
    },
    "npm": null,
-   "stars": 20,
+   "stars": 23,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-custom-tool",
    "added": "2026-08-13"
   },
   {
    "name": "dsh-computer-use",
+   "owner": "ZRui-C",
+   "url": "https://github.com/ZRui-C/dsh-computer-use",
+   "page": "https://awesome-dsh-plugin.com/p/ZRui-C/dsh-computer-use/",
+   "category": "tools",
+   "description": {
+    "en": "Text-first computer use for DSH: background Chromium control via Playwright/CDP plus accessibility-first macOS control; actions stay pinned to the right process and window without taking the user's pointer, ships a Developer ID signed, notarized Universal 2 DMG.",
+    "zh": "DSH 电脑控制：Playwright/CDP 后台操作 Chromium，Accessibility 优先控制 macOS；动作锁定到正确进程与窗口，不抢前台、不移动鼠标，提供已签名公证的 Universal 2 DMG 安装包。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:ZRui-C/dsh-computer-use",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-computer-use",
    "owner": "Anionex",
    "url": "https://github.com/Anionex/dsh-computer-use",
+   "page": "https://awesome-dsh-plugin.com/p/Anionex/dsh-computer-use/",
    "category": "tools",
    "description": {
     "en": "Accessibility-first macOS computer use: fresh observations, stale-state rejection, scoped permissions, and safe input.",
     "zh": "macOS 电脑控制：Accessibility 观测、过期状态拒绝、作用域权限与安全输入。"
    },
-   "npm": null,
-   "stars": 15,
-   "install": "dsh plugin --profile web add github:Anionex/dsh-computer-use",
+   "npm": "@anionex/dsh-computer-use",
+   "stars": 18,
+   "install": "dsh plugin --profile web add @anionex/dsh-computer-use",
    "added": "2026-08-13"
   },
   {
    "name": "dsh-mobile-gui-agent",
    "owner": "kunjinkao-os",
    "url": "https://github.com/kunjinkao-os/dsh-mobile-gui-agent",
+   "page": "https://awesome-dsh-plugin.com/p/kunjinkao-os/dsh-mobile-gui-agent/",
    "category": "tools",
    "description": {
     "en": "Android GUI Agent with ADB screenshots, compact UI hierarchy grounding, verified iterative actions, approvals, and a Mobile Web view.",
     "zh": "Android GUI Agent：ADB 截图、压缩 UI hierarchy 定位、逐步动作验证、审批和 Mobile Web 视图。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:kunjinkao-os/dsh-mobile-gui-agent",
    "added": "2026-08-14"
   },
@@ -1273,27 +3100,29 @@
    "name": "dsh-data-agent",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-data-agent",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-data-agent/",
    "category": "tools",
    "description": {
     "en": "Let the AI connect to databases and write SQL for you.",
     "zh": "让 AI 帮你连数据库、写 SQL。"
    },
-   "npm": null,
-   "stars": 11,
-   "install": "dsh plugin --profile web add github:omdsh-dev/dsh-data-agent",
+   "npm": "@yejiming/dsh-data-agent",
+   "stars": 20,
+   "install": "dsh plugin --profile web add @yejiming/dsh-data-agent",
    "added": "2026-08-13"
   },
   {
    "name": "dsh-toolkit",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-toolkit",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-toolkit/",
    "category": "tools",
    "description": {
     "en": "Zero-dependency toolkit: time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema — ten deterministic tools in one install.",
     "zh": "零依赖工具包：time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema 十件套一键安装。"
    },
    "npm": null,
-   "stars": 14,
+   "stars": 16,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-toolkit",
    "added": "2026-08-13"
   },
@@ -1301,13 +3130,14 @@
    "name": "dsh-remote",
    "owner": "flymysql",
    "url": "https://github.com/flymysql/dsh-remote",
+   "page": "https://awesome-dsh-plugin.com/p/flymysql/dsh-remote/",
    "category": "tools",
    "description": {
-    "en": "Remote workspace: connect a host over SSH (password or key), pick a remote workspace directory and operate on it with rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec tools.",
-    "zh": "远程工作区：SSH 密码或 key 连接远程主机，选取远程工作区目录，用 rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec 工具在远程直接操作。"
+    "en": "Multi-machine remote workspace: manage many SSH hosts, pick a local or remote workspace in the native Add-workspace flow (system folder chooser / local path / remote dir browse), mirror a remote workspace to a real local folder, and operate it with rw_* tools. The picker is a centered modal that opens on the local tab and auto-fills `/` for remote paths, live-completing each directory level.",
+    "zh": "多机远程工作区：管理多台 SSH 主机，在原生「添加工作区」流程里选本机系统文件夹或远程目录，把远程工作区镜像成真实本地文件夹并用 rw_* 工具操作。选择器是居中弹窗，默认落在本机页签，远程路径自动预填 `/` 并逐级自动补全目录。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 10,
    "install": "dsh plugin --profile web add github:flymysql/dsh-remote",
    "added": "2026-08-14"
   },
@@ -1315,13 +3145,14 @@
    "name": "dsh-tool-csv",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-csv",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-csv/",
    "category": "tools",
    "description": {
     "en": "Parse/query/aggregate/convert CSV (RFC 4180) with a zero-dependency state-machine parser.",
     "zh": "CSV 解析/查询/统计/转换（RFC 4180），零依赖状态机解析器。"
    },
    "npm": null,
-   "stars": 3,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-csv",
    "added": "2026-08-13"
   },
@@ -1329,13 +3160,14 @@
    "name": "dsh-tool-calculator",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-calculator",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-calculator/",
    "category": "tools",
    "description": {
     "en": "Safe math expression evaluator, zero-dependency recursive-descent parser.",
     "zh": "安全的数学表达式求值器，零依赖递归下降解析器。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-calculator",
    "added": "2026-08-13"
   },
@@ -1343,13 +3175,14 @@
    "name": "dsh-tool-diff",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-diff",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-diff/",
    "category": "tools",
    "description": {
     "en": "Structured comparison and unified diffs for text/JSON/CSV/Markdown.",
     "zh": "文本/JSON/CSV/Markdown 结构化比较与 unified diff。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-diff",
    "added": "2026-08-13"
   },
@@ -1357,13 +3190,14 @@
    "name": "dsh-tool-encoding",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-encoding",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-encoding/",
    "category": "tools",
    "description": {
     "en": "base64/url/hex encoding, common hashes, and UUID generation.",
     "zh": "base64/url/hex 编解码、常用哈希、UUID 生成。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-encoding",
    "added": "2026-08-13"
   },
@@ -1371,13 +3205,14 @@
    "name": "dsh-tool-json",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-json",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-json/",
    "category": "tools",
    "description": {
     "en": "JSON queries with a JMESPath subset.",
     "zh": "JMESPath 子集 JSON 查询。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-json",
    "added": "2026-08-13"
   },
@@ -1385,13 +3220,14 @@
    "name": "dsh-tool-markdown",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-markdown",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-markdown/",
    "category": "tools",
    "description": {
     "en": "HTML↔Markdown conversion, GFM table normalization, and TOC generation.",
     "zh": "HTML↔Markdown 转换、GFM 表格规范化、目录生成。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-markdown",
    "added": "2026-08-13"
   },
@@ -1399,13 +3235,14 @@
    "name": "dsh-tool-regex",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-regex",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-regex/",
    "category": "tools",
    "description": {
     "en": "Test/extract/safe-replace/statically explain regexes without executing code.",
     "zh": "正则测试/提取/安全替换/静态解释（不执行代码）。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-regex",
    "added": "2026-08-13"
   },
@@ -1413,13 +3250,14 @@
    "name": "dsh-tool-schema",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-schema",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-schema/",
    "category": "tools",
    "description": {
     "en": "JSON Schema validation: validate/paths/explain/normalize.",
     "zh": "JSON Schema 验证：validate/paths/explain/normalize。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-schema",
    "added": "2026-08-13"
   },
@@ -1427,13 +3265,14 @@
    "name": "dsh-tool-stat",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-stat",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-stat/",
    "category": "tools",
    "description": {
     "en": "Descriptive statistics, percentiles, frequency distributions, and correlation.",
     "zh": "描述统计/百分位数/频数分布/相关性。"
    },
    "npm": null,
-   "stars": 3,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-stat",
    "added": "2026-08-13"
   },
@@ -1441,13 +3280,14 @@
    "name": "dsh-tool-time",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-tool-time",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-tool-time/",
    "category": "tools",
    "description": {
     "en": "Strict ISO 8601 parsing, IANA timezone conversion, and UTC calendar arithmetic.",
     "zh": "严格 ISO 8601 解析、IANA 时区转换、UTC 日历运算。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-tool-time",
    "added": "2026-08-13"
   },
@@ -1455,13 +3295,14 @@
    "name": "dsh-kb-sieve",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-kb-sieve",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-kb-sieve/",
    "category": "tools",
    "description": {
     "en": "Build auditable KB packs (SQLite FTS5) from md/txt/docx/pdf with deterministic retrieval and original-text reading.",
     "zh": "从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5），确定性检索与原文阅读。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-kb-sieve",
    "added": "2026-08-13"
   },
@@ -1469,13 +3310,14 @@
    "name": "dsh-plugin-mineru",
    "owner": "HuanLinOTO",
    "url": "https://github.com/HuanLinOTO/dsh-plugin-mineru",
+   "page": "https://awesome-dsh-plugin.com/p/HuanLinOTO/dsh-plugin-mineru/",
    "category": "tools",
    "description": {
     "en": "Expose MineRU document parsing tools to the model.",
     "zh": "向模型暴露 MineRU 文档解析工具。"
    },
    "npm": null,
-   "stars": 7,
+   "stars": 13,
    "install": "dsh plugin --profile web add github:HuanLinOTO/dsh-plugin-mineru",
    "added": "2026-08-13"
   },
@@ -1483,13 +3325,14 @@
    "name": "dsh-cowork",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-cowork",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-cowork/",
    "category": "tools",
    "description": {
     "en": "Bounded, cell-addressed `doc_read`/`doc_write` for xlsx / pdf / docx / pptx / ipynb, plus an MCP server and CLI.",
     "zh": "doc_read/doc_write：以有界、单元格寻址的方式读写 xlsx / pdf / docx / pptx / ipynb，另附 MCP 服务器与 CLI。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:Jesse-njx/dsh-cowork",
    "added": "2026-08-14"
   },
@@ -1497,13 +3340,14 @@
    "name": "dsh-skillport",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-skillport",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-skillport/",
    "category": "tools",
    "description": {
     "en": "Bring your existing Agent Skills (SKILL.md) library to DSH: discover skills across Claude/Codex/Cursor/Gemini paths, inject a progressive-disclosure index, and load bodies on demand.",
     "zh": "把已有的 Agent Skills（SKILL.md）技能库带进 DSH：扫描 Claude/Codex/Cursor/Gemini 技能目录、注入渐进式索引，按需加载技能正文。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:Jesse-njx/dsh-skillport",
    "added": "2026-08-14"
   },
@@ -1511,6 +3355,7 @@
    "name": "pack-agent",
    "owner": "sakikoTGW",
    "url": "https://github.com/sakikoTGW/pack-agent",
+   "page": "https://awesome-dsh-plugin.com/p/sakikoTGW/pack-agent/",
    "category": "tools",
    "description": {
     "en": "Project .pack.json/.pack.zip into .agent-pack/modpacks/ and expose skills via a workspace allow-list.",
@@ -1525,13 +3370,14 @@
    "name": "dsh-tool-search",
    "owner": "vibeinging",
    "url": "https://github.com/vibeinging/dsh-tool-search",
+   "page": "https://awesome-dsh-plugin.com/p/vibeinging/dsh-tool-search/",
    "category": "tools",
    "description": {
     "en": "Per-agent on-demand tool discovery and progressive schema disclosure.",
     "zh": "按 agent 的按需工具发现与渐进式 schema 披露。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:vibeinging/dsh-tool-search",
    "added": "2026-08-13"
   },
@@ -1539,13 +3385,14 @@
    "name": "dsh-openmaic",
    "owner": "THU-MAIC",
    "url": "https://github.com/THU-MAIC/dsh-openmaic",
+   "page": "https://awesome-dsh-plugin.com/p/THU-MAIC/dsh-openmaic/",
    "category": "tools",
    "description": {
     "en": "OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching.",
     "zh": "OpenMAIC 教学：课堂、幻灯片、交互组件与苏格拉底式教学。"
    },
    "npm": null,
-   "stars": 5,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:THU-MAIC/dsh-openmaic",
    "added": "2026-08-13"
   },
@@ -1553,13 +3400,14 @@
    "name": "dsh-scholar",
    "owner": "lzszq",
    "url": "https://github.com/lzszq/dsh-scholar",
+   "page": "https://awesome-dsh-plugin.com/p/lzszq/dsh-scholar/",
    "category": "tools",
    "description": {
     "en": "Academic assistant plugin.",
     "zh": "学术助手插件。"
    },
    "npm": null,
-   "stars": 9,
+   "stars": 15,
    "install": "dsh plugin --profile web add github:lzszq/dsh-scholar",
    "added": "2026-08-13"
   },
@@ -1567,6 +3415,7 @@
    "name": "noatmark-dsh-plugin",
    "owner": "ylwl1997",
    "url": "https://github.com/ylwl1997/noatmark-dsh-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/ylwl1997/noatmark-dsh-plugin/",
    "category": "tools",
    "description": {
     "en": "Text hygiene as a dsh plugin: sanitize untrusted text, scan invisible characters, clean LLM formatting, and escape CSV formula injection.",
@@ -1581,6 +3430,7 @@
    "name": "dsh-apple-mode",
    "owner": "jihongboo",
    "url": "https://github.com/jihongboo/dsh-apple-mode",
+   "page": "https://awesome-dsh-plugin.com/p/jihongboo/dsh-apple-mode/",
    "category": "tools",
    "description": {
     "en": "Xcode AI integration for DSH: 26 Xcode MCP tools (mcpbridge) + Apple platform skills + Xcode Intelligence-style persona (agent preset or global bundle).",
@@ -1595,13 +3445,14 @@
    "name": "dsh-continual-evolve",
    "owner": "ZK-Andy",
    "url": "https://github.com/ZK-Andy/dsh-continual-evolve",
+   "page": "https://awesome-dsh-plugin.com/p/ZK-Andy/dsh-continual-evolve/",
    "category": "tools",
    "description": {
     "en": "Continual self-evolution: versioned, auditable, rollback-safe harness state (prompts, memory, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills.",
     "zh": "持续自进化：从会话轨迹沉淀版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格），带审查门禁与技能热加载。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:ZK-Andy/dsh-continual-evolve",
    "added": "2026-08-14"
   },
@@ -1609,13 +3460,14 @@
    "name": "dsh-recommend",
    "owner": "zp-home",
    "url": "https://github.com/zp-home/dsh-recommend",
+   "page": "https://awesome-dsh-plugin.com/p/zp-home/dsh-recommend/",
    "category": "tools",
    "description": {
     "en": "Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.",
     "zh": "DSH 插件透明排行与推荐：每日自动抓取 `dsh-plugin` 话题生态，公开评分模型，提供 rank/search/recommend 工具与设置页榜单。"
    },
    "npm": "dsh-recommend",
-   "stars": 8,
+   "stars": 11,
    "install": "dsh plugin --profile web add dsh-recommend",
    "added": "2026-08-14"
   },
@@ -1623,13 +3475,14 @@
    "name": "modlens",
    "owner": "liustack",
    "url": "https://github.com/liustack/modlens",
+   "page": "https://awesome-dsh-plugin.com/p/liustack/modlens/",
    "category": "tools",
    "description": {
     "en": "Vision bridge for text-only models: paste an image, get structured JSON evidence (OCR, layout, semantics).",
     "zh": "为纯文本模型架起视觉桥梁：粘贴图片，输出结构化 JSON 证据（OCR、版面、语义）。"
    },
    "npm": "@liustack/modlens",
-   "stars": 1037,
+   "stars": 1398,
    "install": "dsh plugin --profile web add @liustack/modlens",
    "added": "2026-08-14"
   },
@@ -1637,27 +3490,59 @@
    "name": "dsh-market",
    "owner": "dsh-market",
    "url": "https://github.com/dsh-market/dsh-market",
+   "page": "https://awesome-dsh-plugin.com/p/dsh-market/dsh-market/",
    "category": "tools",
    "description": {
     "en": "The plugin market inside DSH: a Settings page to browse and search the full community catalog by category, with confirmed one-click installs and an installed-plugins view.",
     "zh": "装在 DSH 里的插件市场：设置页内逛/搜全部社区插件，按分类筛选，确认后一键安装，已装插件一目了然。"
    },
    "npm": "dshmarket",
-   "stars": 4,
+   "stars": 96,
    "install": "dsh plugin --profile web add dshmarket",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-suite#dsh-plugin-center",
+   "owner": "crTnT",
+   "url": "https://github.com/crTnT/dsh-plugin-suite/tree/main/dsh-plugin-center",
+   "page": "https://awesome-dsh-plugin.com/p/crTnT/dsh-plugin-suite--dsh-plugin-center/",
+   "category": "tools",
+   "description": {
+    "en": "Plugin center: discover, install, and manage DSH plugins from Settings.",
+    "zh": "插件中心：在设置页发现、安装与管理 DSH 插件。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:crTnT/dsh-plugin-suite#path:/dsh-plugin-center",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-suite#dsh-plugin-updater",
+   "owner": "crTnT",
+   "url": "https://github.com/crTnT/dsh-plugin-suite/tree/main/dsh-plugin-updater",
+   "page": "https://awesome-dsh-plugin.com/p/crTnT/dsh-plugin-suite--dsh-plugin-updater/",
+   "category": "tools",
+   "description": {
+    "en": "Update manager for installed plugins: check for updates, back up, and roll back.",
+    "zh": "已装插件更新管理：检查更新、备份与回滚。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:crTnT/dsh-plugin-suite#path:/dsh-plugin-updater",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-find-plugin",
    "owner": "awesome-dsh-plugin",
    "url": "https://github.com/awesome-dsh-plugin/dsh-find-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/awesome-dsh-plugin/dsh-find-plugin/",
    "category": "tools",
    "description": {
     "en": "Find plugins without leaving the agent: search this curated registry by keyword or category, with ready-to-run install commands.",
     "zh": "会话内直接找插件：按关键词/分类搜索本精选 registry，返回描述与可直接执行的安装命令。"
    },
    "npm": "dsh-find-plugin",
-   "stars": 8,
+   "stars": 19,
    "install": "dsh plugin --profile web add dsh-find-plugin",
    "added": "2026-08-14"
   },
@@ -1665,6 +3550,7 @@
    "name": "dsh-code-intel",
    "owner": "lonelymoon87",
    "url": "https://github.com/lonelymoon87/dsh-code-intel",
+   "page": "https://awesome-dsh-plugin.com/p/lonelymoon87/dsh-code-intel/",
    "category": "tools",
    "description": {
     "en": "Indexes workspace symbols with Tree-sitter and provides lexical or optional embedding-assisted code search.",
@@ -1679,13 +3565,14 @@
    "name": "dsh-subagent-tools",
    "owner": "lynx-gt",
    "url": "https://github.com/lynx-gt/dsh-subagent-tools",
+   "page": "https://awesome-dsh-plugin.com/p/lynx-gt/dsh-subagent-tools/",
    "category": "tools",
    "description": {
     "en": "Per-call model, provider, persona, and toolFilter overrides for subagent delegation, with @preset: references and provider/model composite ids.",
     "zh": "子代理委派的按调用覆盖：model/provider/persona/toolFilter、@preset: 引用与 provider/model 组合 id。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:lynx-gt/dsh-subagent-tools",
    "added": "2026-08-14"
   },
@@ -1693,13 +3580,14 @@
    "name": "dsh-subagent-cwd",
    "owner": "lynx-gt",
    "url": "https://github.com/lynx-gt/dsh-subagent-cwd",
+   "page": "https://awesome-dsh-plugin.com/p/lynx-gt/dsh-subagent-cwd/",
    "category": "tools",
    "description": {
     "en": "Extends dsh-subagent-tools with a per-call cwd for subagents, shipped with the two in-process provider patches it requires.",
     "zh": "在 dsh-subagent-tools 基础上增加子代理按调用 cwd，附带所需的两个 in-process provider 补丁。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:lynx-gt/dsh-subagent-cwd",
    "added": "2026-08-14"
   },
@@ -1707,6 +3595,7 @@
    "name": "dsh-voice",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-voice",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-voice/",
    "category": "tools",
    "description": {
     "en": "Voice notes in, spoken answers out: dictate audio that becomes user messages (transcribe), have the agent read replies aloud (speak), local-first under ~/.dsh/voice.",
@@ -1721,13 +3610,14 @@
    "name": "dsh-docker",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-docker",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-docker/",
    "category": "tools",
    "description": {
     "en": "Typed, guarded container control: ps/logs/inspect/exec/start/stop and compose up/down with JSON output, project-aware targeting, and approval-gated destructive ops.",
     "zh": "类型安全、带护栏的容器控制：ps/logs/inspect/exec/start/stop 与 compose up/down，JSON 输出、项目感知定位、破坏性操作需审批。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:Jesse-njx/dsh-docker",
    "added": "2026-08-14"
   },
@@ -1735,20 +3625,67 @@
    "name": "dsh-excel-chat",
    "owner": "hccccc01333",
    "url": "https://github.com/hccccc01333/dsh-excel-chat",
+   "page": "https://awesome-dsh-plugin.com/p/hccccc01333/dsh-excel-chat/",
    "category": "tools",
    "description": {
     "en": "Talk to Excel in DeepSeek Harness: create, edit, repair, and verify spreadsheets by conversation, with automatic formula health checks after every edit.",
     "zh": "在 DeepSeek Harness 里对话完成 Excel 工作：建表、编辑、修复公式、图表校验，每次编辑后自动体检公式。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:hccccc01333/dsh-excel-chat",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-finance",
+   "owner": "zhang787jun",
+   "url": "https://github.com/zhang787jun/dsh-finance",
+   "page": "https://awesome-dsh-plugin.com/p/zhang787jun/dsh-finance/",
+   "category": "tools",
+   "description": {
+    "en": "Financial research workflow and portfolio risk tools with source discipline for current market facts.",
+    "zh": "金融研究工作流与组合风控工具，对当前市场事实强制来源与时间戳边界。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:zhang787jun/dsh-finance",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-us-stocks",
+   "owner": "Realyujie",
+   "url": "https://github.com/Realyujie/dsh-us-stocks",
+   "page": "https://awesome-dsh-plugin.com/p/Realyujie/dsh-us-stocks/",
+   "category": "tools",
+   "description": {
+    "en": "US stock quotes, price history, financial statements, analyst consensus and news via yahoo-finance2.",
+    "zh": "美股行情、历史 K 线、财务报表、分析师共识与新闻，数据来自 yahoo-finance2。"
+   },
+   "npm": "dsh-us-stocks",
+   "stars": 5,
+   "install": "dsh plugin --profile web add dsh-us-stocks",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-tavily",
+   "owner": "1624318455",
+   "url": "https://github.com/1624318455/dsh-plugin-tavily",
+   "page": "https://awesome-dsh-plugin.com/p/1624318455/dsh-plugin-tavily/",
+   "category": "tools",
+   "description": {
+    "en": "Tavily-backed web search provider for the built-in web_search tool, with a settings card for the API key, result count, and recency window.",
+    "zh": "基于 Tavily 的网页搜索提供方：替换内置 web_search 的后端，并提供 API Key、结果数量与时间窗口的设置卡片。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:1624318455/dsh-plugin-tavily",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-context-proxy",
    "owner": "EvilIrving",
    "url": "https://github.com/EvilIrving/dsh-context-proxy",
+   "page": "https://awesome-dsh-plugin.com/p/EvilIrving/dsh-context-proxy/",
    "category": "tools",
    "description": {
     "en": "Thin on-demand context retrieval: context_query / context_slice / context_grep tools that read already-persisted history back with replay-safe citations.",
@@ -1763,13 +3700,14 @@
    "name": "notes",
    "owner": "zhaoolee",
    "url": "https://github.com/zhaoolee/notes",
+   "page": "https://awesome-dsh-plugin.com/p/zhaoolee/notes/",
    "category": "tools",
    "description": {
     "en": "Export DSH conversations as Smartisan Notes-style PNGs, or create and update Markdown notes in a configured account-scoped workspace.",
     "zh": "将 DSH 对话导出为锤子便签风格 PNG，或在配置的账号工作区中新建和更新 Markdown 便签。"
    },
    "npm": null,
-   "stars": 138,
+   "stars": 141,
    "install": "dsh plugin --profile web add github:zhaoolee/notes",
    "added": "2026-08-14"
   },
@@ -1777,6 +3715,7 @@
    "name": "dsh-figma-to-lottie",
    "owner": "zimai233",
    "url": "https://github.com/zimai233/dsh-figma-to-lottie",
+   "page": "https://awesome-dsh-plugin.com/p/zimai233/dsh-figma-to-lottie/",
    "category": "tools",
    "description": {
     "en": "Compile SVG paths and keyframe specs into self-contained Lottie JSON animation files.",
@@ -1791,13 +3730,14 @@
    "name": "dsh-exam-countdown",
    "owner": "zimai233",
    "url": "https://github.com/zimai233/dsh-exam-countdown",
+   "page": "https://awesome-dsh-plugin.com/p/zimai233/dsh-exam-countdown/",
    "category": "tools",
    "description": {
     "en": "Query 64 Chinese exams (高考/考研/四六级/CPA/法考…) with rule-aware date math (2nd-Saturday, 1st-Sunday) and countdowns.",
     "zh": "查询 64 场中国考试（高考/考研/四六级/CPA/法考…）的规则日期（第二个周六、第一个周日）与倒计时。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:zimai233/dsh-exam-countdown",
    "added": "2026-08-14"
   },
@@ -1805,6 +3745,7 @@
    "name": "dsh-wash-calendar",
    "owner": "zimai233",
    "url": "https://github.com/zimai233/dsh-wash-calendar",
+   "page": "https://awesome-dsh-plugin.com/p/zimai233/dsh-wash-calendar/",
    "category": "tools",
    "description": {
     "en": "Recurring-habit scheduling from pure date math: next occurrence, range schedules, and overdue advice.",
@@ -1819,6 +3760,7 @@
    "name": "dsh-adhd-copilot",
    "owner": "zimai233",
    "url": "https://github.com/zimai233/dsh-adhd-copilot",
+   "page": "https://awesome-dsh-plugin.com/p/zimai233/dsh-adhd-copilot/",
    "category": "tools",
    "description": {
     "en": "ADHD behavioral coaching skill: task breakdown, overwhelm management, launch rituals, and failure recovery.",
@@ -1833,6 +3775,7 @@
    "name": "dsh-image-search",
    "owner": "zimai233",
    "url": "https://github.com/zimai233/dsh-image-search",
+   "page": "https://awesome-dsh-plugin.com/p/zimai233/dsh-image-search/",
    "category": "tools",
    "description": {
     "en": "Multi-engine reverse image search aggregator: Google Lens, Baidu, Yandex, TinEye, SauceNAO, IQDB, Ascii2d.",
@@ -1847,6 +3790,7 @@
    "name": "dsh-video-downloader",
    "owner": "zimai233",
    "url": "https://github.com/zimai233/dsh-video-downloader",
+   "page": "https://awesome-dsh-plugin.com/p/zimai233/dsh-video-downloader/",
    "category": "tools",
    "description": {
     "en": "Detect and download media from Bilibili/YouTube/Douyin/Xiaohongshu with quality and format analysis.",
@@ -1861,13 +3805,14 @@
    "name": "dsh-plugin-knowledge-graph",
    "owner": "Luke-Yong",
    "url": "https://github.com/Luke-Yong/dsh-plugin-knowledge-graph",
+   "page": "https://awesome-dsh-plugin.com/p/Luke-Yong/dsh-plugin-knowledge-graph/",
    "category": "tools",
    "description": {
     "en": "A read_graph tool backed by a codebase knowledge graph (CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL relations).",
     "zh": "基于代码库知识图谱的 read_graph 工具（CONTAINS / EXPORTS / IMPORTS / IMPORTS_SYMBOL 关系）。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:Luke-Yong/dsh-plugin-knowledge-graph",
    "added": "2026-08-14"
   },
@@ -1875,13 +3820,14 @@
    "name": "modsearch",
    "owner": "liustack",
    "url": "https://github.com/liustack/modsearch",
+   "page": "https://awesome-dsh-plugin.com/p/liustack/modsearch/",
    "category": "tools",
    "description": {
     "en": "Web search bridge for text-only agents: ask the web or X, get structured JSON evidence (search, fetch, citations).",
     "zh": "纯文本 agent 的联网搜索桥：搜索网页与 X，返回结构化 JSON 证据（search/fetch/引用）。"
    },
    "npm": "@liustack/modsearch",
-   "stars": 78,
+   "stars": 95,
    "install": "dsh plugin --profile web add @liustack/modsearch",
    "added": "2026-08-14"
   },
@@ -1889,13 +3835,14 @@
    "name": "argo",
    "owner": "taxueseek",
    "url": "https://github.com/taxueseek/argo",
+   "page": "https://awesome-dsh-plugin.com/p/taxueseek/argo/",
    "category": "tools",
    "description": {
     "en": "Search built for agents: multilingual coverage across web, academic, code, shopping, finance, news, and encyclopedias.",
     "zh": "专为 agent 打造的搜索工具：多语言，覆盖中文/英文/学术/代码/购物/金融/新闻/百科。"
    },
    "npm": "argo-search",
-   "stars": 65,
+   "stars": 70,
    "install": "dsh plugin --profile web add argo-search",
    "added": "2026-08-14"
   },
@@ -1903,13 +3850,14 @@
    "name": "dsh-web-search-exa",
    "owner": "TonyDua",
    "url": "https://github.com/TonyDua/dsh-web-search-exa",
+   "page": "https://awesome-dsh-plugin.com/p/TonyDua/dsh-web-search-exa/",
    "category": "tools",
    "description": {
     "en": "Zero-config Exa web search provider for the ctx.web seam: anonymous MCP fallback without an API key, plus keyed REST search.",
     "zh": "ctx.web 接缝的零配置 Exa 网页搜索提供方：无 API key 时走匿名 MCP 兜底，配 key 时走 REST 搜索。"
    },
    "npm": "@tonydua/dsh-web-search-exa",
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add @tonydua/dsh-web-search-exa",
    "added": "2026-08-14"
   },
@@ -1917,13 +3865,14 @@
    "name": "dsh-browser",
    "owner": "Lum1104",
    "url": "https://github.com/Lum1104/dsh-browser",
+   "page": "https://awesome-dsh-plugin.com/p/Lum1104/dsh-browser/",
    "category": "tools",
    "description": {
     "en": "Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required.",
     "zh": "Chrome 侧边栏扩展，让 DSH 直接操控你的浏览器，无需视觉能力。"
    },
    "npm": null,
-   "stars": 68,
+   "stars": 101,
    "install": "dsh plugin --profile web add github:Lum1104/dsh-browser",
    "added": "2026-08-14"
   },
@@ -1931,13 +3880,14 @@
    "name": "dsh-webui-market-plugin",
    "owner": "Sanqi-normal",
    "url": "https://github.com/Sanqi-normal/dsh-webui-market-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/Sanqi-normal/dsh-webui-market-plugin/",
    "category": "tools",
    "description": {
     "en": "In-harness plugin market for the dsh web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall plugins into a profile from Settings → Plugins → Plugin Market.",
     "zh": "dsh Web GUI 内的社区插件市场：浏览 awesome-dsh-plugin.com 目录，从 设置 → 插件 → 插件市场 安装/卸载插件到 profile。"
    },
    "npm": "@sanqi-normal/dsh-webui-market-plugin",
-   "stars": 0,
+   "stars": 28,
    "install": "dsh plugin --profile web add @sanqi-normal/dsh-webui-market-plugin",
    "added": "2026-08-14"
   },
@@ -1945,27 +3895,59 @@
    "name": "trio",
    "owner": "huey1in",
    "url": "https://github.com/huey1in/trio",
+   "page": "https://awesome-dsh-plugin.com/p/huey1in/trio/",
    "category": "tools",
    "description": {
     "en": "Browser automation (Playwright) with a live view, an MCP server exposing DSH agents to any MCP client, and GitHub issue/PR/webhook review tools.",
     "zh": "浏览器自动化（Playwright，带实时画面）+ MCP Server（把 DSH agent 暴露给任何 MCP 客户端）+ GitHub issue/PR/webhook 评审工具。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:huey1in/trio",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-github-release-radar",
+   "owner": "zoahdev",
+   "url": "https://github.com/zoahdev/dsh-github-release-radar",
+   "page": "https://awesome-dsh-plugin.com/p/zoahdev/dsh-github-release-radar/",
+   "category": "tools",
+   "description": {
+    "en": "Track releases and stars of any public GitHub repository from inside dsh agents — no API key needed.",
+    "zh": "让 dsh agent 直接查询任意 GitHub 公开仓库的 Release 与星标变化，无需 API Key。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:zoahdev/dsh-github-release-radar",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-github-intelligence",
+   "owner": "zoahdev",
+   "url": "https://github.com/zoahdev/dsh-github-intelligence",
+   "page": "https://awesome-dsh-plugin.com/p/zoahdev/dsh-github-intelligence/",
+   "category": "tools",
+   "description": {
+    "en": "The most complete GitHub integration for dsh: repo overview, releases, issues, pull requests, contributors, search, and a deep repo report with TTL caching — no API key needed.",
+    "zh": "目前最完整的 dsh GitHub 整合：仓库概览、Release、Issue、PR、贡献者、搜索与一键深度报告，内置 TTL 缓存，无需 API Key。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:zoahdev/dsh-github-intelligence",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-adb",
    "owner": "SamXiaBing",
    "url": "https://github.com/SamXiaBing/dsh-adb",
+   "page": "https://awesome-dsh-plugin.com/p/SamXiaBing/dsh-adb/",
    "category": "tools",
    "description": {
     "en": "ADB device & bench operations for DSH: device discovery, structured logcat (background streaming), apk install, file pull/push, and dumpsys performance snapshots.",
     "zh": "ADB 设备·台架运维工具集：设备发现、结构化 logcat（后台采集）、apk 安装、文件 pull/push、性能快照。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:SamXiaBing/dsh-adb",
    "added": "2026-08-14"
   },
@@ -1973,13 +3955,14 @@
    "name": "dsh-backup",
    "owner": "xiaoyuyu6420",
    "url": "https://github.com/xiaoyuyu6420/dsh-backup",
+   "page": "https://awesome-dsh-plugin.com/p/xiaoyuyu6420/dsh-backup/",
    "category": "tools",
    "description": {
-    "en": "One-command backup of DSH user data: /backup, scheduled auto-backup, sha256 checksums and rotation.",
-    "zh": "一键备份 DSH 用户数据：/backup 命令、定时自动备份、sha256 校验与自动轮换。"
+    "en": "One-command backup & restore of DSH user data: /backup, verify, restore, restart-surviving scheduled auto-backup, sha256 checksums and rotation (macOS/Linux/Windows).",
+    "zh": "一键备份与恢复 DSH 用户数据：/backup 备份、完整性校验、恢复，定时自动备份（重启续跑），sha256 校验与自动轮换（macOS/Linux/Windows）。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:xiaoyuyu6420/dsh-backup",
    "added": "2026-08-14"
   },
@@ -1987,13 +3970,14 @@
    "name": "dsh-tool-search",
    "owner": "Letter2025",
    "url": "https://github.com/Letter2025/dsh-tool-search",
+   "page": "https://awesome-dsh-plugin.com/p/Letter2025/dsh-tool-search/",
    "category": "tools",
    "description": {
     "en": "Hermes-style tool search & slimming: progressive disclosure, semantic search, describe, and call long-tail tools on demand while core tools stay eager.",
     "zh": "Hermes 风格工具搜索与瘦身：渐进式披露，语义搜索/查看/调用长尾工具，核心工具保持直通。"
    },
    "npm": "dsh-tool-search",
-   "stars": null,
+   "stars": 3,
    "install": "dsh plugin --profile web add dsh-tool-search",
    "added": "2026-08-14"
   },
@@ -2001,13 +3985,14 @@
    "name": "dsh-hdc-bridge",
    "owner": "1na-ko",
    "url": "https://github.com/1na-ko/dsh-hdc-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/1na-ko/dsh-hdc-bridge/",
    "category": "tools",
    "description": {
     "en": "HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane.",
     "zh": "鸿蒙设备桥：hdc 截图/装包/日志/崩溃/UI 自动化闭环（配 read_image 看图），官方优先版本化 API 知识层（SDK .d.ts + 离线随包文档），以及 DevEco CLI 构建/签名/lint 通道。"
    },
    "npm": "dsh-hdc-bridge",
-   "stars": 3,
+   "stars": 4,
    "install": "dsh plugin --profile web add dsh-hdc-bridge",
    "added": "2026-08-14"
   },
@@ -2015,20 +4000,472 @@
    "name": "dsh-plugin",
    "owner": "PicGo",
    "url": "https://github.com/PicGo/dsh-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/PicGo/dsh-plugin/",
    "category": "tools",
    "description": {
     "en": "Upload local images and files to your image host through PicGo's existing configuration (PicGo Cloud, GitHub, S3, COS, Qiniu, or any installed uploader plugin), via a `picgo_upload` tool and a `/picgo` command.",
     "zh": "通过 PicGo 已有配置（PicGo Cloud、GitHub、S3、腾讯云 COS、七牛，或任意已安装的上传插件）把本地图片和文件上传到图床，提供 `picgo_upload` 工具与 `/picgo` 命令。"
    },
    "npm": "@picgo/dsh-plugin",
-   "stars": 3,
+   "stars": 4,
    "install": "dsh plugin --profile web add @picgo/dsh-plugin",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-net-proxy",
+   "owner": "mafeis",
+   "url": "https://github.com/mafeis/dsh-net-proxy",
+   "page": "https://awesome-dsh-plugin.com/p/mafeis/dsh-net-proxy/",
+   "category": "tools",
+   "description": {
+    "en": "Route agent network requests through a local HTTP/CONNECT/SOCKS5 proxy.",
+    "zh": "让 agent 的网络请求走本机 HTTP/CONNECT/SOCKS5 代理。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:mafeis/dsh-net-proxy",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-session-audit",
+   "owner": "bwndlct",
+   "url": "https://github.com/bwndlct/dsh-session-audit",
+   "page": "https://awesome-dsh-plugin.com/p/bwndlct/dsh-session-audit/",
+   "category": "tools",
+   "description": {
+    "en": "Session execution analytics: steps, tool calls, failures, repeated actions, token usage and verification signals, rendered as text/Markdown/JSON reports.",
+    "zh": "会话执行分析：步骤、工具调用、失败、重复动作、token 用量与验证信号，输出 text/Markdown/JSON 报告。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:bwndlct/dsh-session-audit",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-overleaf",
+   "owner": "fly233338",
+   "url": "https://github.com/fly233338/dsh-overleaf",
+   "page": "https://awesome-dsh-plugin.com/p/fly233338/dsh-overleaf/",
+   "category": "tools",
+   "description": {
+    "en": "Connect multiple Overleaf projects to DSH through OverleafMCP for browsing, analysis, and Git-based file updates.",
+    "zh": "通过 OverleafMCP 将多个 Overleaf 项目接入 DSH，支持浏览、分析和通过 Git 写回 LaTeX 文件。"
+   },
+   "npm": "dsh-overleaf",
+   "stars": 7,
+   "install": "dsh plugin --profile web add dsh-overleaf",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-fleet-audit",
+   "owner": "LeslieWylie",
+   "url": "https://github.com/LeslieWylie/dsh-fleet-audit",
+   "page": "https://awesome-dsh-plugin.com/p/LeslieWylie/dsh-fleet-audit/",
+   "category": "tools",
+   "description": {
+    "en": "Read-only agent-fleet credential hygiene audit: credential-file permissions, embedded credentials in git remotes (masked in output), and provider token literal counts; zero-dependency and deterministic.",
+    "zh": "只读的 agent 机群凭据卫生审计：检查凭据文件权限、git remote 内嵌凭据（输出脱敏）与 provider token 字面量计数；零依赖、确定性。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:LeslieWylie/dsh-fleet-audit",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-suite#plugin-manager",
+   "owner": "whyihaveyou",
+   "url": "https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager",
+   "page": "https://awesome-dsh-plugin.com/p/whyihaveyou/dsh-suite--packages-plugins-plugin-manager/",
+   "category": "tools",
+   "description": {
+    "en": "In-app plugin store for the DSH Web UI: browse, search, one-click install, compat badges.",
+    "zh": "DSH Web UI 内置插件商店：浏览、搜索、一键安装、兼容性徽章。"
+   },
+   "npm": "@dsh-suite/plugin-manager",
+   "stars": 19,
+   "install": "dsh plugin --profile web add @dsh-suite/plugin-manager",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-workshop",
+   "owner": "loguhan",
+   "url": "https://github.com/loguhan/dsh-workshop",
+   "page": "https://awesome-dsh-plugin.com/p/loguhan/dsh-workshop/",
+   "category": "tools",
+   "description": {
+    "en": "Steam Workshop-style plugin store for the DSH Web UI: browse, search, and one-click install community plugins with mirror acceleration, progress UI, security checks, and Chinese descriptions.",
+    "zh": "DSH Web UI 的 Steam 创意工坊式插件商店：浏览、搜索并一键安装社区插件，支持镜像加速、进度 UI、安全检测与中文描述。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:loguhan/dsh-workshop",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-md-preview",
+   "owner": "LeslieWylie",
+   "url": "https://github.com/LeslieWylie/dsh-md-preview",
+   "page": "https://awesome-dsh-plugin.com/p/LeslieWylie/dsh-md-preview/",
+   "category": "tools",
+   "description": {
+    "en": "Render Markdown to a standalone, self-contained HTML page: an `md_html_render` tool that works in a headless profile, plus a web drawer to browse, preview, edit and export local `.md` files; both share one renderer, with no runtime dependencies.",
+    "zh": "把 Markdown 渲染为自包含的独立 HTML 页面：提供在 headless 配置下同样可用的 `md_html_render` 工具，以及在网页端浏览、预览、编辑并导出本地 `.md` 文件的抽屉；两个入口共用同一个渲染器，无运行时依赖。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:LeslieWylie/dsh-md-preview",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "deepseek-harness-forge-plugins#forge-gates",
+   "owner": "jinguanghai",
+   "url": "https://github.com/jinguanghai/deepseek-harness-forge-plugins/tree/main/plugins/forge-gates",
+   "page": "https://awesome-dsh-plugin.com/p/jinguanghai/deepseek-harness-forge-plugins--plugins-forge-gates/",
+   "category": "tools",
+   "description": {
+    "en": "Real-compute verification gates: math simplification, logic proofs, regex validation, E-prover FOL, state-machine checks, and code repair, backed by Go-compiled binaries with prebuilt Windows executables.",
+    "zh": "真实计算验证门：数学化简、逻辑证明、正则校验、E-prover 一阶逻辑、状态机检查与代码修复，由 Go 编译的二进制支撑（附 Windows 预编译产物）。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:jinguanghai/deepseek-harness-forge-plugins#path:/plugins/forge-gates",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "deepseek-harness-forge-plugins#forge-tcm",
+   "owner": "jinguanghai",
+   "url": "https://github.com/jinguanghai/deepseek-harness-forge-plugins/tree/main/plugins/forge-tcm",
+   "page": "https://awesome-dsh-plugin.com/p/jinguanghai/deepseek-harness-forge-plugins--plugins-forge-tcm/",
+   "category": "tools",
+   "description": {
+    "en": "Traditional Chinese Medicine toolkit: eight-axes diagnosis and herb-pair lookup.",
+    "zh": "中医工具集：八纲辨证与药对查询。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:jinguanghai/deepseek-harness-forge-plugins#path:/plugins/forge-tcm",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-device-info",
+   "owner": "lsz-asd",
+   "url": "https://github.com/lsz-asd/dsh-plugin-device-info",
+   "page": "https://awesome-dsh-plugin.com/p/lsz-asd/dsh-plugin-device-info/",
+   "category": "tools",
+   "description": {
+    "en": "Read-only Windows device information tools: one agent tool per Win32 device category (time, system, cpu, memory, disk, gpu, network, battery, processes, usb, audio, printers) via WMI/CIM and Node os collectors.",
+    "zh": "只读的 Windows 设备信息工具：每个 Win32 设备类别一个 agent 工具（时间、系统、CPU、内存、磁盘、GPU、网络、电池、进程、USB、音频、打印机），基于 WMI/CIM 与 Node os 采集。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:lsz-asd/dsh-plugin-device-info",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-codebase-memory",
+   "owner": "jiayan-xu",
+   "url": "https://github.com/jiayan-xu/dsh-codebase-memory",
+   "page": "https://awesome-dsh-plugin.com/p/jiayan-xu/dsh-codebase-memory/",
+   "category": "tools",
+   "description": {
+    "en": "Code knowledge graph bridge for codebase-memory-mcp: semantic symbol search (BM25), source snippets, architecture overview with Leiden communities, call/data-flow/cross-service traces, graph-augmented grep.",
+    "zh": "codebase-memory-mcp 的代码知识图谱桥：语义符号搜索（BM25）、源码片段、Leiden 社区架构总览、调用/数据流/跨服务追踪、图增强 grep。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:jiayan-xu/dsh-codebase-memory",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-nuphus-mcp",
+   "owner": "jiayan-xu",
+   "url": "https://github.com/jiayan-xu/dsh-nuphus-mcp",
+   "page": "https://awesome-dsh-plugin.com/p/jiayan-xu/dsh-nuphus-mcp/",
+   "category": "tools",
+   "description": {
+    "en": "Desktop and browser automation bridge (36 tools): window/screen/mouse/keyboard control with PaddleOCR element perception, Chrome CDP browsing with accessibility snapshots.",
+    "zh": "桌面 + 浏览器自动化桥（36 个工具）：窗口/屏幕/鼠标/键盘控制配 PaddleOCR 元素感知，Chrome CDP 浏览配无障碍快照。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:jiayan-xu/dsh-nuphus-mcp",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-s1",
+   "owner": "superagents-lab",
+   "url": "https://github.com/superagents-lab/dsh-s1",
+   "page": "https://awesome-dsh-plugin.com/p/superagents-lab/dsh-s1/",
+   "category": "tools",
+   "description": {
+    "en": "Native Search1API (s1) web research tools: search, news, page crawling, sitemap discovery, and trending topics as first-class `s1_*` tools, with a bundled s1 skill.",
+    "zh": "Search1API（s1）原生联网检索工具：网页搜索、新闻、页面抓取、站点地图与趋势榜，以 `s1_*` 一等工具形式提供，并附带 s1 技能。"
+   },
+   "npm": "dsh-s1",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-s1",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-git-workflow",
+   "owner": "truelove-dreamer",
+   "url": "https://github.com/truelove-dreamer/dsh-plugin-git-workflow",
+   "page": "https://awesome-dsh-plugin.com/p/truelove-dreamer/dsh-plugin-git-workflow/",
+   "category": "tools",
+   "description": {
+    "en": "First-class Git tools for the model: status / diff / log / commit / branch with validated messages and paths - no bare-shell git calls.",
+    "zh": "一等公民的 Git 工具：status / diff / log / commit / branch，参数与路径校验、零 shell 调用，杜绝注入。"
+   },
+   "npm": "dsh-plugin-git-workflow",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-plugin-git-workflow",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "knowlp-rag",
+   "owner": "wly8691-jpg",
+   "url": "https://github.com/wly8691-jpg/knowlp-rag",
+   "page": "https://awesome-dsh-plugin.com/p/wly8691-jpg/knowlp-rag/",
+   "category": "tools",
+   "description": {
+    "en": "Dual knowledge-graph RAG for Markdown notes: prerequisite + similarity graphs (P/S-Agent traversal), paragraph chunking, n-gram/embedding hybrid search, and an explicit weight feedback loop — via MCP.",
+    "zh": "Markdown 笔记的双知识图谱 RAG：前置依赖 + 相似关联双图（P/S-Agent 遍历）、段落级匹配、ngram/embedding 混合检索、显式权重反馈闭环，以 MCP 接入。"
+   },
+   "npm": "@eqman00003/knowlp-rag",
+   "stars": 2,
+   "install": "dsh plugin --profile web add @eqman00003/knowlp-rag",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-mcpguard",
+   "owner": "ChenLaoshiYF",
+   "url": "https://github.com/ChenLaoshiYF/dsh-mcpguard",
+   "page": "https://awesome-dsh-plugin.com/p/ChenLaoshiYF/dsh-mcpguard/",
+   "category": "tools",
+   "description": {
+    "en": "Scans skills and MCP configs for prompt injection, homoglyphs, hidden Unicode, dangerous shell, and credential leaks.",
+    "zh": "扫描 skill 与 MCP 配置中的提示注入、同形字、Unicode 隐形字符、危险 shell 与凭据泄露。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:ChenLaoshiYF/dsh-mcpguard",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-wsl-workspace",
+   "owner": "6Mikao9",
+   "url": "https://github.com/6Mikao9/dsh-wsl-workspace",
+   "page": "https://awesome-dsh-plugin.com/p/6Mikao9/dsh-wsl-workspace/",
+   "category": "tools",
+   "description": {
+    "en": "Add a WSL workspace from the web GUI without needing to install dsh or related tools again inside WSL. Bash commands and file read/write operations run within the local WSL distribution on the host machine, while Windows files remain accessible.",
+    "zh": "从 Web GUI 添加 WSL 工作区，无需在 WSL 之中再次安装 dsh 以及相关工具，bash 命令与文件读写运行在本机 WSL 发行版内，Windows 文件仍可访问。"
+   },
+   "npm": "dsh-wsl-workspace",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-wsl-workspace",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-trajectory-governance",
+   "owner": "dfycaly98931680",
+   "url": "https://github.com/dfycaly98931680/dsh-trajectory-governance",
+   "page": "https://awesome-dsh-plugin.com/p/dfycaly98931680/dsh-trajectory-governance/",
+   "category": "tools",
+   "description": {
+    "en": "Agent trajectory governance and anomaly diagnosis: rebuilds flat session logs into multi-branch trajectory trees, detects loop deadlock, invalid retry, and goal drift, alerts with cost attribution, one-click interrupt and breakpoint fork via official APIs, independent GUI tab.",
+    "zh": "Agent 轨迹治理与异常诊断：把平铺会话日志重建为多分支轨迹树，识别循环死锁/无效重试/目标漂移，带成本归因的告警与一键中断/断点分支（官方 API），独立 GUI Tab。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:dfycaly98931680/dsh-trajectory-governance",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-ask-guard",
+   "owner": "Q1hangL",
+   "url": "https://github.com/Q1hangL/dsh-ask-guard",
+   "page": "https://awesome-dsh-plugin.com/p/Q1hangL/dsh-ask-guard/",
+   "category": "tools",
+   "description": {
+    "en": "Cooperative timeout guard for ask_user_question: lost or unanswered questions resolve as a structured ASK_TIMEOUT instead of hanging the turn forever.",
+    "zh": "为 ask_user_question 提供协作式超时守卫：提问卡片丢失或用户未答复时以结构化 ASK_TIMEOUT 结束调用，避免回合无限挂起。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:Q1hangL/dsh-ask-guard",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-plugin-call-trace",
+   "owner": "Huang-zhishi",
+   "url": "https://github.com/Huang-zhishi/dsh-plugin-call-trace",
+   "page": "https://awesome-dsh-plugin.com/p/Huang-zhishi/dsh-plugin-call-trace/",
+   "category": "tools",
+   "description": {
+    "en": "Persistent model tool-call trace recorder: every tool call is durably written to a JSONL file that survives restarts, queryable via a structured call_trace tool and a callTraceHistory service, with size rotation and an optional floating canvas UI add-on.",
+    "zh": "持久化模型工具调用轨迹记录器：每次工具调用落盘为 JSONL（重启不丢），提供结构化 call_trace 查询工具与 callTraceHistory 服务，支持文件大小轮转，附可选浮层画布 UI。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:Huang-zhishi/dsh-plugin-call-trace",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-translate-pro",
+   "owner": "ShiXiangYu2",
+   "url": "https://github.com/ShiXiangYu2/dsh-translate-pro",
+   "page": "https://awesome-dsh-plugin.com/p/ShiXiangYu2/dsh-translate-pro/",
+   "category": "tools",
+   "description": {
+    "en": "Professional translation for DSH: 18 target languages, 4 styles (formal/casual/technical/literal), glossary-controlled terminology, and whole-file translation (README/docs/subtitles) with Markdown/code-block format preservation; powered by DeepSeek via SiliconFlow.",
+    "zh": "专业翻译：18 种目标语言、4 种风格（正式/口语/技术/直译）、术语表控制译名、整文件翻译（README/文档/字幕）并保留 Markdown 与代码块格式；经 SiliconFlow 调用 DeepSeek。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:ShiXiangYu2/dsh-translate-pro",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-web-search-pro",
+   "owner": "anweat",
+   "url": "https://github.com/anweat/dsh-web-search-pro",
+   "page": "https://awesome-dsh-plugin.com/p/anweat/dsh-web-search-pro/",
+   "category": "tools",
+   "description": {
+    "en": "Persistent enhanced web search: multi-engine routing (DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/Xiaohongshu/Twitter/Reddit/RSS), SQLite+LRU cache, userscript-style extraction, Playwright rendering.",
+    "zh": "增强型、可持久化的网页搜索：多引擎路由（DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/Twitter/Reddit/RSS）、SQLite+LRU 缓存、userscript 风格抽取、Playwright 渲染。"
+   },
+   "npm": "dsh-web-search-pro",
+   "stars": 4,
+   "install": "dsh plugin --profile web add dsh-web-search-pro",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-browser",
+   "owner": "anweat",
+   "url": "https://github.com/anweat/dsh-browser",
+   "page": "https://awesome-dsh-plugin.com/p/anweat/dsh-browser/",
+   "category": "tools",
+   "description": {
+    "en": "Self-contained browser runtime: Playwright (chromium) + OpenCLI as plugin-local dependencies (global reuse fallback), exposes a `browser` service and 9 interactive browser tools.",
+    "zh": "自包含浏览器运行时：Playwright（chromium）+ OpenCLI 作为插件本地依赖（全局复用回退），提供 `browser` 服务与 9 个交互式浏览器工具。"
+   },
+   "npm": "@anweat/dsh-browser",
+   "stars": 2,
+   "install": "dsh plugin --profile web add @anweat/dsh-browser",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-voice-webspeech",
+   "owner": "anweat",
+   "url": "https://github.com/anweat/dsh-voice-webspeech",
+   "page": "https://awesome-dsh-plugin.com/p/anweat/dsh-voice-webspeech/",
+   "category": "tools",
+   "description": {
+    "en": "Browser Web Speech API voice input: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).",
+    "zh": "浏览器 Web Speech API 语音输入：零服务端、零密钥、零模型下载（Edge=Azure 语音、Chrome=Google 语音）。"
+   },
+   "npm": "dsh-voice-webspeech",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-voice-webspeech",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-Kimi-WebBridge",
+   "owner": "MicroHEROX",
+   "url": "https://github.com/MicroHEROX/dsh-Kimi-WebBridge",
+   "page": "https://awesome-dsh-plugin.com/p/MicroHEROX/dsh-Kimi-WebBridge/",
+   "category": "tools",
+   "description": {
+    "en": "Drive the user's real browser through the local Kimi WebBridge daemon: navigate, find-tab, snapshot, click, fill, evaluate, CDP, screenshot, network, upload, PDF export and tab-management tools that reuse existing login sessions.",
+    "zh": "通过本地 Kimi WebBridge 守护进程驱动用户的真实浏览器：navigate、find-tab、snapshot、click、fill、evaluate、CDP、screenshot、network、upload、PDF 导出与标签管理工具，复用浏览器已登录会话。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:MicroHEROX/dsh-Kimi-WebBridge",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-exa-mcp",
+   "owner": "MicroHEROX",
+   "url": "https://github.com/MicroHEROX/dsh-exa-mcp",
+   "page": "https://awesome-dsh-plugin.com/p/MicroHEROX/dsh-exa-mcp/",
+   "category": "tools",
+   "description": {
+    "en": "Mounts the hosted Exa search MCP endpoint (https://mcp.exa.ai/mcp) through the in-box @deepseek-ai/dsh-mcp-client bridge: web_search_exa and web_fetch_exa tools, anonymous on the free tier or with your own EXA_API_KEY.",
+    "zh": "通过内置的 @deepseek-ai/dsh-mcp-client 桥接接入托管的 Exa 搜索 MCP 端点（mcp.exa.ai）：web_search_exa 与 web_fetch_exa 工具，免费额度匿名可用，设置 EXA_API_KEY 可解锁更高限额。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:MicroHEROX/dsh-exa-mcp",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-koboldcpp-hands",
+   "owner": "MicroHEROX",
+   "url": "https://github.com/MicroHEROX/dsh-koboldcpp-hands",
+   "page": "https://awesome-dsh-plugin.com/p/MicroHEROX/dsh-koboldcpp-hands/",
+   "category": "tools",
+   "description": {
+    "en": "Hands repetitive text and vision labor (OCR, image analysis, comparison) to a local KoboldCpp (llama.cpp) server through koboldcpp_run and koboldcpp_vision tools, with on-demand server lifecycle management.",
+    "zh": "给在线模型装上本地双手：koboldcpp_run 与 koboldcpp_vision 工具把重复的文本与视觉（OCR、图像分析、对比）劳动交给本地 KoboldCpp（llama.cpp）服务器，并按需拉起与管理服务器生命周期。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:MicroHEROX/dsh-koboldcpp-hands",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-unsloth-hands",
+   "owner": "MicroHEROX",
+   "url": "https://github.com/MicroHEROX/dsh-unsloth-hands",
+   "page": "https://awesome-dsh-plugin.com/p/MicroHEROX/dsh-unsloth-hands/",
+   "category": "tools",
+   "description": {
+    "en": "Hands repetitive text and vision labor (OCR, image analysis, comparison) to a locally running Unsloth Desktop (Unsloth Studio) server through unsloth_run and unsloth_vision tools; pure HTTP client, never spawns or owns processes.",
+    "zh": "把重复的文本与视觉（OCR、图像分析、对比）劳动交给本地运行的 Unsloth Desktop（Unsloth Studio）服务器：unsloth_run 与 unsloth_vision 两个工具，纯 HTTP 客户端，不拉起也不持有任何进程。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:MicroHEROX/dsh-unsloth-hands",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-reverse-skill",
+   "owner": "dhicoc",
+   "url": "https://github.com/dhicoc/dsh-reverse-skill",
+   "page": "https://awesome-dsh-plugin.com/p/dhicoc/dsh-reverse-skill/",
+   "category": "skill",
+   "description": {
+    "en": "Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.",
+    "zh": "完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究的技能路由包。"
+   },
+   "npm": null,
+   "stars": 8,
+   "install": "dsh plugin --profile web add github:dhicoc/dsh-reverse-skill",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-wuyun-liuqi",
+   "owner": "dhicoc",
+   "url": "https://github.com/dhicoc/dsh-wuyun-liuqi",
+   "page": "https://awesome-dsh-plugin.com/p/dhicoc/dsh-wuyun-liuqi/",
+   "category": "skill",
+   "description": {
+    "en": "Complete wuyun-liuqi (five-evolutions-six-qi / 五运六气) Traditional Chinese Medicine skill pack as a DeepSeek Harness Cordis plugin: annual and guest-qi calculation, clinical pattern differentiation, and pathogenesis reasoning.",
+    "zh": "完整 wuyun-liuqi（五运六气）中医运气学技能包，封装为 DeepSeek Harness 插件：年度与客气推算、临床辨证、病机推演。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:dhicoc/dsh-wuyun-liuqi",
+   "added": "2026-08-15"
   },
   {
    "name": "skills",
    "owner": "creght-dev",
    "url": "https://github.com/creght-dev/skills",
+   "page": "https://awesome-dsh-plugin.com/p/creght-dev/skills/",
    "category": "skill",
    "description": {
     "en": "Skills for building websites on the Creght platform: CLI pull/push sync, page and component conventions, CMS, forms, auth, SEO, publishing and version rollback.",
@@ -2040,44 +4477,182 @@
    "added": "2026-08-14"
   },
   {
+   "name": "dsh-design-skills",
+   "owner": "zhaiyateng",
+   "url": "https://github.com/zhaiyateng/dsh-design-skills",
+   "page": "https://awesome-dsh-plugin.com/p/zhaiyateng/dsh-design-skills/",
+   "category": "skill",
+   "description": {
+    "en": "Design-aesthetics skill pack (10 styles: dark SaaS, minimal white, neumorphism, brutalism, glassmorphism, Japanese minimal, bento grid, cyberpunk, vaporwave, art deco) with runnable landing-page demos: tokens, component rules, forbidden lists, and acceptance checklists per style.",
+    "zh": "设计美学技能包：10 种风格（深色 SaaS、极简白、新拟态、粗野主义、毛玻璃、日式极简、便当盒、赛博朋克、蒸汽波、装饰艺术），每种含 token、组件规则、禁用清单与验收清单，附可运行落地页 demo。"
+   },
+   "npm": null,
+   "stars": 6,
+   "install": "dsh plugin --profile web add github:zhaiyateng/dsh-design-skills",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-skill-manager-ytxue",
+   "owner": "YTxue",
+   "url": "https://github.com/YTxue/dsh-skill-manager-ytxue",
+   "page": "https://awesome-dsh-plugin.com/p/YTxue/dsh-skill-manager-ytxue/",
+   "category": "skill",
+   "description": {
+    "en": "Skill pool manager in the Settings sidebar: enable/disable, folder batch import with rename-conflict prompts, state-driven one-click DSH-spec check & auto-fix, system/project scope labels.",
+    "zh": "设置侧边栏的 Skill 管理器：池与启用目录启停、文件夹批量导入（重名询问）、状态驱动一键规范检查与自动修复、系统级/项目级来源标识。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:YTxue/dsh-skill-manager-ytxue",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "shopline-ai-toolkit-dsh",
+   "owner": "lunw",
+   "url": "https://github.com/lunw/shopline-ai-toolkit-dsh",
+   "page": "https://awesome-dsh-plugin.com/p/lunw/shopline-ai-toolkit-dsh/",
+   "category": "skill",
+   "description": {
+    "en": "SHOPLINE AI Toolkit: bridges the official SHOPLINE Developer MCP server and ships seven SHOPLINE agent skills (Admin REST, GraphQL, OAuth, webhooks, Sline) — the SHOPLINE counterpart of the Shopify AI Toolkit.",
+    "zh": "SHOPLINE AI 工具包：接入 SHOPLINE 官方开发者 MCP 服务器，内置七个 SHOPLINE 平台技能（Admin REST、GraphQL、OAuth、Webhook、Sline），是 Shopify AI Toolkit 的 SHOPLINE 对应版。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:lunw/shopline-ai-toolkit-dsh",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-skill-pack",
+   "owner": "jeremy9682",
+   "url": "https://github.com/jeremy9682/dsh-skill-pack",
+   "page": "https://awesome-dsh-plugin.com/p/jeremy9682/dsh-skill-pack/",
+   "category": "skill",
+   "description": {
+    "en": "11 shareable workflow skills (handoff, triage, to-spec, to-tickets, wayfinder, teach, wait-what, dsh-mode-routing, ask-matt, overnight-execution, full-throttle) as an installable skill pack.",
+    "zh": "11 个可分享的工作流 skills（handoff、triage、to-spec、to-tickets、wayfinder、teach、wait-what、dsh-mode-routing、ask-matt、overnight-execution、full-throttle），打包为可安装 bundle。"
+   },
+   "npm": "@jeremy9682/dsh-skill-pack",
+   "stars": 0,
+   "install": "dsh plugin --profile web add @jeremy9682/dsh-skill-pack",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "hermes-dsh-collab",
+   "owner": "Cavan-Ou",
+   "url": "https://github.com/Cavan-Ou/hermes-dsh-collab",
+   "page": "https://awesome-dsh-plugin.com/p/Cavan-Ou/hermes-dsh-collab/",
+   "category": "skill",
+   "description": {
+    "en": "Hook DeepSeek Harness into a Hermes pipeline: dispatch-spec template, model-tier routing, orchestrator-run quality gates, git single-writer rule, as a SKILL.md pack (bundle installable).",
+    "zh": "把 DeepSeek Harness 接进 Hermes 管线：派单 spec 模板、模型档位路由、质量门、git 唯一写者约定，SKILL.md 技能包（bundle 可安装）。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:Cavan-Ou/hermes-dsh-collab",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-rigorquant",
+   "owner": "linxichen",
+   "url": "https://github.com/linxichen/dsh-rigorquant",
+   "page": "https://awesome-dsh-plugin.com/p/linxichen/dsh-rigorquant/",
+   "category": "skill",
+   "description": {
+    "en": "RigorQuant preset + skill pack: unattended walled multi-agent research for empirical and computational mathematics (economics, finance, portfolio), with a four-part pre-implementation check battery and a jacobian/Lean escalation lane.",
+    "zh": "RigorQuant 预设与技能包：面向实证与计算数学（经济学、金融、组合）的无人值守隔离多智能体研究，内置四重实现前校验与 jacobian/Lean 升级通道。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:linxichen/dsh-rigorquant",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-task-planner",
+   "owner": "ztl34245881-commits",
+   "url": "https://github.com/ztl34245881-commits/dsh-task-planner",
+   "page": "https://awesome-dsh-plugin.com/p/ztl34245881-commits/dsh-task-planner/",
+   "category": "workflow",
+   "description": {
+    "en": "Task planning with experience muscle-memory: condition-reflex recall of past solutions, LLM capability matching, and auto-persisted lessons.",
+    "zh": "带经验肌肉记忆的任务规划：条件反射检索历史方案 + LLM 能力匹配 + 经验自动沉淀。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:ztl34245881-commits/dsh-task-planner",
+   "added": "2026-08-14"
+  },
+  {
    "name": "dsh_workflow",
    "owner": "icetomoyo",
    "url": "https://github.com/icetomoyo/dsh_workflow",
+   "page": "https://awesome-dsh-plugin.com/p/icetomoyo/dsh_workflow/",
    "category": "workflow",
    "description": {
     "en": "UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.",
     "zh": "把 UltraCode 式多 Agent 调度带给 DSH：可生成、可保存、可治理、可观察、可恢复的 Workflow 层。"
    },
    "npm": null,
-   "stars": 52,
+   "stars": 54,
    "install": "dsh plugin --profile web add github:icetomoyo/dsh_workflow",
    "added": "2026-08-13"
+  },
+  {
+   "name": "dsh-captain",
+   "owner": "KanoNoUta",
+   "url": "https://github.com/KanoNoUta/dsh-captain",
+   "page": "https://awesome-dsh-plugin.com/p/KanoNoUta/dsh-captain/",
+   "category": "workflow",
+   "description": {
+    "en": "GPT plans dependency DAGs, DeepSeek workers execute tasks with adaptive parallelism, and an optional GPT reviewer audits incremental Git diffs and drives repair rounds.",
+    "zh": "GPT 规划依赖 DAG，DeepSeek Worker 自适应并行执行任务，可选 GPT Reviewer 审核增量 Git Diff 并驱动返工轮次。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:KanoNoUta/dsh-captain",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-agent-teams",
    "owner": "NanmiCoder",
    "url": "https://github.com/NanmiCoder/dsh-agent-teams",
+   "page": "https://awesome-dsh-plugin.com/p/NanmiCoder/dsh-agent-teams/",
    "category": "workflow",
    "description": {
     "en": "AgentTeams multi-agent teams.",
     "zh": "AgentTeams 多智能体团队。"
    },
-   "npm": null,
-   "stars": 198,
-   "install": "dsh plugin --profile web add github:NanmiCoder/dsh-agent-teams",
+   "npm": "@nanmicoder/dsh-agent-teams",
+   "stars": 263,
+   "install": "dsh plugin --profile web add @nanmicoder/dsh-agent-teams",
    "added": "2026-08-13"
+  },
+  {
+   "name": "agent_team_gui",
+   "owner": "toolclub",
+   "url": "https://github.com/toolclub/agent_team_gui",
+   "page": "https://awesome-dsh-plugin.com/p/toolclub/agent_team_gui/",
+   "category": "workflow",
+   "description": {
+    "en": "Reusable agent squads with per-agent provider/model routes and tool policies, serial/parallel dispatch, spawn/fork/chain context modes, and a Web management panel.",
+    "zh": "可复用 Agent 小队：每个成员独立配置 provider/model 路由与工具策略，支持串行/并行派单、spawn/fork/chain 上下文模式和 Web 管理面板。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:toolclub/agent_team_gui",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-automation",
    "owner": "titanwings",
    "url": "https://github.com/titanwings/dsh-automation",
+   "page": "https://awesome-dsh-plugin.com/p/titanwings/dsh-automation/",
    "category": "workflow",
    "description": {
     "en": "Scheduled coding runs in fresh agent sessions with auditable history.",
     "zh": "定时任务：让 Coding 任务按计划在全新 Agent Session 中运行，保留可审计历史。"
    },
    "npm": null,
-   "stars": 23,
+   "stars": 32,
    "install": "dsh plugin --profile web add github:titanwings/dsh-automation",
    "added": "2026-08-13"
   },
@@ -2085,6 +4660,7 @@
    "name": "dsh-plugin-automations",
    "owner": "Sev7een",
    "url": "https://github.com/Sev7een/dsh-plugin-automations",
+   "page": "https://awesome-dsh-plugin.com/p/Sev7een/dsh-plugin-automations/",
    "category": "workflow",
    "description": {
     "en": "Settings-based scheduled tasks that run on time or during DeepSeek off-peak hours, with one-time and daily schedules backed by durable task state.",
@@ -2099,6 +4675,7 @@
    "name": "dsh-routines",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-routines",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-routines/",
    "category": "workflow",
    "description": {
     "en": "Scheduled agents on a cron: run a prompt on a schedule and get the digest where you already are, with overlap/missed-run/timeout safety defaults.",
@@ -2113,13 +4690,14 @@
    "name": "dsh-plannotator",
    "owner": "titanwings",
    "url": "https://github.com/titanwings/dsh-plannotator",
+   "page": "https://awesome-dsh-plugin.com/p/titanwings/dsh-plannotator/",
    "category": "workflow",
    "description": {
     "en": "Plan review with anchored annotations and structured feedback back to the agent.",
     "zh": "计划批注：选中计划原文逐条批注，结构化反馈送回 Agent。"
    },
    "npm": null,
-   "stars": 3,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:titanwings/dsh-plannotator",
    "added": "2026-08-13"
   },
@@ -2127,6 +4705,7 @@
    "name": "dsh-loop",
    "owner": "vlln",
    "url": "https://github.com/vlln/dsh-loop",
+   "page": "https://awesome-dsh-plugin.com/p/vlln/dsh-loop/",
    "category": "workflow",
    "description": {
     "en": "Recurring loops: `/loop` command + loop tool + activity status bar.",
@@ -2141,13 +4720,14 @@
    "name": "dsh-sentinel",
    "owner": "fuhefei",
    "url": "https://github.com/fuhefei/dsh-sentinel",
+   "page": "https://awesome-dsh-plugin.com/p/fuhefei/dsh-sentinel/",
    "category": "workflow",
    "description": {
     "en": "Condition-driven wakeup: durable file/command/http/process/webhook watches that wake the agent.",
     "zh": "条件驱动唤醒：file/command/http/process/webhook 持久监视，触发即唤醒 agent。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:fuhefei/dsh-sentinel",
    "added": "2026-08-13"
   },
@@ -2155,13 +4735,14 @@
    "name": "dsh-deep-research",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-deep-research",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-deep-research/",
    "category": "workflow",
    "description": {
     "en": "Adaptive deep-research orchestrator built on the official workflow engine.",
     "zh": "自适应深度研究编排器（基于官方 workflow 引擎）。"
    },
    "npm": null,
-   "stars": 7,
+   "stars": 10,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-deep-research",
    "added": "2026-08-13"
   },
@@ -2169,13 +4750,14 @@
    "name": "dsh-inspect",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-inspect",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-inspect/",
    "category": "workflow",
    "description": {
     "en": "Adversarial checkup → fix → review loop toolset.",
     "zh": "发现问题→修复交付→质量复查的对抗式闭环工具集。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-inspect",
    "added": "2026-08-13"
   },
@@ -2183,13 +4765,14 @@
    "name": "dsh-track",
    "owner": "fakechris",
    "url": "https://github.com/fakechris/dsh-track",
+   "page": "https://awesome-dsh-plugin.com/p/fakechris/dsh-track/",
    "category": "workflow",
    "description": {
     "en": "Embedded task management engine: decision-point protocol, idea capture wall, Linear-style issue store.",
     "zh": "嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。"
    },
    "npm": null,
-   "stars": 3,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:fakechris/dsh-track",
    "added": "2026-08-13"
   },
@@ -2197,13 +4780,14 @@
    "name": "dsh-advisor",
    "owner": "btspoony",
    "url": "https://github.com/btspoony/dsh-advisor",
+   "page": "https://awesome-dsh-plugin.com/p/btspoony/dsh-advisor/",
    "category": "workflow",
    "description": {
     "en": "Pair a second model that passively reviews each turn and injects notes.",
     "zh": "搭配一个副模型，每轮被动审查并注入见解。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 7,
    "install": "dsh plugin --profile web add github:btspoony/dsh-advisor",
    "added": "2026-08-13"
   },
@@ -2211,13 +4795,14 @@
    "name": "dsh-specflow",
    "owner": "lonelymoon87",
    "url": "https://github.com/lonelymoon87/dsh-specflow",
+   "page": "https://awesome-dsh-plugin.com/p/lonelymoon87/dsh-specflow/",
    "category": "workflow",
    "description": {
     "en": "Adds specification artifacts, skills, commands, goal-backed implementation, and task-progress context.",
     "zh": "增加规格工件、技能、命令、由 goal 驱动的实施流程和任务进度上下文。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:lonelymoon87/dsh-specflow",
    "added": "2026-08-14"
   },
@@ -2225,13 +4810,14 @@
    "name": "dsh-science",
    "owner": "biociao",
    "url": "https://github.com/biociao/dsh-science",
+   "page": "https://awesome-dsh-plugin.com/p/biociao/dsh-science/",
    "category": "workflow",
    "description": {
     "en": "Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.",
     "zh": "面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 10,
    "install": "dsh plugin --profile web add github:biociao/dsh-science",
    "added": "2026-08-14"
   },
@@ -2239,6 +4825,7 @@
    "name": "dsh-proof",
    "owner": "EvilIrving",
    "url": "https://github.com/EvilIrving/dsh-proof",
+   "page": "https://awesome-dsh-plugin.com/p/EvilIrving/dsh-proof/",
    "category": "workflow",
    "description": {
     "en": "Independent read-only acceptance layer: spawns a read-only verifier before each top-level turn closes and steers non-pass gaps back into the agent.",
@@ -2253,69 +4840,269 @@
    "name": "dsh-doublecheck",
    "owner": "PerryLink",
    "url": "https://github.com/PerryLink/dsh-doublecheck",
+   "page": "https://awesome-dsh-plugin.com/p/PerryLink/dsh-doublecheck/",
    "category": "workflow",
    "description": {
     "en": "Engineering-discipline guard: grill the requirements before the first edit, enforce red/green test evidence gates, and audit the delivery with a forked adversary (grill-requirements skill + tool-policy gates).",
     "zh": "工程纪律守门：动笔前审讯需求，红绿测试证据门，交付后对抗评审（grill-requirements 技能 + 工具策略门）。"
    },
-   "npm": null,
-   "stars": 1,
-   "install": "dsh plugin --profile web add github:PerryLink/dsh-doublecheck",
+   "npm": "dsh-doublecheck",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-doublecheck",
    "added": "2026-08-14"
   },
   {
    "name": "mstar-harness",
    "owner": "btspoony",
    "url": "https://github.com/btspoony/mstar-harness",
+   "page": "https://awesome-dsh-plugin.com/p/btspoony/mstar-harness/",
    "category": "workflow",
    "description": {
     "en": "Skill-driven harness/loop engineering workflow agent plugin.",
     "zh": "技能驱动的 harness/loop 工程化工作流插件。"
    },
    "npm": null,
-   "stars": 41,
+   "stars": 43,
    "install": "dsh plugin --profile web add github:btspoony/mstar-harness",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-ops-kit",
+   "owner": "LeslieWylie",
+   "url": "https://github.com/LeslieWylie/dsh-ops-kit",
+   "page": "https://awesome-dsh-plugin.com/p/LeslieWylie/dsh-ops-kit/",
+   "category": "workflow",
+   "description": {
+    "en": "Evidence-first operating kit: six read-only tools (capability catalog, staged workflow plans, packaged skill reader, bounded local memory search, repository release audit, release checklist) and five packaged skills - plans and audits, never remote writes.",
+    "zh": "证据优先的操作套件：六个只读工具（能力清单、分阶段编排计划、随包技能阅读、有上限的本地记忆检索、仓库发布审计、发布清单）加五个随包技能；只规划与审计，不做远程写入。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:LeslieWylie/dsh-ops-kit",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-approval-llm",
    "owner": "Letter2025",
    "url": "https://github.com/Letter2025/dsh-approval-llm",
+   "page": "https://awesome-dsh-plugin.com/p/Letter2025/dsh-approval-llm/",
    "category": "workflow",
    "description": {
     "en": "Model-based permission approval: an approval-request answerer backed by a separate reviewer model.",
     "zh": "基于模型的权限审批：由独立审查模型自动应答 approval 权限请求。"
    },
    "npm": "dsh-approval-llm",
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add dsh-approval-llm",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-auto",
+   "owner": "simon300000",
+   "url": "https://github.com/simon300000/dsh-auto",
+   "page": "https://awesome-dsh-plugin.com/p/simon300000/dsh-auto/",
+   "category": "workflow",
+   "description": {
+    "en": "Adds an Auto Approve permission preset to the Web UI, using a fresh restricted Reviewer Agent to allow or deny each approval request.",
+    "zh": "为 WebUI 增加 Auto Approve 权限档位，由全新且受限的审查 Agent 逐次允许或拒绝审批请求。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:simon300000/dsh-auto",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-model-failover",
    "owner": "Letter2025",
    "url": "https://github.com/Letter2025/dsh-model-failover",
+   "page": "https://awesome-dsh-plugin.com/p/Letter2025/dsh-model-failover/",
    "category": "workflow",
    "description": {
     "en": "Two-level model circuit breaker with failover: trip a model or a whole provider after repeated request failures and route the next request to a configured fallback.",
     "zh": "两级模型熔断与回退：模型或平台连续失败后自动熔断，并把下一个请求路由到配置好的备用模型。"
    },
    "npm": "dsh-model-failover",
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add dsh-model-failover",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-suite#plugin-team-board",
+   "owner": "whyihaveyou",
+   "url": "https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board",
+   "page": "https://awesome-dsh-plugin.com/p/whyihaveyou/dsh-suite--packages-plugins-plugin-team-board/",
+   "category": "workflow",
+   "description": {
+    "en": "Shared multi-agent task board (create/claim/transition/query) over a Cordis service key.",
+    "zh": "多 agent 共享任务板：经 Cordis service key 创建/认领/流转/查询任务。"
+   },
+   "npm": "@dsh-suite/plugin-team-board",
+   "stars": 19,
+   "install": "dsh plugin --profile web add @dsh-suite/plugin-team-board",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "DSH-EvoResearch#evoresearch-plugin",
+   "owner": "Karbo123",
+   "url": "https://github.com/Karbo123/DSH-EvoResearch/tree/main/packages/evoresearch-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/Karbo123/DSH-EvoResearch--packages-evoresearch-plugin/",
+   "category": "workflow",
+   "description": {
+    "en": "Research agent suite: long-horizon goal control with auditable evidence chains, cron scheduling, multi-agent expert teams, self-evolving research memory (FTS5 + RRF recall), project workspaces, and a custom workspace UI.",
+    "zh": "科研 agent 套件：长程目标控制（可审计证据链）、定时任务、多智能体专家团队、自进化科研记忆（FTS5 + RRF 召回）、科研项目工作区与自定义工作台界面。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:Karbo123/DSH-EvoResearch#path:/packages/evoresearch-plugin",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-taskswarm",
+   "owner": "february2015",
+   "url": "https://github.com/february2015/dsh-taskswarm",
+   "page": "https://awesome-dsh-plugin.com/p/february2015/dsh-taskswarm/",
+   "category": "workflow",
+   "description": {
+    "en": "DSH port of TaskPlane: dependency-ordered waves run in parallel git-worktree lanes, with task packets, cross-model review, and crash recovery.",
+    "zh": "TaskPlane 的 DSH 移植版：按依赖分波、多 lane 并行执行（git worktree 隔离），任务包 + 跨模型评审 + 崩溃可恢复。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:february2015/dsh-taskswarm",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-plugin-hooks",
+   "owner": "truelove-dreamer",
+   "url": "https://github.com/truelove-dreamer/dsh-plugin-hooks",
+   "page": "https://awesome-dsh-plugin.com/p/truelove-dreamer/dsh-plugin-hooks/",
+   "category": "workflow",
+   "description": {
+    "en": "Claude-Code-style lifecycle hooks: configured shell commands run before/after model tool calls with a JSON payload on stdin; a non-zero pre-tool exit blocks the call.",
+    "zh": "Claude Code 风格生命周期 hooks：工具调用前后自动执行 shell 命令（stdin 收 JSON payload），pre-tool 非零退出即阻断调用。"
+   },
+   "npm": "dsh-plugin-hooks",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-plugin-hooks",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "uagent-sync#packages/dsh",
+   "owner": "severin-ye",
+   "url": "https://github.com/severin-ye/uagent-sync/tree/master/packages/dsh",
+   "page": "https://awesome-dsh-plugin.com/p/severin-ye/uagent-sync--packages-dsh/",
+   "category": "workflow",
+   "description": {
+    "en": "Cross-device workspace backup, restore, and ecosystem update via the uagent-sync CLI.",
+    "zh": "工作区跨设备备份、恢复与扩展更新，经 uagent-sync CLI 桥接执行。"
+   },
+   "npm": "uagent-sync-dsh",
+   "stars": 0,
+   "install": "dsh plugin --profile web add uagent-sync-dsh",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-agent-relay",
+   "owner": "Noelune",
+   "url": "https://github.com/Noelune/dsh-agent-relay",
+   "page": "https://awesome-dsh-plugin.com/p/Noelune/dsh-agent-relay/",
+   "category": "workflow",
+   "description": {
+    "en": "Loopback-first multi-agent message relay: HMAC-authenticated broker plus dsh plugin (relay_send/recv/peers/history), zero-dependency CLI and Python clients, wire protocol v1.0.",
+    "zh": "本地优先的多 Agent 协作中继：HMAC 认证 broker + dsh 插件（relay_send/recv/peers/history）+ 零依赖 CLI 与 Python 客户端，wire protocol v1.0。"
+   },
+   "npm": "dsh-agent-relay",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-agent-relay",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugins#dsh-plugin-scheduled-tasks",
+   "owner": "Ceelog",
+   "url": "https://github.com/Ceelog/dsh-plugins/tree/main/src/plugins/dsh-plugin-scheduled-tasks",
+   "page": "https://awesome-dsh-plugin.com/p/Ceelog/dsh-plugins--src-plugins-dsh-plugin-scheduled-tasks/",
+   "category": "workflow",
+   "description": {
+    "en": "Per-project scheduled prompts run as fresh headless agent sessions, with one-time, interval, and cron schedules plus durable run history.",
+    "zh": "按项目调度提示词，在全新的无头 Agent 会话中执行，支持单次、固定间隔和 cron 计划，并持久化运行历史。"
+   },
+   "npm": "@opendsh/dsh-plugin-scheduled-tasks",
+   "stars": 4,
+   "install": "dsh plugin --profile web add @opendsh/dsh-plugin-scheduled-tasks",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-scheduler",
+   "owner": "yangyongzhen",
+   "url": "https://github.com/yangyongzhen/dsh-scheduler",
+   "page": "https://awesome-dsh-plugin.com/p/yangyongzhen/dsh-scheduler/",
+   "category": "workflow",
+   "description": {
+    "en": "Cron/one-shot scheduled tasks: run shell commands or fire webhooks on a schedule, with optional ServerChan/DingTalk/Feishu/webhook delivery of results.",
+    "zh": "cron / 一次性定时任务：按调度执行 shell 命令或投递 webhook，结果可推送到 ServerChan / 钉钉 / 飞书 / 通用 Webhook。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:yangyongzhen/dsh-scheduler",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-git-workflow",
+   "owner": "yangyongzhen",
+   "url": "https://github.com/yangyongzhen/dsh-git-workflow",
+   "page": "https://awesome-dsh-plugin.com/p/yangyongzhen/dsh-git-workflow/",
+   "category": "workflow",
+   "description": {
+    "en": "Conventional-commit enforcement, changelog generation, PR summaries and branch pushes through the plain git CLI.",
+    "zh": "规范提交（Conventional Commits）、自动 changelog、PR 描述生成与分支推送，纯 git CLI 实现。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:yangyongzhen/dsh-git-workflow",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-article-publish",
+   "owner": "yangyongzhen",
+   "url": "https://github.com/yangyongzhen/dsh-article-publish",
+   "page": "https://awesome-dsh-plugin.com/p/yangyongzhen/dsh-article-publish/",
+   "category": "workflow",
+   "description": {
+    "en": "Publish articles to CSDN / Juejin / CNBlog directly from the session, no external server.",
+    "zh": "会话内直接发布文章到 CSDN / 掘金 / 博客园，无外部服务。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:yangyongzhen/dsh-article-publish",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-plugin-call-me",
+   "owner": "radres",
+   "url": "https://github.com/radres/dsh-plugin-call-me",
+   "page": "https://awesome-dsh-plugin.com/p/radres/dsh-plugin-call-me/",
+   "category": "notify",
+   "description": {
+    "en": "Rings your phone over CallKit: `call_me` and `text_me` tools, plus optional turn-end and approval calls whose spoken answer is transcribed back into the session.",
+    "zh": "通过 CallKit 打电话到你的手机：`call_me` 与 `text_me` 工具，并可在回合结束或等待审批时来电，语音回答转写后送回会话。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:radres/dsh-plugin-call-me",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-open-in-vscode",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-open-in-vscode",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-open-in-vscode/",
    "category": "notify",
    "description": {
     "en": "Open DSH workspace directories in VS Code directly from the web GUI.",
     "zh": "从 Web GUI 一键在 VS Code 中打开工作区目录。"
    },
    "npm": null,
-   "stars": 37,
+   "stars": 40,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-open-in-vscode",
    "added": "2026-08-13"
   },
@@ -2323,13 +5110,14 @@
    "name": "dsh-notification",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-notification",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-notification/",
    "category": "notify",
    "description": {
     "en": "Desktop notifications for turn completions, with per-outcome controls and keyword rules.",
     "zh": "回合完成桌面通知，按结果分控 + 关键词过滤。"
    },
    "npm": null,
-   "stars": 34,
+   "stars": 42,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-notification",
    "added": "2026-08-13"
   },
@@ -2337,6 +5125,7 @@
    "name": "dsh-acp-for-bitfun",
    "owner": "bobleer",
    "url": "https://github.com/bobleer/dsh-acp-for-bitfun",
+   "page": "https://awesome-dsh-plugin.com/p/bobleer/dsh-acp-for-bitfun/",
    "category": "notify",
    "description": {
     "en": "ACP bridge between BitFun and DSH.",
@@ -2351,13 +5140,14 @@
    "name": "deepseek-harness-acp",
    "owner": "openma-ai",
    "url": "https://github.com/openma-ai/deepseek-harness-acp",
+   "page": "https://awesome-dsh-plugin.com/p/openma-ai/deepseek-harness-acp/",
    "category": "notify",
    "description": {
     "en": "ACP profile plugin and standalone stdio server for using the full DSH agent from Zed and other ACP clients while sharing DSH credentials and sessions.",
     "zh": "ACP profile 插件与独立 stdio server，可从 Zed 等 ACP 客户端使用完整 DSH agent，并共享 DSH 凭据与会话。"
    },
    "npm": "@openma/deepseek-harness-acp",
-   "stars": 4,
+   "stars": 7,
    "install": "dsh plugin --profile web add @openma/deepseek-harness-acp",
    "added": "2026-08-14"
   },
@@ -2365,6 +5155,7 @@
    "name": "telegram",
    "owner": "LoserFox",
    "url": "https://github.com/LoserFox/telegram",
+   "page": "https://awesome-dsh-plugin.com/p/LoserFox/telegram/",
    "category": "notify",
    "description": {
     "en": "Bridge to the Telegram Bot API: long polling, per-chat sessions, HTML formatting.",
@@ -2376,9 +5167,25 @@
    "added": "2026-08-13"
   },
   {
+   "name": "dsh-telegram-duty",
+   "owner": "luzhengyangtx",
+   "url": "https://github.com/luzhengyangtx/dsh-telegram-duty",
+   "page": "https://awesome-dsh-plugin.com/p/luzhengyangtx/dsh-telegram-duty/",
+   "category": "notify",
+   "description": {
+    "en": "Telegram duty gateway: phone-message task loop on a dedicated duty session, global approval forwarding while on duty, duty/local toggle, zh/en messages.",
+    "zh": "Telegram 值班网关：手机消息任务闭环（专属值班会话）、值守模式全局审批转发、值守/本地切换、中英双语消息。"
+   },
+   "npm": "@luzhengyangtx/dsh-telegram-duty",
+   "stars": 0,
+   "install": "dsh plugin --profile web add @luzhengyangtx/dsh-telegram-duty",
+   "added": "2026-08-15"
+  },
+  {
    "name": "dsh-chatnode-wechat",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-chatnode-wechat",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-chatnode-wechat/",
    "category": "notify",
    "description": {
     "en": "Chat with, monitor, and approve your DSH agents from WeChat via the iLink gateway: text both ways, session targeting, digest heartbeats, and numbered approval prompts.",
@@ -2393,13 +5200,14 @@
    "name": "dsh-session-notification",
    "owner": "dingyi222666",
    "url": "https://github.com/dingyi222666/dsh-session-notification",
+   "page": "https://awesome-dsh-plugin.com/p/dingyi222666/dsh-session-notification/",
    "category": "notify",
    "description": {
     "en": "Notifications for four session states, with browser alerts and prompts.",
     "zh": "会话完成等四种状态的通知响应，支持浏览器提示。"
    },
    "npm": null,
-   "stars": 3,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:dingyi222666/dsh-session-notification",
    "added": "2026-08-13"
   },
@@ -2407,20 +5215,37 @@
    "name": "dsh-web-ui-notify",
    "owner": "bill9109",
    "url": "https://github.com/bill9109/dsh-web-ui-notify",
+   "page": "https://awesome-dsh-plugin.com/p/bill9109/dsh-web-ui-notify/",
    "category": "notify",
    "description": {
     "en": "Desktop notification reminders.",
     "zh": "桌面通知提醒。"
    },
    "npm": null,
-   "stars": 6,
+   "stars": 12,
    "install": "dsh plugin --profile web add github:bill9109/dsh-web-ui-notify",
    "added": "2026-08-13"
+  },
+  {
+   "name": "dsh-plugins#pet-bridge",
+   "owner": "wsxwj123",
+   "url": "https://github.com/wsxwj123/dsh-plugins/tree/main/packages/pet-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/wsxwj123/dsh-plugins--packages-pet-bridge/",
+   "category": "notify",
+   "description": {
+    "en": "Bridge dsh session status to the cc-pet desktop pet bubble: thinking, tool calls, and completion in real time.",
+    "zh": "dsh ↔ cc-pet 桌面宠物状态桥：把会话状态（思考中 / 读取文件 / 运行命令 / 完成）实时推送到桌面宠物气泡。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:wsxwj123/dsh-plugins#path:/packages/pet-bridge",
+   "added": "2026-08-14"
   },
   {
    "name": "dsh-webbridge",
    "owner": "bill9109",
    "url": "https://github.com/bill9109/dsh-webbridge",
+   "page": "https://awesome-dsh-plugin.com/p/bill9109/dsh-webbridge/",
    "category": "notify",
    "description": {
     "en": "DSH meets Kimi WebBridge.",
@@ -2435,13 +5260,14 @@
    "name": "dsh-im-bridge",
    "owner": "BiBoyang",
    "url": "https://github.com/BiBoyang/dsh-im-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/BiBoyang/dsh-im-bridge/",
    "category": "notify",
    "description": {
     "en": "Two-way WeChat (iLink) bridge: turn-end and approval-request push, in-chat approve/reject and message injection, persistent dedup and convergent long-reply chunking; channel layer extensible to other IMs.",
     "zh": "微信（iLink）双向桥：turn 完成/批准请求推送、聊天内批准与消息注入、持久去重与长回复收敛分段；通道层为多 IM 预留。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:BiBoyang/dsh-im-bridge",
    "added": "2026-08-14"
   },
@@ -2449,41 +5275,299 @@
    "name": "dsh-lark-bridge",
    "owner": "imetn",
    "url": "https://github.com/imetn/dsh-lark-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/imetn/dsh-lark-bridge/",
    "category": "notify",
    "description": {
     "en": "Bidirectional Lark/Feishu controller for DeepSeek Harness with project and session routing, interactive cards, approvals, attachments, and task controls.",
     "zh": "DeepSeek Harness 的飞书/Lark 双向控制器，支持 Project 与 Session 路由、交互卡片、审批、附件和任务控制。"
    },
    "npm": null,
-   "stars": 3,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:imetn/dsh-lark-bridge",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-lark-meeting-notifier",
+   "owner": "yeruizhi",
+   "url": "https://github.com/yeruizhi/dsh-lark-meeting-notifier",
+   "page": "https://awesome-dsh-plugin.com/p/yeruizhi/dsh-lark-meeting-notifier/",
+   "category": "notify",
+   "description": {
+    "en": "Feishu meeting reminder: a dsh-plugin which has only side effect: reminding you, mid-flow with AI, that you \"have to go meet carbon-based lifeforms\".",
+    "zh": "飞书会议提醒：一个只有副作用的 dsh-plugin，在你跟 AI 聊得神魂颠倒时提醒你「不得不去跟碳基生命开会了」。"
+   },
+   "npm": null,
+   "stars": 6,
+   "install": "dsh plugin --profile web add github:yeruizhi/dsh-lark-meeting-notifier",
    "added": "2026-08-14"
   },
   {
    "name": "dsh-notify-bark",
    "owner": "pc439527",
    "url": "https://github.com/pc439527/dsh-notify-bark",
+   "page": "https://awesome-dsh-plugin.com/p/pc439527/dsh-notify-bark/",
    "category": "notify",
    "description": {
     "en": "Bark push notifications to iPhone: turn completion, waiting-for-input, and approval events sent from the DSH Host.",
     "zh": "Bark 推送通知到 iPhone：回合完成、等待回答、等待授权等事件由 Host 端发送。"
    },
    "npm": null,
-   "stars": null,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:pc439527/dsh-notify-bark",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-ding",
+   "owner": "CAOGGL",
+   "url": "https://github.com/CAOGGL/dsh-ding",
+   "page": "https://awesome-dsh-plugin.com/p/CAOGGL/dsh-ding/",
+   "category": "notify",
+   "description": {
+    "en": "Notifies you when a conversation finishes: plays a sound and shows a Windows notification when the agent goes idle (configurable sound file, volume, debounce/throttle).",
+    "zh": "对话完成提醒：Agent 空闲（idle）时播放提示音并弹 Windows 原生通知，可配 ding.mp3、音量与防抖节流。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:CAOGGL/dsh-ding",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-notify-sound",
+   "owner": "ldchaowin",
+   "url": "https://github.com/ldchaowin/dsh-plugin-notify-sound",
+   "page": "https://awesome-dsh-plugin.com/p/ldchaowin/dsh-plugin-notify-sound/",
+   "category": "notify",
+   "description": {
+    "en": "Per-workspace completion ringtones plus attention sounds for approval, question, plan-review, goal-blocked, and task-failure events, with built-in synth, voice (TTS), and custom audio.",
+    "zh": "按工作区定制的任务完成铃声，以及审批、提问、计划评审、目标受阻、任务失败等需要人介入事件的注意提示音，支持内置合成音、语音播报与自定义音频。"
+   },
+   "npm": "dsh-plugin-notify-sound",
+   "stars": 1,
+   "install": "dsh plugin --profile web add dsh-plugin-notify-sound",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-suite#plugin-notify",
+   "owner": "whyihaveyou",
+   "url": "https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-notify",
+   "page": "https://awesome-dsh-plugin.com/p/whyihaveyou/dsh-suite--packages-plugins-plugin-notify/",
+   "category": "notify",
+   "description": {
+    "en": "IM webhook and local notifications on turn completion, errors, or approval (Feishu/WeCom/DingTalk/Slack/Discord/custom).",
+    "zh": "回合完成、错误或待审批时推送 IM webhook（飞书/企微/钉钉/Slack/Discord/自定义）与本地通知。"
+   },
+   "npm": null,
+   "stars": 19,
+   "install": "dsh plugin --profile web add github:whyihaveyou/dsh-suite#path:/packages/plugins/plugin-notify",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-feishu",
+   "owner": "xmanrui",
+   "url": "https://github.com/xmanrui/dsh-feishu",
+   "page": "https://awesome-dsh-plugin.com/p/xmanrui/dsh-feishu/",
+   "category": "notify",
+   "description": {
+    "en": "Connect a Feishu bot to DeepSeek Harness by scanning a QR code.",
+    "zh": "通过扫码把飞书机器人接入DeepSeek Harness。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:xmanrui/dsh-feishu",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-approval-alert",
+   "owner": "doncelee229-cmyk",
+   "url": "https://github.com/doncelee229-cmyk/dsh-plugin-approval-alert",
+   "page": "https://awesome-dsh-plugin.com/p/doncelee229-cmyk/dsh-plugin-approval-alert/",
+   "category": "notify",
+   "description": {
+    "en": "Native OS notifications for approval and question/plan prompts: the toast names the workspace, click jumps to it, bilingual (zh-CN/zh-TW/en), with chime.",
+    "zh": "审批与选择方案的系统级桌面通知：通知显示所属工作区、点击跳转到对应工作区，多语言（简中/繁中/英文），附提示音。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:doncelee229-cmyk/dsh-plugin-approval-alert",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "muretai-dsh-skill",
+   "owner": "muretai",
+   "url": "https://github.com/muretai/muretai-dsh-skill",
+   "page": "https://awesome-dsh-plugin.com/p/muretai/muretai-dsh-skill/",
+   "category": "notify",
+   "description": {
+    "en": "Puts the agent on the Muretai network: its own identity, invite-based introductions, signed end-to-end encrypted messaging with agents owned by other people, and an inbound-mail wake that lets it reply on its own.",
+    "zh": "让智能体加入 Muretai 网络：拥有自己的身份，通过邀请相识，与属于其他人的智能体进行签名、端到端加密的通信；来信唤醒后可自行回复。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:muretai/muretai-dsh-skill",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-feishu",
+   "owner": "itr-del",
+   "url": "https://github.com/itr-del/dsh-feishu",
+   "page": "https://awesome-dsh-plugin.com/p/itr-del/dsh-feishu/",
+   "category": "notify",
+   "description": {
+    "en": "Feishu (Lark) IM bridge for DeepSeek Harness via `dsh plugin add`; one DM user to one persistent dsh session, with full debugging docs.",
+    "zh": "DeepSeek Harness 的飞书/Lark 私聊桥接插件，支持 `dsh plugin add` 一键安装，配套完整调试文档。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:itr-del/dsh-feishu",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-feishu-bridge",
+   "owner": "wz-heng",
+   "url": "https://github.com/wz-heng/dsh-feishu-bridge",
+   "page": "https://awesome-dsh-plugin.com/p/wz-heng/dsh-feishu-bridge/",
+   "category": "notify",
+   "description": {
+    "en": "Fail-closed Feishu (Lark) channel bridge: chat with a bot, get dsh agent turns back. Official-Python-SDK-only integration (exact-pinned); deny-by-default allowlist, webhook signature/timestamp/replay verification, per-chat sticky sessions; bilingual docs.",
+    "zh": "Fail-closed 的飞书（Lark）channel 桥：和机器人聊天即驱动 dsh agent turn。仅经官方 Python SDK 集成（精确锁版）；白名单默认全拒、webhook 验签/时间窗/防重放、按 chat 粘性会话；中英双语文档。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:wz-heng/dsh-feishu-bridge",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-notify",
+   "owner": "huguangyu666",
+   "url": "https://github.com/huguangyu666/dsh-plugin-notify",
+   "page": "https://awesome-dsh-plugin.com/p/huguangyu666/dsh-plugin-notify/",
+   "category": "notify",
+   "description": {
+    "en": "Notification outbox: agent proactively notifies via toast / Chinese TTS voice / sound effects (explosion, victory, alarm), 60s confirmation window voice-calls you back, volume boost, settings panel.",
+    "zh": "通知出口：agent 主动通过桌面通知 / 中文语音 / 音效（炸裂、胜利、警报）联系你，60 秒确认窗口后语音呼叫，音量增强，设置面板。"
+   },
+   "npm": "dsh-plugin-notify",
+   "stars": 3,
+   "install": "dsh plugin --profile web add dsh-plugin-notify",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-weixin",
+   "owner": "xmanrui",
+   "url": "https://github.com/xmanrui/dsh-weixin",
+   "page": "https://awesome-dsh-plugin.com/p/xmanrui/dsh-weixin/",
+   "category": "notify",
+   "description": {
+    "en": "Connect a Weixin bot to DeepSeek Harness by scanning a QR code.",
+    "zh": "通过微信扫码把微信机器人接入 DeepSeek Harness。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:xmanrui/dsh-weixin",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-im",
+   "owner": "xmanrui",
+   "url": "https://github.com/xmanrui/dsh-im",
+   "page": "https://awesome-dsh-plugin.com/p/xmanrui/dsh-im/",
+   "category": "notify",
+   "description": {
+    "en": "Connect IM bots to DeepSeek Harness by scanning QR codes (supports Feishu, Weixin, DingTalk, and more).",
+    "zh": "通过扫码把IM机器人接入DeepSeek Harness（支持飞书、微信、钉钉等）。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:xmanrui/dsh-im",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-notifier",
+   "owner": "THEWOLFWALKER",
+   "url": "https://github.com/THEWOLFWALKER/dsh-notifier",
+   "page": "https://awesome-dsh-plugin.com/p/THEWOLFWALKER/dsh-notifier/",
+   "category": "notify",
+   "description": {
+    "en": "Unified notification push for DSH: one minimal notify() API with 8 channel adapters (Telegram / DingTalk / Feishu / WxPusher / PushPlus / ServerChan / Bark / webhook), auto session-event push on turn-end, approval and error, plus an agent-callable notify tool; zero runtime deps.",
+    "zh": "统一通知推送：一个 notify() API 接 8 个渠道（Telegram / 钉钉 / 飞书 / WxPusher / PushPlus / Server 酱 / Bark / webhook），回合结束、待审批、报错时自动推送，agent 也能主动调用 notify 工具；零运行时依赖。"
+   },
+   "npm": "dsh-notifier",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-notifier",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-notify",
+   "owner": "zhengjy01",
+   "url": "https://github.com/zhengjy01/dsh-notify",
+   "page": "https://awesome-dsh-plugin.com/p/zhengjy01/dsh-notify/",
+   "category": "notify",
+   "description": {
+    "en": "System-level desktop notifications: turn-completion and workflow-end banners, plus a modal alert when an approval is needed (macOS osascript / Linux notify-send).",
+    "zh": "系统级桌面通知：回合完成 / 工作流完成横幅，需要审批时弹出模态提醒（macOS osascript / Linux notify-send）。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:zhengjy01/dsh-notify",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-im-hub",
+   "owner": "ThreeBody6666",
+   "url": "https://github.com/ThreeBody6666/dsh-im-hub",
+   "page": "https://awesome-dsh-plugin.com/p/ThreeBody6666/dsh-im-hub/",
+   "category": "notify",
+   "description": {
+    "en": "Multi-platform IM gateway for DSH: Feishu (Lark) WebSocket long connection (no public URL), WeCom AES-encrypted callbacks, and Telegram long polling — per-chat agent sessions, whitelist access, and a visual settings card in the web GUI.",
+    "zh": "多平台 IM 网关：飞书（Lark）WebSocket 长连接（无需公网）、企业微信 AES 加密回调、Telegram 长轮询；每会话独立 agent、白名单访问、Web GUI 可视化设置卡片。"
+   },
+   "npm": "dsh-im-hub",
+   "stars": 1,
+   "install": "dsh plugin --profile web add dsh-im-hub",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-notify",
+   "owner": "yangyongzhen",
+   "url": "https://github.com/yangyongzhen/dsh-notify",
+   "page": "https://awesome-dsh-plugin.com/p/yangyongzhen/dsh-notify/",
+   "category": "notify",
+   "description": {
+    "en": "Task-completion notifications via ServerChan / DingTalk / Feishu / generic webhooks.",
+    "zh": "任务完成通知：ServerChan / 钉钉 / 飞书 / 通用 Webhook。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:yangyongzhen/dsh-notify",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-github-login",
+   "owner": "Noob-stupid",
+   "url": "https://github.com/Noob-stupid/dsh-github-login",
+   "page": "https://awesome-dsh-plugin.com/p/Noob-stupid/dsh-github-login/",
+   "category": "model",
+   "description": {
+    "en": "Visual GitHub login without a terminal: in-window device flow, token synced into the gh CLI, and host status/launch endpoints.",
+    "zh": "零终端的 GitHub 可视化登录插件：窗口内完成设备码授权，令牌同步进 gh CLI，附宿主端状态与唤起接口。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:Noob-stupid/dsh-github-login",
+   "added": "2026-08-15"
   },
   {
    "name": "llm-adaptive",
    "owner": "dylan121322",
    "url": "https://github.com/dylan121322/llm-adaptive",
+   "page": "https://awesome-dsh-plugin.com/p/dylan121322/llm-adaptive/",
    "category": "model",
    "description": {
     "en": "Adaptive model routing: per-request complexity classification with automatic provider routing.",
     "zh": "自适应模型路由：请求级复杂度分类，按配置链自动选择后端 provider。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:dylan121322/llm-adaptive",
    "added": "2026-08-14"
   },
@@ -2491,13 +5575,14 @@
    "name": "dsh-llm-fallbacks",
    "owner": "btspoony",
    "url": "https://github.com/btspoony/dsh-llm-fallbacks",
+   "page": "https://awesome-dsh-plugin.com/p/btspoony/dsh-llm-fallbacks/",
    "category": "model",
    "description": {
     "en": "Role-based LLM retry & fallback strategies.",
     "zh": "基于角色的模型重试与备用策略。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:btspoony/dsh-llm-fallbacks",
    "added": "2026-08-13"
   },
@@ -2505,13 +5590,14 @@
    "name": "dsh-codex-connect",
    "owner": "franksong2702",
    "url": "https://github.com/franksong2702/dsh-codex-connect",
+   "page": "https://awesome-dsh-plugin.com/p/franksong2702/dsh-codex-connect/",
    "category": "model",
    "description": {
     "en": "Connect ChatGPT OAuth and OpenAI Codex models to DeepSeek Harness, with opt-in search and image tools.",
     "zh": "通过 ChatGPT OAuth 将 OpenAI Codex 模型接入 DeepSeek Harness，并提供可选的搜索与图片工具。"
    },
    "npm": "dsh-codex-connect",
-   "stars": 2,
+   "stars": 7,
    "install": "dsh plugin --profile web add dsh-codex-connect",
    "added": "2026-08-14"
   },
@@ -2519,6 +5605,7 @@
    "name": "dsh-everything-oauth",
    "owner": "kam74515-boop",
    "url": "https://github.com/kam74515-boop/dsh-everything-oauth",
+   "page": "https://awesome-dsh-plugin.com/p/kam74515-boop/dsh-everything-oauth/",
    "category": "model",
    "description": {
     "en": "Import local Codex, Grok, Claude, OpenCode, and CC Switch logins into DSH; pick sources and enable models in Settings.",
@@ -2533,13 +5620,14 @@
    "name": "Qwen-MM-Plugins",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/Qwen-MM-Plugins",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/Qwen-MM-Plugins/",
    "category": "model",
    "description": {
     "en": "Qwen multi-modal plugin support.",
     "zh": "Qwen 多模态插件支持。"
    },
    "npm": null,
-   "stars": 3,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:omdsh-dev/Qwen-MM-Plugins",
    "added": "2026-08-13"
   },
@@ -2547,27 +5635,134 @@
    "name": "dsh-codex-auth",
    "owner": "suntianc",
    "url": "https://github.com/suntianc/dsh-codex-auth",
+   "page": "https://awesome-dsh-plugin.com/p/suntianc/dsh-codex-auth/",
    "category": "model",
    "description": {
     "en": "Reuses the Codex CLI ChatGPT login as an `openai-codex` LLM route and adds GPT Auth controls to DSH Web settings.",
     "zh": "复用 Codex CLI 的 ChatGPT 登录态注册 `openai-codex` LLM 路由，并在 DSH Web 设置中提供 GPT Auth 控件。"
    },
    "npm": "dsh-codex-auth",
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add dsh-codex-auth",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "deepseek-harness-wallet",
+   "owner": "feibi-mochi",
+   "url": "https://github.com/feibi-mochi/deepseek-harness-wallet",
+   "page": "https://awesome-dsh-plugin.com/p/feibi-mochi/deepseek-harness-wallet/",
+   "category": "model",
+   "description": {
+    "en": "Multi-provider wallet chip: official DeepSeek balance, per-session cost & tokens, third-party token totals, recharge shortcut, low-balance alerts.",
+    "zh": "多供应商钱包标签：官方 DeepSeek 余额、本会话花费与 token、第三方合计 token、一键充值、低余额提醒。"
+   },
+   "npm": null,
+   "stars": 7,
+   "install": "dsh plugin --profile web add github:feibi-mochi/deepseek-harness-wallet",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-model-router",
+   "owner": "superboy911",
+   "url": "https://github.com/superboy911/dsh-model-router",
+   "page": "https://awesome-dsh-plugin.com/p/superboy911/dsh-model-router/",
+   "category": "model",
+   "description": {
+    "en": "Deterministic keyword routing, allowlisted model switching, and an isolated image_gen channel for DeepSeek Harness.",
+    "zh": "DSH 关键词路由与隔离生图插件：确定性关键词路由、白名单模型切换与隔离的 image_gen 生图通道。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:superboy911/dsh-model-router",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-vision-recognizer",
+   "owner": "kaixinbaba",
+   "url": "https://github.com/kaixinbaba/dsh-vision-recognizer",
+   "page": "https://awesome-dsh-plugin.com/p/kaixinbaba/dsh-vision-recognizer/",
+   "category": "model",
+   "description": {
+    "en": "Vision provider route that transcribes attached images to text through a configurable model (15+ OpenAI-compatible and Anthropic vendors) while DeepSeek keeps answering.",
+    "zh": "视觉模型路由：把附加图片经可配置模型（15+ OpenAI 兼容与 Anthropic 供应商）转译为文字，对话仍由 DeepSeek 作答。"
+   },
+   "npm": "dsh-vision-recognizer",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-vision-recognizer",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-plugin-scout",
+   "owner": "icefall7",
+   "url": "https://github.com/icefall7/dsh-plugin-scout",
+   "page": "https://awesome-dsh-plugin.com/p/icefall7/dsh-plugin-scout/",
+   "category": "dev",
+   "description": {
+    "en": "Scouts the deepseek-harness repo and every dsh-plugin-tagged repository to discover harnesses related to your goal, then judges each as worth trying, watching, or skipping.",
+    "zh": "侦察 deepseek-harness 官方仓库与所有 dsh-plugin topic 仓库，发现与目标相关的 harness，并判断每个值得试用、观望还是跳过。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:icefall7/dsh-plugin-scout",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-boot-guard",
+   "owner": "SaiSenBox",
+   "url": "https://github.com/SaiSenBox/dsh-boot-guard",
+   "page": "https://awesome-dsh-plugin.com/p/SaiSenBox/dsh-boot-guard/",
+   "category": "dev",
+   "description": {
+    "en": "Loader-independent startup recovery for DSH Web that detects likely broken plugins, temporarily skips them, and restores only Boot Guard-managed changes.",
+    "zh": "独立于常规客户端插件加载链的 DSH Web 启动救援工具，可定位疑似故障插件、临时跳过，并且只恢复 Boot Guard 写入的配置。"
+   },
+   "npm": "dsh-boot-guard",
+   "stars": 4,
+   "install": "dsh plugin --profile web add dsh-boot-guard",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "Code2Skill",
+   "owner": "leechen298",
+   "url": "https://github.com/leechen298/Code2Skill",
+   "page": "https://awesome-dsh-plugin.com/p/leechen298/Code2Skill/",
+   "category": "dev",
+   "description": {
+    "en": "Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.",
+    "zh": "从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:leechen298/Code2Skill",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-testgen",
+   "owner": "bujue600-arch",
+   "url": "https://github.com/bujue600-arch/dsh-testgen",
+   "page": "https://awesome-dsh-plugin.com/p/bujue600-arch/dsh-testgen/",
+   "category": "dev",
+   "description": {
+    "en": "Automated unit-test generation: a /testgen command and generate_tests tool that scaffold, run, and fix tests until they pass (LLM + offline template generators; vitest/jest/mocha/node:test).",
+    "zh": "自动化单元测试生成：/testgen 命令与 generate_tests 工具，生成、运行并修复测试直至通过（LLM 与离线模板双生成器；支持 vitest/jest/mocha/node:test）。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:bujue600-arch/dsh-testgen",
    "added": "2026-08-14"
   },
   {
    "name": "fabric",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/fabric",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/fabric/",
    "category": "dev",
    "description": {
     "en": "An MC-Fabric-style hook processor.",
     "zh": "类似 MC Fabric 的 hook 处理器。"
    },
    "npm": null,
-   "stars": 8,
+   "stars": 9,
    "install": "dsh plugin --profile web add github:omdsh-dev/fabric",
    "added": "2026-08-13"
   },
@@ -2575,6 +5770,7 @@
    "name": "dsh-git-identity",
    "owner": "LoserFox",
    "url": "https://github.com/LoserFox/dsh-git-identity",
+   "page": "https://awesome-dsh-plugin.com/p/LoserFox/dsh-git-identity/",
    "category": "dev",
    "description": {
     "en": "Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings.",
@@ -2589,27 +5785,44 @@
    "name": "dsh-context-doctor",
    "owner": "Zhenyu98",
    "url": "https://github.com/Zhenyu98/dsh-context-doctor",
+   "page": "https://awesome-dsh-plugin.com/p/Zhenyu98/dsh-context-doctor/",
    "category": "dev",
    "description": {
     "en": "Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection.",
     "zh": "上下文注入审计：统计指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。"
    },
    "npm": null,
-   "stars": 6,
+   "stars": 7,
    "install": "dsh plugin --profile web add github:Zhenyu98/dsh-context-doctor",
    "added": "2026-08-13"
+  },
+  {
+   "name": "dsh-mcp-lens",
+   "owner": "labmimors",
+   "url": "https://github.com/labmimors/dsh-mcp-lens",
+   "page": "https://awesome-dsh-plugin.com/p/labmimors/dsh-mcp-lens/",
+   "category": "dev",
+   "description": {
+    "en": "Progressive-disclosure MCP gateway that searches large remote catalogs through `mcp_search`, then invokes exact schemas through `mcp_call` with lazy connections and bounded caches.",
+    "zh": "渐进披露 MCP 网关：用 `mcp_search` 检索大型远程工具目录，再由 `mcp_call` 按精确 schema 调用，并采用惰性连接与有界缓存。"
+   },
+   "npm": null,
+   "stars": 4,
+   "install": "dsh plugin --profile web add github:labmimors/dsh-mcp-lens",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-pain-point-check",
    "owner": "ICCuse",
    "url": "https://github.com/ICCuse/dsh-pain-point-check",
+   "page": "https://awesome-dsh-plugin.com/p/ICCuse/dsh-pain-point-check/",
    "category": "dev",
    "description": {
     "en": "Enforced pain-point gate: after two non-converged experiments it injects the three questions, denies non-investigative tool calls until answered, and blocks same-direction retries.",
     "zh": "强制痛点检查：同一问题连续 2 个实验未收敛后注入三问、拦截非调查类工具调用直到答出、阻止同方向重试。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:ICCuse/dsh-pain-point-check",
    "added": "2026-08-14"
   },
@@ -2617,13 +5830,14 @@
    "name": "dsh-plugin-check",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-plugin-check",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-plugin-check/",
    "category": "dev",
    "description": {
     "en": "Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only.",
     "zh": "插件健康检查：扫描清单协议/patch 格式/构建陷阱，零依赖只读。"
    },
    "npm": null,
-   "stars": 14,
+   "stars": 17,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-plugin-check",
    "added": "2026-08-13"
   },
@@ -2631,13 +5845,14 @@
    "name": "dsh-security-audit",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-security-audit",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-security-audit/",
    "category": "dev",
    "description": {
     "en": "Local security audit: config, plugin origins, sessions, network exposure — read-only redacted risk report.",
     "zh": "本机安全审计：配置/插件来源/会话/网络暴露面，只读脱敏风险报告。"
    },
    "npm": null,
-   "stars": 9,
+   "stars": 10,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-security-audit",
    "added": "2026-08-13"
   },
@@ -2645,13 +5860,14 @@
    "name": "dsh-session-health",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-session-health",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-session-health/",
    "category": "dev",
    "description": {
     "en": "Frame-level scan diagnostics for session files (torn/corrupt/empty detection).",
     "zh": "会话文件帧级扫描诊断（torn/损坏/空会话检测）。"
    },
    "npm": null,
-   "stars": 8,
+   "stars": 9,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-session-health",
    "added": "2026-08-13"
   },
@@ -2659,13 +5875,14 @@
    "name": "dsh-evolve",
    "owner": "william-jin-cmu",
    "url": "https://github.com/william-jin-cmu/dsh-evolve",
+   "page": "https://awesome-dsh-plugin.com/p/william-jin-cmu/dsh-evolve/",
    "category": "dev",
    "description": {
     "en": "Self-evolution: the agent hot-mounts/removes persistent plugins on itself mid-session.",
     "zh": "自进化：agent 在会话内给自己热挂载/卸载持久化插件。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:william-jin-cmu/dsh-evolve",
    "added": "2026-08-13"
   },
@@ -2673,6 +5890,7 @@
    "name": "dsh-trace",
    "owner": "vibeinging",
    "url": "https://github.com/vibeinging/dsh-trace",
+   "page": "https://awesome-dsh-plugin.com/p/vibeinging/dsh-trace/",
    "category": "dev",
    "description": {
     "en": "Telemetry backend exporting turns, model steps, and tool calls to yiTrace.",
@@ -2687,13 +5905,14 @@
    "name": "dsh-telemetry-redactor",
    "owner": "030611",
    "url": "https://github.com/030611/dsh-telemetry-redactor",
+   "page": "https://awesome-dsh-plugin.com/p/030611/dsh-telemetry-redactor/",
    "category": "dev",
    "description": {
     "en": "Redacts supported secret patterns from the `session-telemetry/record` export copy before configured telemetry backends receive it.",
     "zh": "在已配置遥测后端接收前，对 `session-telemetry/record` 导出副本中的已支持秘密模式进行脱敏。"
    },
    "npm": "dsh-telemetry-redactor",
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add dsh-telemetry-redactor",
    "added": "2026-08-14"
   },
@@ -2701,27 +5920,44 @@
    "name": "dsh-verification-receipt",
    "owner": "030611",
    "url": "https://github.com/030611/dsh-verification-receipt",
+   "page": "https://awesome-dsh-plugin.com/p/030611/dsh-verification-receipt/",
    "category": "dev",
    "description": {
     "en": "Writes local JSONL summaries of per-turn tool counts and coarse verification signals without storing prompts, tool arguments, or result text.",
     "zh": "把每轮工具计数与粗粒度验证信号写入本地 JSONL，不保存提示词、工具参数或结果正文。"
    },
    "npm": "dsh-verification-receipt",
-   "stars": 1,
+   "stars": 4,
    "install": "dsh plugin --profile web add dsh-verification-receipt",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "qiushi-dsh-evidence-audit",
+   "owner": "030611",
+   "url": "https://github.com/030611/qiushi-dsh-evidence-audit",
+   "page": "https://awesome-dsh-plugin.com/p/030611/qiushi-dsh-evidence-audit/",
+   "category": "dev",
+   "description": {
+    "en": "Appends local hash-chained JSONL receipts for tool results and session events without storing prompts, tool arguments, result text, or raw session IDs.",
+    "zh": "把工具结果与会话事件的 receipt 写入本地哈希链 JSONL，不保存提示词、工具参数、结果正文或原始会话 ID。"
+   },
+   "npm": "qiushi-dsh-evidence-audit",
+   "stars": 4,
+   "install": "dsh plugin --profile web add qiushi-dsh-evidence-audit",
    "added": "2026-08-14"
   },
   {
    "name": "sandbox-micro",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/sandbox-micro",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/sandbox-micro/",
    "category": "dev",
    "description": {
     "en": "Support for the microsandbox backend.",
     "zh": "microsandbox 沙箱支持。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-micro",
    "added": "2026-08-13"
   },
@@ -2729,13 +5965,14 @@
    "name": "sandbox-mxc",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/sandbox-mxc",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/sandbox-mxc/",
    "category": "dev",
    "description": {
     "en": "Microsoft cross-platform sandbox support.",
     "zh": "微软跨平台沙盒支持。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-mxc",
    "added": "2026-08-13"
   },
@@ -2743,13 +5980,14 @@
    "name": "sandbox-nono",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/sandbox-nono",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/sandbox-nono/",
    "category": "dev",
    "description": {
     "en": "Support for the nono sandbox backend.",
     "zh": "nono 沙盒支持。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/sandbox-nono",
    "added": "2026-08-13"
   },
@@ -2757,6 +5995,7 @@
    "name": "dsh-agent-budget",
    "owner": "vibeinging",
    "url": "https://github.com/vibeinging/dsh-agent-budget",
+   "page": "https://awesome-dsh-plugin.com/p/vibeinging/dsh-agent-budget/",
    "category": "dev",
    "description": {
     "en": "Agent-tree token budget management.",
@@ -2771,13 +6010,14 @@
    "name": "dsh-polyglot",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-polyglot",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-polyglot/",
    "category": "dev",
    "description": {
     "en": "The model switch for DSH: point it at any OpenAI-compatible endpoint, with curated free/cheap DeepSeek provider presets and automatic fallback when a free tier rate-limits you.",
     "zh": "DSH 的模型切换器：指向任意 OpenAI 兼容端点，内置精选免费/低价 DeepSeek 服务商预设，免费额度限流时自动回退。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:Jesse-njx/dsh-polyglot",
    "added": "2026-08-14"
   },
@@ -2785,27 +6025,29 @@
    "name": "dsh-tool-approval",
    "owner": "ilharp",
    "url": "https://github.com/ilharp/dsh-tool-approval",
+   "page": "https://awesome-dsh-plugin.com/p/ilharp/dsh-tool-approval/",
    "category": "dev",
    "description": {
     "en": "Manual approval mode (\"Manual Mode\" / \"Ask Mode\").",
     "zh": "手动审批模式（Manual/Ask Mode）。"
    },
-   "npm": null,
+   "npm": "dsh-tool-approval",
    "stars": 1,
-   "install": "dsh plugin --profile web add github:ilharp/dsh-tool-approval",
+   "install": "dsh plugin --profile web add dsh-tool-approval",
    "added": "2026-08-13"
   },
   {
    "name": "dsh-turn-approval",
    "owner": "arrow949",
    "url": "https://github.com/arrow949/dsh-turn-approval",
+   "page": "https://awesome-dsh-plugin.com/p/arrow949/dsh-turn-approval/",
    "category": "dev",
    "description": {
     "en": "Turn-scoped “Allow for this task” approvals: automatically allow matching `danger-full-access` escalations only for the current task, then expire.",
     "zh": "DSH「允许本次任务」临时授权：仅在当前任务内自动放行同类 `danger-full-access` 请求，任务结束自动失效。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:arrow949/dsh-turn-approval",
    "added": "2026-08-14"
   },
@@ -2813,6 +6055,7 @@
    "name": "plugin-template",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/plugin-template",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/plugin-template/",
    "category": "dev",
    "description": {
     "en": "Plugin template repo (based on the official turtle-ui repo).",
@@ -2827,6 +6070,7 @@
    "name": "dsh-tps",
    "owner": "Small-tailqwq",
    "url": "https://github.com/Small-tailqwq/dsh-tps",
+   "page": "https://awesome-dsh-plugin.com/p/Small-tailqwq/dsh-tps/",
    "category": "dev",
    "description": {
     "en": "A TPS metrics plugin.",
@@ -2841,6 +6085,7 @@
    "name": "dsh-tool-call-stats",
    "owner": "disyli",
    "url": "https://github.com/disyli/dsh-tool-call-stats",
+   "page": "https://awesome-dsh-plugin.com/p/disyli/dsh-tool-call-stats/",
    "category": "dev",
    "description": {
     "en": "Per-process tool-call statistics: a `tool_stats` tool reporting per-tool call counts, error counts, and average durations.",
@@ -2855,27 +6100,44 @@
    "name": "dsh-fail-logger",
    "owner": "Areium",
    "url": "https://github.com/Areium/dsh-fail-logger",
+   "page": "https://awesome-dsh-plugin.com/p/Areium/dsh-fail-logger/",
    "category": "dev",
    "description": {
     "en": "Auto-log failed tool calls across native tools, PTC run_code, and inline invocations: dedup and count root causes into a skill so repeated mistakes fade.",
     "zh": "全模式调用工具失败自动实录：把原生工具 / PTC run_code / 代码内嵌工具调用的失败错因去重计数后写入 skill，越用越少错。"
    },
-   "npm": null,
-   "stars": 5,
-   "install": "dsh plugin --profile web add github:Areium/dsh-fail-logger",
+   "npm": "dsh-fail-logger",
+   "stars": 7,
+   "install": "dsh plugin --profile web add dsh-fail-logger",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-observation-journal",
+   "owner": "Cavan-Ou",
+   "url": "https://github.com/Cavan-Ou/dsh-observation-journal",
+   "page": "https://awesome-dsh-plugin.com/p/Cavan-Ou/dsh-observation-journal/",
+   "category": "dev",
+   "description": {
+    "en": "Zero-touch runtime telemetry for DSH: every session auto-writes task, model tier, tools, failures, duration, status into a human-readable journal with a stats section (pure observer — no tools, no LLM calls, no injection).",
+    "zh": "DeepSeek Harness 零侵入运行事实遥测：每个会话自动把任务/模型档位/工具/失败/时长/状态写入人机共读观测卡并附统计区（纯观察者——零工具、零 LLM、零注入）。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:Cavan-Ou/dsh-observation-journal",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-eval-harness",
    "owner": "BiBoyang",
    "url": "https://github.com/BiBoyang/dsh-eval-harness",
+   "page": "https://awesome-dsh-plugin.com/p/BiBoyang/dsh-eval-harness/",
    "category": "dev",
    "description": {
     "en": "Evaluation harness for DSH plugins: YAML cases drive real headless agent runs, assert on tool calls, args, results and token usage, with a baseline gate for CI regression.",
     "zh": "DSH 插件评测框架：YAML 用例驱动真实 headless agent，断言工具调用/参数/返回与 token 用量，baseline 门禁做 CI 回归。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 4,
    "install": "dsh plugin --profile web add github:BiBoyang/dsh-eval-harness",
    "added": "2026-08-14"
   },
@@ -2883,13 +6145,14 @@
    "name": "oh-dsh",
    "owner": "hust-open-atom-club",
    "url": "https://github.com/hust-open-atom-club/oh-dsh",
+   "page": "https://awesome-dsh-plugin.com/p/hust-open-atom-club/oh-dsh/",
    "category": "dev",
    "description": {
     "en": "Community distribution: TUI, desktop, and Web UI as one bundle with layered installation.",
     "zh": "社区发行版：TUI、桌面端与 Web UI 统一体验，分层安装、一步到位。"
    },
    "npm": null,
-   "stars": 143,
+   "stars": 174,
    "install": "dsh plugin --profile web add github:hust-open-atom-club/oh-dsh",
    "added": "2026-08-14"
   },
@@ -2897,13 +6160,14 @@
    "name": "dsh-annotate",
    "owner": "BrambleXu",
    "url": "https://github.com/BrambleXu/dsh-annotate",
+   "page": "https://awesome-dsh-plugin.com/p/BrambleXu/dsh-annotate/",
    "category": "dev",
    "description": {
     "en": "Select browser elements directly during Vibe Coding and send structured visual feedback to the DeepSeek Harness Agent.",
     "zh": "面向 Vibe Coding 的浏览器元素标注插件：直接选取页面元素，并将结构化视觉反馈发送给 DeepSeek Harness Agent。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:BrambleXu/dsh-annotate",
    "added": "2026-08-14"
   },
@@ -2911,6 +6175,7 @@
    "name": "dsh-prompt-profile",
    "owner": "BrambleXu",
    "url": "https://github.com/BrambleXu/dsh-prompt-profile",
+   "page": "https://awesome-dsh-plugin.com/p/BrambleXu/dsh-prompt-profile/",
    "category": "dev",
    "description": {
     "en": "Reusable Markdown prompt profiles for DeepSeek Harness with per-turn model selection, argument substitution, and state restoration.",
@@ -2925,13 +6190,14 @@
    "name": "dsh-revdiff",
    "owner": "BrambleXu",
    "url": "https://github.com/BrambleXu/dsh-revdiff",
+   "page": "https://awesome-dsh-plugin.com/p/BrambleXu/dsh-revdiff/",
    "category": "dev",
    "description": {
     "en": "Native interactive Git diff review for DeepSeek Harness with structured annotations sent back to the current Agent session.",
     "zh": "DeepSeek Harness 原生交互式 Git diff 审查，支持结构化批注并回传当前 Agent 会话。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:BrambleXu/dsh-revdiff",
    "added": "2026-08-14"
   },
@@ -2939,13 +6205,14 @@
    "name": "dsh-gitflow",
    "owner": "lonelymoon87",
    "url": "https://github.com/lonelymoon87/dsh-gitflow",
+   "page": "https://awesome-dsh-plugin.com/p/lonelymoon87/dsh-gitflow/",
    "category": "dev",
    "description": {
     "en": "Adds approval-gated Git status, diff, log, commit, branch, and optional checkpoint tools.",
     "zh": "增加需要审批的 Git 状态、diff、日志、提交、分支和可选检查点工具。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:lonelymoon87/dsh-gitflow",
    "added": "2026-08-14"
   },
@@ -2953,13 +6220,14 @@
    "name": "dsh-guardian",
    "owner": "lonelymoon87",
    "url": "https://github.com/lonelymoon87/dsh-guardian",
+   "page": "https://awesome-dsh-plugin.com/p/lonelymoon87/dsh-guardian/",
    "category": "dev",
    "description": {
     "en": "Adds dangerous-operation policy checks, output redaction, and a security-review workflow.",
     "zh": "增加危险操作策略检查、输出脱敏和安全审查工作流。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:lonelymoon87/dsh-guardian",
    "added": "2026-08-14"
   },
@@ -2967,13 +6235,14 @@
    "name": "dsh-plugin-manager",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-plugin-manager",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-plugin-manager/",
    "category": "dev",
    "description": {
     "en": "The `dsh pm` plugin manager: multi-source search (awesome list + GitHub + npm), install/remove/update per profile, and a doctor audit of manifests, bundle patches, and version drift.",
     "zh": "`dsh pm` 插件管理器：多源搜索（awesome 列表 + GitHub + npm）、按 profile 安装/移除/更新，以及 doctor 审计（清单、bundle patch、版本漂移）。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 1,
    "install": "dsh plugin --profile web add github:Jesse-njx/dsh-plugin-manager",
    "added": "2026-08-14"
   },
@@ -2981,6 +6250,7 @@
    "name": "dsh-tmuxctl",
    "owner": "Jesse-njx",
    "url": "https://github.com/Jesse-njx/dsh-tmuxctl",
+   "page": "https://awesome-dsh-plugin.com/p/Jesse-njx/dsh-tmuxctl/",
    "category": "dev",
    "description": {
     "en": "Take control of your tmux panes: list/send-keys/capture, run long jobs in a pane with watch mode, and approval-gated destructive commands.",
@@ -2995,13 +6265,14 @@
    "name": "dsh-updater-ui",
    "owner": "xingyingyuzhui",
    "url": "https://github.com/xingyingyuzhui/dsh-updater-ui",
+   "page": "https://awesome-dsh-plugin.com/p/xingyingyuzhui/dsh-updater-ui/",
    "category": "dev",
    "description": {
     "en": "DSH self-updater in the settings page: one-click check/pull (`git pull --ff-only`), auto background checks, version diff and changelog preview with a red-dot reminder.",
     "zh": "设置页中的 DSH 自助更新器：一键检查/拉取（git pull --ff-only）、自动后台检查、版本对比与更新说明预览，带红点提醒。"
    },
    "npm": null,
-   "stars": 5,
+   "stars": 6,
    "install": "dsh plugin --profile web add github:xingyingyuzhui/dsh-updater-ui",
    "added": "2026-08-14"
   },
@@ -3009,6 +6280,7 @@
    "name": "dsh-repro",
    "owner": "EvilIrving",
    "url": "https://github.com/EvilIrving/dsh-repro",
+   "page": "https://awesome-dsh-plugin.com/p/EvilIrving/dsh-repro/",
    "category": "dev",
    "description": {
     "en": "/repro exports a minimal, secret-scrubbed, replayable problem bundle: the session log, failed commands, and Git diff.",
@@ -3023,27 +6295,29 @@
    "name": "dsh-mcp-panel",
    "owner": "PerryLink",
    "url": "https://github.com/PerryLink/dsh-mcp-panel",
+   "page": "https://awesome-dsh-plugin.com/p/PerryLink/dsh-mcp-panel/",
    "category": "dev",
    "description": {
     "en": "Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors, and reconnect counts through the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.",
     "zh": "官方 MCP 客户端（dsh-mcp-client）的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。"
    },
-   "npm": null,
-   "stars": 1,
-   "install": "dsh plugin --profile web add github:PerryLink/dsh-mcp-panel",
+   "npm": "dsh-mcp-panel",
+   "stars": 4,
+   "install": "dsh plugin --profile web add dsh-mcp-panel",
    "added": "2026-08-14"
   },
   {
    "name": "forkprobe",
    "owner": "Jayden-X-L",
    "url": "https://github.com/Jayden-X-L/forkprobe",
+   "page": "https://awesome-dsh-plugin.com/p/Jayden-X-L/forkprobe/",
    "category": "dev",
    "description": {
     "en": "Compare multiple skills on the same task and pick the winner.",
     "zh": "同一任务并行试跑多个技能，对比结果选出最优。"
    },
    "npm": null,
-   "stars": 64,
+   "stars": 65,
    "install": "dsh plugin --profile web add github:Jayden-X-L/forkprobe",
    "added": "2026-08-14"
   },
@@ -3051,13 +6325,14 @@
    "name": "plugin-registry",
    "owner": "vlln",
    "url": "https://github.com/vlln/plugin-registry",
+   "page": "https://awesome-dsh-plugin.com/p/vlln/plugin-registry/",
    "category": "dev",
    "description": {
     "en": "Ecosystem infrastructure: a thin browser console for managing official repository plugins (zero patches) plus a make-dsh-plugin skill for guided plugin development.",
     "zh": "插件生态基建：浏览器面板管理官方 repository 插件（0 patch）+ make-dsh-plugin 插件开发引导技能。"
    },
    "npm": null,
-   "stars": 28,
+   "stars": 38,
    "install": "dsh plugin --profile web add github:vlln/plugin-registry",
    "added": "2026-08-14"
   },
@@ -3065,13 +6340,14 @@
    "name": "dsh-multica-runtime",
    "owner": "forrestchang",
    "url": "https://github.com/forrestchang/dsh-multica-runtime",
+   "page": "https://awesome-dsh-plugin.com/p/forrestchang/dsh-multica-runtime/",
    "category": "dev",
    "description": {
     "en": "Run the dsh runtime on Multica.",
     "zh": "让 dsh 运行时跑在 Multica 上。"
    },
    "npm": null,
-   "stars": 27,
+   "stars": 33,
    "install": "dsh plugin --profile web add github:forrestchang/dsh-multica-runtime",
    "added": "2026-08-14"
   },
@@ -3079,13 +6355,14 @@
    "name": "dsh-user-experience",
    "owner": "DietCokewithSugar",
    "url": "https://github.com/DietCokewithSugar/dsh-user-experience",
+   "page": "https://awesome-dsh-plugin.com/p/DietCokewithSugar/dsh-user-experience/",
    "category": "dev",
    "description": {
     "en": "Finds potential UX issues in your project: automatically reviews React/TypeScript code, pinpoints each problem, and gives concrete suggestions.",
     "zh": "帮你发现项目中可能存在的用户体验问题：自动走查 React/TypeScript 源码，定位问题并给出具体优化建议。"
    },
    "npm": null,
-   "stars": 6,
+   "stars": 18,
    "install": "dsh plugin --profile web add github:DietCokewithSugar/dsh-user-experience",
    "added": "2026-08-14"
   },
@@ -3093,13 +6370,14 @@
    "name": "dsh-cost-tracker",
    "owner": "yflmq001",
    "url": "https://github.com/yflmq001/dsh-cost-tracker",
+   "page": "https://awesome-dsh-plugin.com/p/yflmq001/dsh-cost-tracker/",
    "category": "dev",
    "description": {
     "en": "Per-model token cost tracking with configurable cache-hit/miss, output and peak-window pricing, a live session cost bar, and unconfigured-model flags.",
     "zh": "按模型追踪 token 成本：可配置缓存命中/未命中、输出与高峰时段单价，实时会话花费条，并标记未配置价格的模型。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:yflmq001/dsh-cost-tracker",
    "added": "2026-08-14"
   },
@@ -3107,13 +6385,14 @@
    "name": "dsh-passwords",
    "owner": "slywalker2006",
    "url": "https://github.com/slywalker2006/dsh-passwords",
+   "page": "https://awesome-dsh-plugin.com/p/slywalker2006/dsh-passwords/",
    "category": "dev",
    "description": {
     "en": "Login gateway for the DSH web UI: password door with first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF, anti-framing.",
     "zh": "DSH Web UI 登录网关：首次配置、bcrypt + 静态加密（AES-256-GCM/HMAC）、防爆破、审计日志、TLS 1.2+ 与 80→443 跳转、CSRF 与防嵌框。"
    },
    "npm": null,
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:slywalker2006/dsh-passwords",
    "added": "2026-08-14"
   },
@@ -3121,13 +6400,14 @@
    "name": "dsh-webui-auth",
    "owner": "Yuuz12",
    "url": "https://github.com/Yuuz12/dsh-webui-auth",
+   "page": "https://awesome-dsh-plugin.com/p/Yuuz12/dsh-webui-auth/",
    "category": "dev",
    "description": {
     "en": "WebUI authentication enforced at the HTTP/transport layer: four-layer login gate (resources, plugin bundles, /api, WebSocket), server-side sessions with HttpOnly cookies.",
     "zh": "WebUI 身份认证：HTTP/传输层强制登录（资源、插件 bundle、/api、WebSocket 四层防护），服务端会话 + HttpOnly Cookie。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:Yuuz12/dsh-webui-auth",
    "added": "2026-08-14"
   },
@@ -3135,27 +6415,239 @@
    "name": "dsh-lan-access",
    "owner": "Leon0555",
    "url": "https://github.com/Leon0555/dsh-lan-access",
+   "page": "https://awesome-dsh-plugin.com/p/Leon0555/dsh-lan-access/",
    "category": "dev",
    "description": {
     "en": "LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure (LAN HTTP) contexts.",
     "zh": "局域网访问：Web GUI 绑定 0.0.0.0 + crypto.randomUUID polyfill（修复非安全上下文下 RPC 崩溃）。"
    },
    "npm": "dsh-lan-access",
-   "stars": 1,
+   "stars": 3,
    "install": "dsh plugin --profile web add dsh-lan-access",
    "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-remote-access-web#remote-access-web",
+   "owner": "wikkd",
+   "url": "https://github.com/wikkd/dsh-remote-access-web/tree/main/packages/bundle/remote-access-web",
+   "page": "https://awesome-dsh-plugin.com/p/wikkd/dsh-remote-access-web--packages-bundle-remote-access-web/",
+   "category": "dev",
+   "description": {
+    "en": "Reverse tunnel for the DSH Web GUI: exposes a `dsh --profile web` deployment at a public frp URL and switches the directory picker to the in-app browser, so a phone or remote machine can open and manage the workspace.",
+    "zh": "DSH Web GUI 反向隧道：通过 frp 把 `dsh --profile web` 发布到公网地址，目录选择器改用应用内浏览器，手机或远程机器可直接打开并管理工作区。"
+   },
+   "npm": "@froststarinquire/dsh-remote-access-web",
+   "stars": 1,
+   "install": "dsh plugin --profile web add @froststarinquire/dsh-remote-access-web",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-chameleon#bundle",
+   "owner": "lsz-asd",
+   "url": "https://github.com/lsz-asd/dsh-chameleon/tree/main/bundle",
+   "page": "https://awesome-dsh-plugin.com/p/lsz-asd/dsh-chameleon--bundle/",
+   "category": "dev",
+   "description": {
+    "en": "Self-editing desktop workbench for DeepSeek Harness: a full dsh web replica with an edit mode in which the agent modifies the workbench (patch layers, plugins, UI) with hot reload.",
+    "zh": "可自修改的 DeepSeek Harness 桌面工作台：完整 dsh web 副本 + 编辑模式，agent 在对话中实时修改工作台（补丁层、插件、UI）并热更新生效。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:lsz-asd/dsh-chameleon#path:/bundle",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-ocr-review",
+   "owner": "jiayan-xu",
+   "url": "https://github.com/jiayan-xu/dsh-ocr-review",
+   "page": "https://awesome-dsh-plugin.com/p/jiayan-xu/dsh-ocr-review/",
+   "category": "dev",
+   "description": {
+    "en": "Local AI code-review gate: review a workspace/branch/commit diff via the managed ocr.js, returning structured findings with token stats; gate mode fails on findings.",
+    "zh": "本地 AI 代码评审门禁：对工作区/分支/commit diff 跑评审（托管 ocr.js），返回结构化 findings 与 token 统计；门禁模式发现问题即失败。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:jiayan-xu/dsh-ocr-review",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-store",
+   "owner": "huguangyu666",
+   "url": "https://github.com/huguangyu666/dsh-store",
+   "page": "https://awesome-dsh-plugin.com/p/huguangyu666/dsh-store/",
+   "category": "dev",
+   "description": {
+    "en": "Plugin store: npm authoritative catalog + awesome curated list (550+ plugins, 11 categories), dsh-field quality verification, official `dsh plugin add/remove` one-click install, sidebar + settings entry.",
+    "zh": "dsh 插件商店：npm 权威目录 + awesome 精选（550+ 插件、11 分类）、dsh 字段质量验证、官方 `dsh plugin add/remove` 一键安装，侧边栏与设置页入口。"
+   },
+   "npm": "dsh-store",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-store",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-plugin-manager",
+   "owner": "liqichen",
+   "url": "https://github.com/liqichen/dsh-plugin-manager",
+   "page": "https://awesome-dsh-plugin.com/p/liqichen/dsh-plugin-manager/",
+   "category": "dev",
+   "description": {
+    "en": "GUI in the DSH settings panel: toggle/delete MCP servers, browse and trash skills, and list built-in plugin packages — hot-applied without restart.",
+    "zh": "在 DSH 设置面板内嵌的图形化管理器：开关/删除 MCP 服务、浏览并回收 Skills、查看内置插件包，改动热生效无需重启。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:liqichen/dsh-plugin-manager",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-pluginmanager",
+   "owner": "buhuikongpan",
+   "url": "https://github.com/buhuikongpan/dsh-pluginmanager",
+   "page": "https://awesome-dsh-plugin.com/p/buhuikongpan/dsh-pluginmanager/",
+   "category": "dev",
+   "description": {
+    "en": "Layered plugin manager for DSH web: native plugins grouped read-only by system/WebUI/tools, user extensions with enable/disable, register, uninstall and editable descriptions.",
+    "zh": "DSH 分层插件管理器：原生插件按系统/WebUI/工具三层只读展示，用户扩展支持停用/启用、补登记、卸载与可编辑描述。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:buhuikongpan/dsh-pluginmanager",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-hot-plugin-host",
+   "owner": "tianyaZTY",
+   "url": "https://github.com/tianyaZTY/dsh-hot-plugin-host",
+   "page": "https://awesome-dsh-plugin.com/p/tianyaZTY/dsh-hot-plugin-host/",
+   "category": "dev",
+   "description": {
+    "en": "Runtime plugin loading for the Web UI: a watched hot directory installs/updates client-plugin bundles live on every open page, no restart. Includes a right-column subagent dashboard example.",
+    "zh": "Web UI 运行时插件加载：监视热目录，运行中安装/更新客户端插件 bundle，所有页面即时生效，免重启。附子智能体看板示例。"
+   },
+   "npm": null,
+   "stars": 1,
+   "install": "dsh plugin --profile web add github:tianyaZTY/dsh-hot-plugin-host",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-doctor#plugin",
+   "owner": "moonquake2004",
+   "url": "https://github.com/moonquake2004/dsh-doctor/tree/main/plugin",
+   "page": "https://awesome-dsh-plugin.com/p/moonquake2004/dsh-doctor--plugin/",
+   "category": "dev",
+   "description": {
+    "en": "Offline diagnostic for DSH: 19 checks across env, profile, and session state, with a settings \"Doctor\" panel and a read-only JSON API.",
+    "zh": "离线诊断工具：环境/Profile/会话共 19 项检查，带设置「诊断」面板与只读 JSON API。"
+   },
+   "npm": "@moonquake2004/dsh-doctor",
+   "stars": 0,
+   "install": "dsh plugin --profile web add @moonquake2004/dsh-doctor",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-guard",
+   "owner": "x2802490130-prog",
+   "url": "https://github.com/x2802490130-prog/dsh-guard",
+   "page": "https://awesome-dsh-plugin.com/p/x2802490130-prog/dsh-guard/",
+   "category": "dev",
+   "description": {
+    "en": "A development safety kit: rolling config snapshots, automatic rollback on plugin failures, boot-failure rescue, and an in-settings management panel.",
+    "zh": "开发配套守护：滚动快照、插件失败自动回退、启动失败救援、设置页管理面板。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:x2802490130-prog/dsh-guard",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-shield",
+   "owner": "x2802490130-prog",
+   "url": "https://github.com/x2802490130-prog/dsh-shield",
+   "page": "https://awesome-dsh-plugin.com/p/x2802490130-prog/dsh-shield/",
+   "category": "dev",
+   "description": {
+    "en": "A hands-off safety net: directories the agent deletes go to a trash folder first and symlinks are never followed, with zero approvals.",
+    "zh": "脱手模式安全网：agent 删除的目录先进回收站、链接绝不跟随，零审批。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:x2802490130-prog/dsh-shield",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "mirage#dsh",
+   "owner": "strukto-ai",
+   "url": "https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh",
+   "page": "https://awesome-dsh-plugin.com/p/strukto-ai/mirage--typescript-packages-dsh/",
+   "category": "dev",
+   "description": {
+    "en": "Swaps the filesystem and bash providers for a mirage virtual workspace: file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk, with per-mount read/write/exec modes, per-command sandbox routing (monty, pyodide, quickjs in process; docker, e2b, daytona remote), and installed CLIs (git, gh, slack, linear, ntn, gws, or one you register) as head words in the virtual terminal.",
+    "zh": "把文件系统与 bash 提供者换成 mirage 虚拟工作区：文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘，支持按挂载点设置读/写/执行模式、按命令选择沙箱（进程内 monty、pyodide、quickjs；远程 docker、e2b、daytona），并可在虚拟终端中安装 CLI（git、gh、slack、linear、ntn、gws，或自行注册的程序树）作为命令头词。"
+   },
+   "npm": "@struktoai/mirage-dsh",
+   "stars": 3419,
+   "install": "dsh plugin --profile web add @struktoai/mirage-dsh",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-plugin-vetting",
+   "owner": "truelove-dreamer",
+   "url": "https://github.com/truelove-dreamer/dsh-plugin-vetting",
+   "page": "https://awesome-dsh-plugin.com/p/truelove-dreamer/dsh-plugin-vetting/",
+   "category": "dev",
+   "description": {
+    "en": "Heuristic vetting of installed third-party plugins: static scan for exfiltration, credential access, obfuscation, and persistence patterns, plus an optional runtime subprocess tripwire.",
+    "zh": "第三方插件启发式体检：静态扫描网络外传、凭据访问、代码混淆、持久化等可疑模式并按权重打分（SAFE/LOW/MEDIUM/HIGH），可选运行时子进程绊线（只记不改）。"
+   },
+   "npm": "dsh-plugin-vetting",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-plugin-vetting",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "dsh-restart",
+   "owner": "anweat",
+   "url": "https://github.com/anweat/dsh-restart",
+   "page": "https://awesome-dsh-plugin.com/p/anweat/dsh-restart/",
+   "category": "dev",
+   "description": {
+    "en": "Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.",
+    "zh": "DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。"
+   },
+   "npm": "dsh-restart",
+   "stars": 2,
+   "install": "dsh plugin --profile web add dsh-restart",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-movein",
+   "owner": "sjh9714",
+   "url": "https://github.com/sjh9714/dsh-movein",
+   "page": "https://awesome-dsh-plugin.com/p/sjh9714/dsh-movein/",
+   "category": "dev",
+   "description": {
+    "en": "Move a whole Claude Code setup into DSH. Skills, MCP servers, hooks, subagents and permission rules, with a dry-run moving estimate and a migration diff report; installs as a plugin exposing a movein_from_claude_code tool so the agent can do the move for you.",
+    "zh": "把整套 Claude Code 配置搬进 DSH：技能、MCP、hooks、子代理、权限规则，默认先出搬家清单预演并输出迁移差异报告；作为插件提供 movein_from_claude_code 工具，直接让 agent 帮你搬。"
+   },
+   "npm": "dsh-movein",
+   "stars": 0,
+   "install": "dsh plugin --profile web add dsh-movein",
+   "added": "2026-08-15"
   },
   {
    "name": "dsh-ads",
    "owner": "Nagi-ovo",
    "url": "https://github.com/Nagi-ovo/dsh-ads",
+   "page": "https://awesome-dsh-plugin.com/p/Nagi-ovo/dsh-ads/",
    "category": "fun",
    "description": {
     "en": "Parody ads in 2005-Chinese-web style: sidebar banners, in-chat feeds, corner popups, and a close button whose hit area is smaller than it looks. All fictional.",
     "zh": "2005 年中文站点风格的整活广告插件：侧栏广告/信息流/角落弹窗 + 假关闭叉，素材全虚构。"
    },
    "npm": null,
-   "stars": 277,
+   "stars": 357,
    "install": "dsh plugin --profile web add github:Nagi-ovo/dsh-ads",
    "added": "2026-08-13"
   },
@@ -3163,13 +6655,14 @@
    "name": "dsh-gomoku",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-gomoku",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-gomoku/",
    "category": "fun",
    "description": {
     "en": "Play Gomoku against the AI, or let two AIs battle it out.",
     "zh": "与 AI 下五子棋，也可让 AI 对局比棋力。"
    },
    "npm": null,
-   "stars": 10,
+   "stars": 13,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-gomoku",
    "added": "2026-08-13"
   },
@@ -3177,13 +6670,14 @@
    "name": "dsh-stock-market",
    "owner": "AnacondaKC",
    "url": "https://github.com/AnacondaKC/dsh-stock-market",
+   "page": "https://awesome-dsh-plugin.com/p/AnacondaKC/dsh-stock-market/",
    "category": "fun",
    "description": {
     "en": "Fixes the bug where your account can't lose money while you code.",
     "zh": "有效解决了写代码的时候账户不能同时亏钱的 BUG。"
    },
    "npm": null,
-   "stars": 9,
+   "stars": 11,
    "install": "dsh plugin --profile web add github:AnacondaKC/dsh-stock-market",
    "added": "2026-08-13"
   },
@@ -3191,13 +6685,14 @@
    "name": "dsh-emoji",
    "owner": "hellodigua",
    "url": "https://github.com/hellodigua/dsh-emoji",
+   "page": "https://awesome-dsh-plugin.com/p/hellodigua/dsh-emoji/",
    "category": "fun",
    "description": {
     "en": "Automatically add emojis to AI replies.",
     "zh": "为 AI 回复自动添加表情。"
    },
    "npm": null,
-   "stars": 9,
+   "stars": 17,
    "install": "dsh plugin --profile web add github:hellodigua/dsh-emoji",
    "added": "2026-08-13"
   },
@@ -3205,13 +6700,14 @@
    "name": "dsh-minigames",
    "owner": "lhh010",
    "url": "https://github.com/lhh010/dsh-minigames",
+   "page": "https://awesome-dsh-plugin.com/p/lhh010/dsh-minigames/",
    "category": "fun",
    "description": {
     "en": "Side-panel arcade: 18 offline mini-games to play while the model thinks.",
     "zh": "右侧小游戏面板：18 款离线小游戏，等模型回复时的摸鱼神器。"
    },
    "npm": null,
-   "stars": 11,
+   "stars": 14,
    "install": "dsh plugin --profile web add github:lhh010/dsh-minigames",
    "added": "2026-08-13"
   },
@@ -3219,13 +6715,14 @@
    "name": "dsh-stickers",
    "owner": "william-jin-cmu",
    "url": "https://github.com/william-jin-cmu/dsh-stickers",
+   "page": "https://awesome-dsh-plugin.com/p/william-jin-cmu/dsh-stickers/",
    "category": "fun",
    "description": {
     "en": "Bidirectional sticker reactions between user and agent.",
     "zh": "用户与 agent 双向表情贴纸互动。"
    },
    "npm": null,
-   "stars": 8,
+   "stars": 13,
    "install": "dsh plugin --profile web add github:william-jin-cmu/dsh-stickers",
    "added": "2026-08-13"
   },
@@ -3233,13 +6730,14 @@
    "name": "whale-girl",
    "owner": "vlln",
    "url": "https://github.com/vlln/whale-girl",
+   "page": "https://awesome-dsh-plugin.com/p/vlln/whale-girl/",
    "category": "fun",
    "description": {
     "en": "Desktop pet (QQ-pet style): floats in the corner, draggable, feedable, playable.",
     "zh": "桌面宠物（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍。"
    },
    "npm": null,
-   "stars": 106,
+   "stars": 141,
    "install": "dsh plugin --profile web add github:vlln/whale-girl",
    "added": "2026-08-13"
   },
@@ -3247,13 +6745,14 @@
    "name": "deepseek-manners",
    "owner": "Moeblack",
    "url": "https://github.com/Moeblack/deepseek-manners",
+   "page": "https://awesome-dsh-plugin.com/p/Moeblack/deepseek-manners/",
    "category": "fun",
    "description": {
     "en": "Append a thank-you note after every message. Mind your manners.",
     "zh": "给每次消息后注入感谢语，做个有礼貌的人。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 10,
    "install": "dsh plugin --profile web add github:Moeblack/deepseek-manners",
    "added": "2026-08-13"
   },
@@ -3261,13 +6760,14 @@
    "name": "dsh-plugin-d399",
    "owner": "HuanLinOTO",
    "url": "https://github.com/HuanLinOTO/dsh-plugin-d399",
+   "page": "https://awesome-dsh-plugin.com/p/HuanLinOTO/dsh-plugin-d399/",
    "category": "fun",
    "description": {
     "en": "Pops up a mini-game menu (wordle, match-3, extensible) while the model generates.",
     "zh": "模型生成时弹出小游戏菜单（wordle/消消乐，可扩展）。"
    },
    "npm": null,
-   "stars": 4,
+   "stars": 5,
    "install": "dsh plugin --profile web add github:HuanLinOTO/dsh-plugin-d399",
    "added": "2026-08-13"
   },
@@ -3275,13 +6775,14 @@
    "name": "dsh-auto-chess",
    "owner": "omdsh-dev",
    "url": "https://github.com/omdsh-dev/dsh-auto-chess",
+   "page": "https://awesome-dsh-plugin.com/p/omdsh-dev/dsh-auto-chess/",
    "category": "fun",
    "description": {
     "en": "Auto chess: human vs AI, or AI vs AI.",
     "zh": "自走棋：人机对战或双 AI 对弈。"
    },
    "npm": null,
-   "stars": 2,
+   "stars": 3,
    "install": "dsh plugin --profile web add github:omdsh-dev/dsh-auto-chess",
    "added": "2026-08-13"
   },
@@ -3289,6 +6790,7 @@
    "name": "dsh-douyin",
    "owner": "AnacondaKC",
    "url": "https://github.com/AnacondaKC/dsh-douyin",
+   "page": "https://awesome-dsh-plugin.com/p/AnacondaKC/dsh-douyin/",
    "category": "fun",
    "description": {
     "en": "Short-video sidebar: native player, series navigation, precise history replay.",
@@ -3303,71 +6805,106 @@
    "name": "DeepSeek-Harness-Pet",
    "owner": "minybear",
    "url": "https://github.com/minybear/DeepSeek-Harness-Pet",
+   "page": "https://awesome-dsh-plugin.com/p/minybear/DeepSeek-Harness-Pet/",
    "category": "fun",
    "description": {
     "en": "Codex-style desktop pet: a floating animated sprite in the corner that mirrors the agent's running state (working, waiting, failed, done).",
     "zh": "Codex 风格桌面宠物：右下角悬浮动画精灵，随 agent 运行状态实时变化（工作、等待、报错、完成）。"
    },
    "npm": null,
-   "stars": 0,
+   "stars": 2,
    "install": "dsh plugin --profile web add github:minybear/DeepSeek-Harness-Pet",
    "added": "2026-08-14"
   },
   {
-   "name": "dsh-web-search-pro",
-   "owner": "anweat",
-   "url": "https://github.com/anweat/dsh-web-search-pro",
+   "name": "dsh-expression",
+   "owner": "yyh-001",
+   "url": "https://github.com/yyh-001/dsh-expression",
+   "page": "https://awesome-dsh-plugin.com/p/yyh-001/dsh-expression/",
    "category": "fun",
    "description": {
-    "en": "Persistent enhanced web search: multi-engine routing (DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/Xiaohongshu/Twitter/Reddit/RSS), SQLite+LRU cache, userscript-style extraction, Playwright rendering.",
-    "zh": "增强型、可持久化的网页搜索：多引擎路由（DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/Twitter/Reddit/RSS）、SQLite+LRU 缓存、userscript 风格抽取、Playwright 渲染。"
+    "en": "Meme search, the fun way: describe the vibe, and the agent finds and sends a real meme that actually fits.",
+    "zh": "陪 AI 斗图的搞笑插件：说个感觉，AI 帮你搜到、发出那张恰到好处的真实表情包。"
    },
-   "npm": "dsh-web-search-pro",
+   "npm": "dsh-expression",
    "stars": 3,
-   "install": "dsh plugin --profile web add dsh-web-search-pro",
+   "install": "dsh plugin --profile web add dsh-expression",
    "added": "2026-08-14"
   },
   {
-   "name": "dsh-browser",
-   "owner": "anweat",
-   "url": "https://github.com/anweat/dsh-browser",
+   "name": "dsh-pet#dsh-pet",
+   "owner": "PC2005-cloud",
+   "url": "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet",
+   "page": "https://awesome-dsh-plugin.com/p/PC2005-cloud/dsh-pet--dsh-pet/",
    "category": "fun",
    "description": {
-    "en": "Self-contained browser runtime: Playwright (chromium) + OpenCLI as plugin-local dependencies (global reuse fallback), exposes a `browser` service and 9 interactive browser tools.",
-    "zh": "自包含浏览器运行时：Playwright（chromium）+ OpenCLI 作为插件本地依赖（全局复用回退），提供 `browser` 服务与 9 个交互式浏览器工具。"
+    "en": "Desktop pet for the DSH Web UI with 25 transparent animations, screen wandering, click reactions and drag, plus a reproducible asset-generation pipeline.",
+    "zh": "DSH Web UI 桌面宠物：25 个透明动画、屏幕漫游、点击反应与拖拽，附可复现的素材生成链。"
    },
-   "npm": "@anweat/dsh-browser",
-   "stars": 1,
-   "install": "dsh plugin --profile web add @anweat/dsh-browser",
+   "npm": "dsh-pet",
+   "stars": 19,
+   "install": "dsh plugin --profile web add dsh-pet",
    "added": "2026-08-14"
   },
   {
-   "name": "dsh-voice-webspeech",
-   "owner": "anweat",
-   "url": "https://github.com/anweat/dsh-voice-webspeech",
+   "name": "dsh-MusicPlayer",
+   "owner": "xiekai886",
+   "url": "https://github.com/xiekai886/dsh-MusicPlayer",
+   "page": "https://awesome-dsh-plugin.com/p/xiekai886/dsh-MusicPlayer/",
    "category": "fun",
    "description": {
-    "en": "Browser Web Speech API voice input: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).",
-    "zh": "浏览器 Web Speech API 语音输入：零服务端、零密钥、零模型下载（Edge=Azure 语音、Chrome=Google 语音）。"
+    "en": "A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search — chat and listen at the same time.",
+    "zh": "可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。"
    },
-   "npm": "dsh-voice-webspeech",
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:xiekai886/dsh-MusicPlayer",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-LorebookMD",
+   "owner": "609476965",
+   "url": "https://github.com/609476965/dsh-LorebookMD",
+   "page": "https://awesome-dsh-plugin.com/p/609476965/dsh-LorebookMD/",
+   "category": "fun",
+   "description": {
+    "en": "Import SillyTavern/TavernAI character cards and world books, save them as local Markdown lore documents, and generate novel prose from your prompts with the world settings as reference.",
+    "zh": "导入酒馆（SillyTavern/TavernAI）角色卡与世界书，落地为本地 Markdown 设定文档，激活创作模式后根据用户输入、参考世界书创作小说。"
+   },
+   "npm": null,
+   "stars": 3,
+   "install": "dsh plugin --profile web add github:609476965/dsh-LorebookMD",
+   "added": "2026-08-14"
+  },
+  {
+   "name": "dsh-stock-watch",
+   "owner": "Awu12277",
+   "url": "https://github.com/Awu12277/dsh-stock-watch",
+   "page": "https://awesome-dsh-plugin.com/p/Awu12277/dsh-stock-watch/",
+   "category": "fun",
+   "description": {
+    "en": "A-share watchlist real-time market monitoring plugin: a collapsible popup in the top-right corner of the DeepSeek Harness (DSH) web interface for real-time quote monitoring, group switching, intraday and candlestick (K-line) charts, and buy/sell target price settings.",
+    "zh": "A 股自选股实时行情盯盘插件：在 DeepSeek Harness（DSH）Web 界面的右上角显示一个可折叠弹窗，实时监控自选股行情、切换分组、查看分时与 K 线、设置买卖目标价。"
+   },
+   "npm": null,
+   "stars": 2,
+   "install": "dsh plugin --profile web add github:Awu12277/dsh-stock-watch",
+   "added": "2026-08-15"
+  },
+  {
+   "name": "clippy-harness#plugin",
+   "owner": "sjh9714",
+   "url": "https://github.com/sjh9714/clippy-harness/tree/master/plugin",
+   "page": "https://awesome-dsh-plugin.com/p/sjh9714/clippy-harness--plugin/",
+   "category": "fun",
+   "description": {
+    "en": "Clippy is back and this time he can actually help. An office assistant pet that reacts to real agent state, jumps when the turn completes, and opens a classic \"illegal operation\" dialog when a turn fails.",
+    "zh": "回形针助手回来了，这次它真的会干活：会对真实 agent 状态做出反应的办公助手宠物，任务完成时跳起来庆祝，回合失败时弹出经典的 \"illegal operation\" 对话框。"
+   },
+   "npm": "dsh-clippy",
    "stars": 0,
-   "install": "dsh plugin --profile web add dsh-voice-webspeech",
-   "added": "2026-08-14"
-  },
-  {
-   "name": "dsh-restart",
-   "owner": "anweat",
-   "url": "https://github.com/anweat/dsh-restart",
-   "category": "fun",
-   "description": {
-    "en": "Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.",
-    "zh": "DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。"
-   },
-   "npm": "dsh-restart",
-   "stars": 1,
-   "install": "dsh plugin --profile web add dsh-restart",
-   "added": "2026-08-14"
+   "install": "dsh plugin --profile web add dsh-clippy",
+   "added": "2026-08-15"
   }
  ]
 }


### PR DESCRIPTION
Refreshes data/registry-snapshot.json with the current https://awesome-dsh-plugin.com/plugins.json (the catalog the market serves), using the repo's own snapshot script command (curl plugins.json). This brings in plugins listed since the last refresh, including dsh-telegram-duty.