### PR TITLE
fix: live check must match bundle entries named as package subpaths

### DIFF
--- a/src/verify.ts
+++ b/src/verify.ts
@@ -53,6 +53,24 @@ interface PkgDsh {
   client?: unknown
 }
 
+/**
+ * True when `live` contains the package itself or a subpath entry of it.
+ *
+ * The live set (see `liveNames` in routes.ts) holds loader entry names — the
+ * `name:` field of each bundle patch row. Bundles usually name the bare
+ * package (`dshmarket`, `@scope/pkg`), but may point at a subpath entry
+ * (`@vectorize-io/hindsight-coding-agents/dsh`, `aegis/extensions/dsh/index.js`).
+ * Either form means the package's fiber is up and it must read as live;
+ * a different package sharing a name prefix (`@scope/pkg2` vs `@scope/pkg`)
+ * must not — the `/` bound keeps the match a real subpath.
+ */
+function liveIncludes(live: ReadonlySet<string>, packageName: string): boolean {
+  if (live.has(packageName)) return true
+  const prefix = `${packageName}/`
+  for (const name of live) if (name.startsWith(prefix)) return true
+  return false
+}
+
 function readPkgDsh(profile: string, name: string): PkgDsh | null {
   try {
     const manifest = JSON.parse(
@@ -110,7 +128,7 @@ export function verifyActivation(
     }
   }
 
-  if (live.has(name)) {
+  if (liveIncludes(live, name)) {
     const clientOnly = dsh.bundle === undefined && dsh.client !== undefined
     return {
       state: 'live',

--- a/tests/verify.spec.ts
+++ b/tests/verify.spec.ts
@@ -92,4 +92,32 @@ describe('verifyActivation (P0-2)', () => {
     pkg('dsh-loop', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'index.js' }, { 'index.js': '', 'cordis.patch.yml': SIMPLE_PATCH })
     expect(verifyActivation('web', 'dsh-loop', new Set())).toMatchObject({ state: 'restart', bundle: true })
   })
+
+  it('live when the bundle entry name is a scoped subpath of the package (patch name ≠ package name)', () => {
+    profile(['@vectorize-io/hindsight-coding-agents'])
+    pkg('@vectorize-io/hindsight-coding-agents',
+      { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'index.js' },
+      { 'index.js': '', 'cordis.patch.yml': SIMPLE_PATCH })
+    // liveNames() reports loader entry names — the patch's `name:` field, which
+    // may be a subpath (`@vectorize-io/hindsight-coding-agents/dsh`) rather than
+    // the bare package name. The fiber being up must still read as live.
+    expect(verifyActivation('web', '@vectorize-io/hindsight-coding-agents',
+      new Set(['@vectorize-io/hindsight-coding-agents/dsh']))).toMatchObject({ state: 'live', hot: true, bundle: true })
+  })
+
+  it('live when the bundle entry name is an unscoped subpath of the package (e.g. aegis)', () => {
+    profile(['aegis'])
+    pkg('aegis',
+      { dsh: { bundle: { patch: './extensions/dsh/cordis.patch.yml' } }, main: 'index.js' },
+      { 'index.js': '' })
+    expect(verifyActivation('web', 'aegis', new Set(['aegis/extensions/dsh/index.js']))).toMatchObject({ state: 'live', hot: true, bundle: true })
+  })
+
+  it('does not treat a similarly-prefixed different package as live', () => {
+    profile(['dsh-loop'])
+    pkg('dsh-loop', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'index.js' }, { 'index.js': '', 'cordis.patch.yml': SIMPLE_PATCH })
+    // 'dsh-loop-tool' is a distinct package; only an exact name or a real
+    // `name/` subpath entry counts as the package being live.
+    expect(verifyActivation('web', 'dsh-loop', new Set(['dsh-loop-tool']))).toMatchObject({ state: 'restart', bundle: true })
+  })
 })


### PR DESCRIPTION
## Problem / 问题

`verifyActivation` reports a running bundle-layer plugin as **"restart"** ("已进入 profile bundle 层但本次未能热挂载;重启后生效") in the plugin inventory after every boot, even though its loader fiber is up — the plugin is actually working.

`liveNames()` (routes.ts) builds the live set from **loader entry names** — the `name:` field of each bundle patch row. Most bundles name the bare package (`dshmarket`, `@scope/pkg`), which matches the package-name lookup in `verifyActivation` exactly. But bundles that point at a **subpath entry** never match:

- `@vectorize-io/hindsight-coding-agents` → patch row `name: "@vectorize-io/hindsight-coding-agents/dsh"`
- `aegis` → patch row `name: "aegis/extensions/dsh/index.js"`

For these, `live.has(packageName)` is always false, so the inventory shows "restart" indefinitely — misleading users into restarting (or believing the plugin is broken) when it is already live.

## Fix / 修复

Match the package name itself **or any `name/` subpath entry** in the live set, with the `/` bound so a similarly-prefixed different package (e.g. `@scope/pkg2` vs `@scope/pkg`) never reads as live.

## Tests / 测试

Adds regression tests (red first) covering:
- scoped subpath entry: `@vectorize-io/hindsight-coding-agents/dsh` → live
- unscoped subpath entry: `aegis/extensions/dsh/index.js` → live
- prefix-bound: `dsh-loop-tool` must NOT make `dsh-loop` live

## Verification / 验证

- `npm test`: 95 passed (12 files)
- `npm run typecheck`: clean

Fixes #71 — bundle-layer subpath entries always read as "restart".
