### PR TITLE
fix(dshmarket): accept version-qualified names in approve-builds and allow retry of failed installs

### DIFF
--- a/src/ndjson.ts
+++ b/src/ndjson.ts
@@ -138,7 +138,13 @@ export function createProgressTracker(): ProgressTracker {
       snap.seen = true
       if (Array.isArray(msg.packageNames)) {
         for (const pkg of msg.packageNames) {
-          if (typeof pkg === 'string' && !snap.ignoredBuilds.includes(pkg)) snap.ignoredBuilds.push(pkg)
+          // pnpm's ndjson event reports version-qualified names (cloudflared@0.7.3);
+          // the approve-builds allowlist keys and node_modules lookups use bare
+          // package names, so strip the suffix (same rule as the human-line
+          // fallback in install.ts's parseIgnoredBuilds).
+          const at = typeof pkg === 'string' ? pkg.lastIndexOf('@') : -1
+          const bare = at > 0 ? pkg.slice(0, at) : pkg
+          if (typeof bare === 'string' && bare !== '' && !snap.ignoredBuilds.includes(bare)) snap.ignoredBuilds.push(bare)
         }
       }
       return

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -474,9 +474,16 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           // scripts are usually TRANSITIVE deps (cloudflared, ssh2,
           // cpu-features…), which never appear in package.json (#56 by
           // @walnut1218).
+          // pnpm 11's ndjson `ignored-scripts` event reports version-qualified
+          // names (cloudflared@0.7.3); strip the @version suffix so the
+          // allowlist keys and node_modules lookups use bare package names.
+          const stripVersion = (name: string): string => {
+            const at = name.lastIndexOf('@')
+            return at > 0 ? name.slice(0, at) : name
+          }
           const PKG_RE = /^(@[A-Za-z0-9-~][A-Za-z0-9._~-]*\/)?[A-Za-z0-9-~][A-Za-z0-9._~-]*$/
           const body = (await readJsonBody(request)) as { packages?: unknown }
-          const packages = (Array.isArray(body.packages) ? body.packages.map(String) : [])
+          const packages = (Array.isArray(body.packages) ? body.packages.map(String).map(stripVersion) : [])
             .filter(name => PKG_RE.test(name)
               && existsSync(join(profileDir(config.profile), 'node_modules', name, 'package.json')))
           if (packages.length === 0) {
@@ -629,16 +636,46 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           // twice — two loader entries with one id brick the next boot.
           // Monorepo subpath entries (distinct plugins in one repo) pass:
           // their entry urls differ by subpath and identity is name-based.
-          const aliasOf = findInstalledAlias(entry, readInstalled(config.profile))
+          // A dependency left in package.json by a FAILED install (blocked
+          // build scripts: pnpm writes the manifest, then exits 1) is NOT a
+          // duplicate — it was never activated. Blocking the retry would
+          // make the approve-builds flow dead-end, so a leftover that is the
+          // SAME package/source (not a repo-only alias of a different entry)
+          // and is not yet active (bundle layer or live mount) may be retried.
+          const installedNow = readInstalled(config.profile)
+          const aliasOf = findInstalledAlias(entry, installedNow)
+          // When the duplicate guard allows a retry of a leftover dep, that
+          // name must be treated as "newly added" by the post-install
+          // validation and hot-mount below (it IS in package.json from the
+          // failed attempt, so the plain before/after diff would miss it).
+          let retryAlias: string | null = null
           if (aliasOf !== null) {
-            logEvent('warn', 'install-rejected', `${entry.name}: same plugin already installed as ${aliasOf}`)
-            sendJson(response, 400, { error: `已以「${aliasOf}」安装过同一个插件，无需重复安装 / this plugin is already installed as "${aliasOf}"` })
-            return
+            // Same install? The leftover's own name/spec must match what we
+            // are about to add — an npm entry retries under its npm name; a
+            // github entry's package.json spec equals the target.
+            const sameSource = aliasOf.toLowerCase() === (entry.npm ?? '').toLowerCase()
+              || String(installedNow[aliasOf] ?? '').replace(/^file:/, '').toLowerCase() === String(target).replace(/^file:/, '').toLowerCase()
+            let active = false
+            try {
+              const manifest = JSON.parse(readFileSync(join(profileDir(config.profile), 'package.json'), 'utf8')) as { dsh?: { profile?: { bundles?: string[] } } }
+              active = (manifest.dsh?.profile?.bundles ?? []).includes(aliasOf) || liveNames().has(aliasOf)
+            } catch {
+              // unreadable manifest — treat as active to stay safe
+              active = true
+            }
+            if (active || !sameSource) {
+              logEvent('warn', 'install-rejected', `${entry.name}: same plugin already installed as ${aliasOf}`)
+              sendJson(response, 400, { error: `已以「${aliasOf}」安装过同一个插件，无需重复安装 / this plugin is already installed as "${aliasOf}"` })
+              return
+            }
+            retryAlias = aliasOf
+            logEvent('info', 'install', `${entry.name}: ${aliasOf} present but inactive (leftover of a failed install) — retrying`)
           }
           installing = true
           try {
             const beforeSpecs = readInstalled(config.profile)
             const before = new Set(Object.keys(beforeSpecs))
+            if (retryAlias !== null) before.delete(retryAlias)
             const result = await runPlugin(config.profile, ['add', target])
             const cancelled = result.cancelled
             let ok = result.exitCode === 0 && !result.timedOut && !cancelled
@@ -693,6 +730,12 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             }
             logEvent(ok || cancelled ? 'info' : 'error', 'install',
               `${target} exit=${String(result.exitCode)}${result.timedOut ? ' TIMEOUT' : ''}${cancelled ? ' CANCELLED' : ''}${ok ? ` hot=${String(hot)}` : cancelled ? '' : ` stderr=${result.stderr.slice(-300)}`}`)
+            const ignoredBuilds = (() => {
+              // Prefer the structured event (pnpm 11 ndjson) over the human line.
+              if (Array.isArray(result.ignoredBuilds) && result.ignoredBuilds.length > 0) return result.ignoredBuilds
+              const list = parseIgnoredBuilds(result.stdout, result.stderr)
+              return list.length > 0 ? list : undefined
+            })()
             sendJson(response, ok || cancelled ? 200 : 502, {
               ok,
               cancelled: cancelled || undefined,
@@ -700,13 +743,15 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
               partial: cancelDiff?.partial,
               changed: cancelDiff?.changed,
               activation,
-              ignoredBuilds: (() => {
-                // Prefer the structured event (pnpm 11 ndjson) over the human line.
-                if (Array.isArray(result.ignoredBuilds) && result.ignoredBuilds.length > 0) return result.ignoredBuilds
-                const list = parseIgnoredBuilds(result.stdout, result.stderr)
-                return list.length > 0 ? list : undefined
-              })(),
-              error: notAPlugin ? 'nothing installable: the plugin(s) need a build step (blocked by default, see allowBuilds) or ship no prebuilt artifacts / 没有可安装的内容：插件需要构建授权（allowBuilds，默认拦截）或未附带构建产物，详见导出日志' : undefined,
+              ignoredBuilds,
+              // Blocked build scripts are expected (pnpm >= 10 blocks them by
+              // default): surface the approve-builds banner instead of scaring
+              // the user with pnpm's raw stack.
+              error: notAPlugin
+                ? 'nothing installable: the plugin(s) need a build step (blocked by default, see allowBuilds) or ship no prebuilt artifacts / 没有可安装的内容：插件需要构建授权（allowBuilds，默认拦截）或未附带构建产物，详见导出日志'
+                : Array.isArray(ignoredBuilds) && ignoredBuilds.length > 0
+                  ? `构建脚本被 pnpm 默认拦截（${ignoredBuilds.join(', ')}），请点击上方按钮放行后重试 / build scripts are blocked by pnpm by default (${ignoredBuilds.join(', ')}); click "Allow build scripts and retry" above`
+                  : undefined,
               exitCode: result.exitCode,
               timedOut: result.timedOut,
               stdout: result.stdout,

--- a/tests/ndjson.spec.ts
+++ b/tests/ndjson.spec.ts
@@ -68,6 +68,21 @@ describe('pnpm ndjson progress parser', () => {
     expect(snap.ignoredBuilds).toEqual(['esbuild', 'koffi'])
   })
 
+  it('strips @version suffixes from ignored-scripts names (pnpm 11 ndjson)', () => {
+    // pnpm 11's `pnpm:ignored-scripts` event reports version-qualified names
+    // (cloudflared@0.7.3), but the approve-builds allowlist keys and
+    // node_modules lookups use bare package names.
+    const snap = feed([
+      '{"time":1,"name":"pnpm:ignored-scripts","packageNames":["cloudflared@0.7.3","cpu-features@0.0.10","ssh2@1.17.0","@scope/pkg@1.2.3"]}',
+    ])
+    expect(snap.ignoredBuilds).toEqual(['cloudflared', 'cpu-features', 'ssh2', '@scope/pkg'])
+    // scoped bare names and duplicates stay untouched
+    const snap2 = feed([
+      '{"time":1,"name":"pnpm:ignored-scripts","packageNames":["@scope/pkg","cloudflared@0.7.3","cloudflared@0.7.3"]}',
+    ])
+    expect(snap2.ignoredBuilds).toEqual(['@scope/pkg', 'cloudflared'])
+  })
+
   it('captures the fatal error message from the stream', () => {
     const snap = feed([
       '{"time":1,"name":"pnpm","level":"error","prefix":"p","err":{"name":"pnpm","message":"Unexpected token \\"{\\" is not valid JSON","stack":"at JSON.parse"}}',


### PR DESCRIPTION
pnpm 11's ndjson `pnpm:ignored-scripts` event reports **version-qualified** package names (`cloudflared@0.7.3`), but the approve-builds route's `PKG_RE` and `existsSync(node_modules/<name>)` only accept bare package names. Every package was filtered out → `400 "no installed packages given"`, so the one-click **"Allow build scripts and retry"** flow silently did nothing.

Additionally, a failed `pnpm add` (blocked build scripts) already writes the dependency into package.json (manifest is written before the build-script check runs). On retry, the install route's duplicate guard treated that leftover as "already installed" ("已以「…」安装过同一个插件"), dead-ending the flow even after a successful approval.

## Changes
- **ndjson.ts**: strip `@version` suffixes from `pnpm:ignored-scripts` names, matching the human-line fallback in `install.ts`'s `parseIgnoredBuilds`.
- **routes.ts (approve-builds)**: defensively strip `@version` suffixes before `PKG_RE`/`existsSync` validation, so version-qualified names from pnpm 11 ndjson are accepted.
- **routes.ts (install)**: only reject the duplicate guard when the matched dependency is **active** (bundle layer or live mount) or a genuinely different source; a same-source leftover of a failed install is retried and excluded from the `before` set so post-install validation and hot-mount treat it as newly added.
- **routes.ts (install)**: surface a friendly bilingual message instead of pnpm's raw stack when build scripts are blocked.
- **tests/ndjson.spec.ts**: regression test for version-stripping (incl. scoped names + dedupe).

## Repro
```sh
dsh plugin --profile web add dshmarket
dsh plugin --profile web add @linxin666/dsh-web-ui-all  # transitive deps cloudflared/cpu-features/ssh2 have build scripts
```
Expected: `ERR_PNPM_IGNORED_BUILDS` exit 1 with the dep already written to package.json; clicking "Allow build scripts and retry" currently 400s and dead-ends. After this fix the approval is accepted and the retry install completes (exit 0, bundle activated).

## Test status
- `tsc -p tsconfig.json --noEmit`: clean
- `vitest run`: 93/93 pass (12 files), including the new regression test