### PR TITLE
[codex] fix: remove live bundle entries during uninstall

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -39,7 +39,7 @@ export interface WebServerService {
 
 export interface MarketHost {
   webServer: WebServerService
-  loader: { entries(): Iterable<LoaderEntry> }
+  loader: { entries(): Iterable<LoaderEntry>; remove(id: string): Promise<void> }
   plugin(plugin: unknown, config: unknown): { await(): Promise<unknown>; dispose(): Promise<unknown> | void }
   on?(event: string, callback: (fiber: { entry?: { options?: { name?: string } } }) => void): () => void
   logger?: { info?(message: string): void; warn(message: string): void }
@@ -106,6 +106,27 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
       await hotUnmount(name)
       logEvent('warn', 'hot-sweep', `${name}: package removed outside the market — live mount dropped`)
     }
+  }
+
+  /**
+   * A package removal deletes client assets immediately, while a bundle-layer
+   * loader entry stays alive until the host restarts. Remove those live
+   * entries first so the next page refresh cannot import a deleted bundle.
+   */
+  async function removeLiveEntries(name: string): Promise<boolean> {
+    let removed = false
+    for (const entry of [...host.loader.entries()]) {
+      if (entry.options.name !== name || entry.fiber === undefined) continue
+      try {
+        await host.loader.remove(entry.id)
+        removed = true
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        host.logger?.warn(`[dsh-market] live-remove ${name} failed: ${message}`)
+        logEvent('warn', 'uninstall', `${name}: live loader entry removal failed: ${message}`)
+      }
+    }
+    return removed
   }
 
   /** Every plugin command goes through the pnpm-drift recovery wrapper (#20). */
@@ -492,6 +513,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             if (ok) {
               invalidateUpdates()
               hot = await hotUnmount(name)
+              if (await removeLiveEntries(name)) hot = true
             }
             logEvent(ok || cancelled ? 'info' : 'error', 'uninstall',
               `${name} exit=${String(result.exitCode)}${cancelled ? ' CANCELLED' : ''}${ok ? ` live-removed=${String(hot)}` : cancelled ? '' : ` stderr=${result.stderr.slice(-300)}`}`)

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -13,6 +13,7 @@ import { repoOf } from './sources.ts'
 
 /** The slice of a cordis loader entry the market needs for live enable/disable. */
 export interface LoaderEntry {
+  id: string
   options: { id?: string; name?: string; disabled?: boolean | null }
   fiber?: unknown
   update(options: { disabled: boolean | null }, create?: boolean, force?: boolean): Promise<void>

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -199,13 +199,15 @@ type Handler = (request: unknown, response: unknown) => void | Promise<void>
 
 interface Testbed {
   dispatch(method: string, path: string, body?: unknown, options?: { crossOrigin?: boolean; remoteAddress?: string; forwarded?: boolean }): Promise<{ status: number; json: any }>
-  loaderEntries: { options: { name: string; disabled?: boolean | null }; fiber?: unknown; update(o: { disabled: boolean | null }): Promise<void> }[]
+  loaderEntries: { id: string; options: { name: string; disabled?: boolean | null }; fiber?: unknown; update(o: { disabled: boolean | null }): Promise<void> }[]
+  loaderRemovals: string[]
   dispose(): void
 }
 
 function createTestbed(config: { allowRestart?: boolean } = {}): Testbed {
   const routes = new Map<string, Handler>()
   const loaderEntries: Testbed['loaderEntries'] = []
+  const loaderRemovals: string[] = []
   const host = {
     webServer: {
       register(route: { path: string; handler: Handler }) {
@@ -213,7 +215,14 @@ function createTestbed(config: { allowRestart?: boolean } = {}): Testbed {
         return () => routes.delete(route.path)
       },
     },
-    loader: { entries: () => loaderEntries },
+    loader: {
+      entries: () => loaderEntries,
+      remove: async (id: string) => {
+        loaderRemovals.push(id)
+        const index = loaderEntries.findIndex(entry => entry.id === id)
+        if (index !== -1) loaderEntries.splice(index, 1)
+      },
+    },
     plugin: () => ({ await: () => Promise.resolve(), dispose: () => {} }),
     on: () => () => {},
   }
@@ -243,7 +252,7 @@ function createTestbed(config: { allowRestart?: boolean } = {}): Testbed {
     try { json = JSON.parse(payload) } catch { /* non-JSON (logs route) */ }
     return { status, json }
   }
-  return { dispatch, loaderEntries, dispose }
+  return { dispatch, loaderEntries, loaderRemovals, dispose }
 }
 
 // ---------------------------------------------------------------- suite
@@ -455,6 +464,24 @@ describe('market self-update', () => {
     const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dshmarket' })
     expect(r.status).toBe(200)
     expect(installedSpec('dshmarket')).toBe('^1.2.3')
+  })
+})
+
+describe('bundle-layer uninstall (#37)', () => {
+  it('removes its live loader entry so refreshing cannot import deleted client files', async () => {
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: { bundle: {} }, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+    bed.loaderEntries.push({
+      id: 'bundle-dsh-loop', options: { name: 'dsh-loop' }, fiber: {},
+      update: () => Promise.resolve(),
+    })
+
+    const r = await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(200)
+    expect(r.json.hot).toBe(true)
+    expect(bed.loaderRemovals).toEqual(['bundle-dsh-loop'])
+    expect(bed.loaderEntries).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes #37.

When a bundle-layer plugin is uninstalled, `dsh plugin remove` deletes its package files but the active host loader entry can remain alive. A following page refresh then imports client assets that no longer exist, leaving the Web UI unable to load until DSH is restarted.

This change removes matching active loader entries after a successful uninstall, in addition to the existing hot-mount cleanup.

## Changes

- Extend the market host loader contract with `remove(id)`.
- Remove matching active loader entries after a successful plugin uninstall.
- Snapshot loader entries before removal so iteration is not affected by loader mutations.
- Log and continue if removal of an individual live entry fails.
- Add a regression flow test for bundle-layer plugin uninstall.

## Root cause

The existing `hotUnmount(name)` cleanup only handles client-only hot mounts. Bundle-layer plugins are served by the host loader and are not listed as hot mounts, so their live entries remained after package files were removed.

## Verification

- [x] `npm test -- --run tests/flows.spec.ts` — 25 tests passed.
- [x] `npm run typecheck` — both TypeScript configurations passed.
- [x] `git diff --check`

## Scope

- No changes to install, update, or restart behavior.
- No changes to the plugin catalog or package-management command behavior.
- No general plugin enable/disable feature added.