### PR TITLE
feat: use DSH Desktop profile and pnpm services

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ dsh plugin --profile web add dshmarket
 
 Restart `dsh web`, then open **Settings → Plugin Market**.
 
+### DSH Desktop
+
+On DSH Desktop builds that expose the public `desktopProfiles` and
+`desktopPnpm` services, install from **Open DSH Terminal** with:
+
+```sh
+dsh plugin add dshmarket
+```
+
+The market automatically targets the immutable active Desktop profile and
+uses Desktop's packaged pnpm operation service. It does not probe or install a
+system pnpm, and Desktop keeps ownership of application restart. Ordinary DSH
+continues to use the existing profile/argv/CLI path when those services are
+absent. The detection order follows Desktop's supported
+[cross-environment plugin contract](https://github.com/anywhere-labs/deepseek-harness-desktop/blob/4f68147091e585aaa1d815f99d30a657b3842d7c/dsh-plugin-desktop/docs/plugin-services.md#cross-environment-plugin-optional-desktop-adapter-and-ordinary-dsh-fallback).
+This compatibility does not mean the market is bundled with Desktop.
+
 ## What you get
 
 - **Browse & search** the full community catalog (300+ plugins, growing daily) — category filters, star counts, top/new sorting, bilingual descriptions that follow your UI language
@@ -68,7 +85,7 @@ Live from [awesome-dsh-plugin.com/plugins.json](https://awesome-dsh-plugin.com/p
 
 ### DeepSeek Harness Desktop
 
-[DeepSeek Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) is a modern desktop client for the DeepSeek Harness ecosystem — start and manage a local Harness service without installing Node.js or touching the command line. Plugin marketplace, mobile remote control, and IM Channels are on its roadmap.
+[DeepSeek Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) is a modern desktop client for the DeepSeek Harness ecosystem — start and manage a local Harness service without a system Node.js installation. Compatible builds can host a user-installed dsh-market through their public profile and package-operation services; bundling remains a Desktop project decision.
 
 [Website](https://www.dshdesktop.cn) · [GitHub](https://github.com/anywhere-labs/deepseek-harness-desktop)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -25,6 +25,21 @@ dsh plugin --profile web add dshmarket
 
 重启 `dsh web`，打开 **设置 → 插件市场**。
 
+### DSH Desktop
+
+如果 DSH Desktop 版本提供公开的 `desktopProfiles` 与 `desktopPnpm`
+服务，可从 **Open DSH Terminal** 安装：
+
+```sh
+dsh plugin add dshmarket
+```
+
+市场会自动使用该代 Desktop 已锁定的活动 profile，以及 Desktop 内置的
+pnpm 操作服务；不会探测或安装系统 pnpm，应用重启仍由 Desktop 负责。
+没有这些服务的普通 DSH 会继续使用现有 profile/argv/CLI 路径。检测顺序遵循
+Desktop 支持的[跨环境插件 contract](https://github.com/anywhere-labs/deepseek-harness-desktop/blob/4f68147091e585aaa1d815f99d30a657b3842d7c/dsh-plugin-desktop/docs/plugin-services.zh.md#跨环境插件可选-desktop-adapter-与普通-dsh-fallback)。
+兼容 Desktop 并不代表市场已预装或捆绑进 Desktop。
+
 ## 你会得到
 
 - **逛与搜**——完整社区目录（300+ 插件，每天在涨），分类筛选、star 数、最热/最新排序，中英描述跟随界面语言
@@ -68,7 +83,7 @@ dsh plugin --profile web add dshmarket
 
 ### DeepSeek Harness Desktop
 
-[DeepSeek Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) 是一款为 DeepSeek Harness 生态打造的现代化桌面端，让用户无需配置 Node.js 或执行命令，即可启动和管理本地 Harness 服务。项目后续还将支持插件市场、移动端远程控制和 IM Channels。
+[DeepSeek Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) 是一款为 DeepSeek Harness 生态打造的现代化桌面端，无需在系统中安装 Node.js 即可启动和管理本地 Harness 服务。兼容版本可通过公开的 profile 与包操作服务运行用户自行安装的 dsh-market；是否预装仍由 Desktop 项目决定。
 
 [访问官网](https://www.dshdesktop.cn) · [GitHub](https://github.com/anywhere-labs/deepseek-harness-desktop)
 

--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -10,7 +10,7 @@
 import { spawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
 import { homedir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { logEvent } from './log.ts'
 import { createProgressTracker, type ProgressPhase } from './ndjson.ts'
 import { pluginArgsFor } from './pnpm-compat.ts'
@@ -70,12 +70,44 @@ export interface InstallResult {
   stderr: string
   /** True when the run ended because the user cancelled it. */
   cancelled: boolean
+  /** Desktop's generation-wide package-operation gate rejected the start. */
+  busy?: boolean
   /** Package names pnpm reported as having ignored build scripts (ndjson). */
   ignoredBuilds?: string[]
 }
 
 /** The shape every orchestration function takes to run plugin commands (injectable in tests). */
 export type PluginRunner = (profile: string, pluginArgs: string[]) => Promise<InstallResult>
+
+/** Package-operation boundary consumed by the HTTP route layer. */
+export interface PluginCommandRuntime {
+  runPlugin: PluginRunner
+  probePnpm(): Promise<boolean>
+  provisionPnpm(): Promise<{ ok: boolean; hint?: string }>
+  cancelActive(): boolean
+}
+
+/** Structural subset of DSH Desktop's public `desktopPnpm` contract. */
+export interface DesktopPnpmLike {
+  runPlugin(
+    args: readonly string[],
+    invokingDir: string,
+    signal?: AbortSignal,
+  ): {
+    readonly stdout: NodeJS.ReadableStream
+    readonly stderr: NodeJS.ReadableStream
+    readonly done: Promise<{
+      readonly exitCode: number | null
+      readonly signal: NodeJS.Signals | null
+    }>
+    cancel(): void
+  }
+}
+
+/** Desktop runtime also owns cleanup of any operation started by this fiber. */
+export interface DesktopPluginRuntime extends PluginCommandRuntime {
+  dispose(): Promise<void>
+}
 
 /**
  * Kill a spawned child and, on Windows, its whole process tree — `kill()`
@@ -95,6 +127,15 @@ export function killChild(child: ChildProcess): void {
 /** The child of the operation currently running, for /dsh-market/cancel. */
 let activeChild: ChildProcess | null = null
 let cancelRequested = false
+
+interface ActiveDesktopOperation {
+  readonly owner: symbol
+  readonly cancel: () => void
+  readonly done: Promise<InstallResult>
+  userCancelled: boolean
+}
+
+let activeDesktopOperation: ActiveDesktopOperation | null = null
 
 /**
  * Kill a child and its whole tree, gracefully where the platform allows:
@@ -129,6 +170,12 @@ function killTree(child: ChildProcess): void {
  * @returns true when there was one to cancel.
  */
 export function cancelActive(): boolean {
+  if (activeDesktopOperation !== null) {
+    activeDesktopOperation.userCancelled = true
+    progress.cancelling = true
+    activeDesktopOperation.cancel()
+    return true
+  }
   if (activeChild === null) return false
   cancelRequested = true
   progress.cancelling = true
@@ -246,6 +293,38 @@ const TARGET_RE = /^[A-Za-z0-9@:./_#+-]+$/
 /** Mutating pnpm commands get the structured reporter appended. */
 const NDJSON_COMMANDS = new Set(['add', 'remove', 'install'])
 
+/** Apply profile-specific pnpm compatibility and the structured reporter. */
+function preparePluginArgs(profileDirectory: string, pluginArgs: readonly string[]): {
+  args: string[]
+  target: string
+} | { error: string } {
+  let args = pluginArgsFor(profileDirectory, [...pluginArgs])
+  const target = args[args.length - 1] ?? ''
+  if (!TARGET_RE.test(target)) {
+    return { error: `unsafe plugin target rejected: ${JSON.stringify(target)}` }
+  }
+  if (NDJSON_COMMANDS.has(args[0])) args = [...args, '--reporter=ndjson']
+  return { args, target }
+}
+
+/** Reset the singleton status snapshot before one operation starts. */
+function beginProgress(target: string): ReturnType<typeof createProgressTracker> {
+  progress.active = true
+  progress.target = target
+  progress.startedAt = Date.now()
+  progress.lastLine = ''
+  progress.phase = null
+  progress.done = 0
+  progress.total = null
+  progress.currentPackage = null
+  progress.downloaded = null
+  progress.size = null
+  progress.ndjson = false
+  progress.error = null
+  progress.cancelling = false
+  return createProgressTracker()
+}
+
 /**
  * Line-buffered progress feed: pnpm's ndjson reporter emits one JSON object
  * per line on stdout, and chunk boundaries can split a line. Human fallback
@@ -271,29 +350,13 @@ function makeProgressFeeder(tracker: ReturnType<typeof createProgressTracker>): 
 /** Run one `dsh plugin --profile <p> …` command with timeout and progress tracking. */
 export function runDshPlugin(profile: string, pluginArgs: string[]): Promise<InstallResult> {
   const { file, args, cwd, viaShell } = dshArgv()
-  pluginArgs = pluginArgsFor(profileDir(profile), pluginArgs)
-  const target = pluginArgs[pluginArgs.length - 1] ?? ''
-  if (!TARGET_RE.test(target)) {
-    logEvent('error', 'install', `unsafe plugin target rejected: ${JSON.stringify(target)}`)
-    return Promise.resolve({ exitCode: 1, timedOut: false, stdout: '', stderr: `unsafe plugin target rejected: ${JSON.stringify(target)}`, cancelled: false })
+  const prepared = preparePluginArgs(profileDir(profile), pluginArgs)
+  if ('error' in prepared) {
+    logEvent('error', 'install', prepared.error)
+    return Promise.resolve({ exitCode: 1, timedOut: false, stdout: '', stderr: prepared.error, cancelled: false })
   }
-  // pnpm's structured reporter must be appended after the target is extracted
-  // (the allowlist above validates the last argument).
-  if (NDJSON_COMMANDS.has(pluginArgs[0])) pluginArgs = [...pluginArgs, '--reporter=ndjson']
-  progress.active = true
-  progress.target = target
-  progress.startedAt = Date.now()
-  progress.lastLine = ''
-  progress.phase = null
-  progress.done = 0
-  progress.total = null
-  progress.currentPackage = null
-  progress.downloaded = null
-  progress.size = null
-  progress.ndjson = false
-  progress.error = null
-  progress.cancelling = false
-  const tracker = createProgressTracker()
+  pluginArgs = prepared.args
+  const tracker = beginProgress(prepared.target)
   const feed = makeProgressFeeder(tracker)
   return new Promise((resolvePromise) => {
     const child = spawn(file, [...args, 'plugin', '--profile', profile, ...pluginArgs], {
@@ -354,6 +417,154 @@ export function runDshPlugin(profile: string, pluginArgs: string[]): Promise<Ins
       })
     })
   })
+}
+
+/**
+ * Adapt DSH Desktop's generation-scoped package manager to the existing
+ * market runner. There is no runtime import or dependency on Desktop: the
+ * Host supplies this public service only when the package is mounted there.
+ */
+export function createDesktopPluginRuntime(
+  service: DesktopPnpmLike,
+  activeProfileDir: string,
+  invokingDir = process.cwd(),
+  timeoutMs = INSTALL_TIMEOUT_MS,
+): DesktopPluginRuntime {
+  if (!isAbsolute(activeProfileDir) || activeProfileDir.includes('\0')) {
+    throw new Error('dsh-market: Desktop profile directory must be an absolute path without NUL')
+  }
+  if (!isAbsolute(invokingDir) || invokingDir.includes('\0')) {
+    throw new Error('dsh-market: Desktop invoking directory must be an absolute path without NUL')
+  }
+  const owner = Symbol('dsh-market desktop runtime')
+  let closed = false
+
+  const runPlugin: PluginRunner = async (_profile, pluginArgs) => {
+    if (closed) {
+      return {
+        exitCode: 127,
+        timedOut: false,
+        stdout: '',
+        stderr: 'dsh-market: Desktop package runtime is disposed',
+        cancelled: false,
+      }
+    }
+    const prepared = preparePluginArgs(activeProfileDir, pluginArgs)
+    if ('error' in prepared) {
+      logEvent('error', 'install', prepared.error)
+      return { exitCode: 1, timedOut: false, stdout: '', stderr: prepared.error, cancelled: false }
+    }
+
+    const abort = new AbortController()
+    let handle: ReturnType<DesktopPnpmLike['runPlugin']>
+    try {
+      handle = service.runPlugin(prepared.args, invokingDir, abort.signal)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const busy = /another desktop pnpm operation is already running/i.test(message)
+      return {
+        exitCode: 127,
+        timedOut: false,
+        stdout: '',
+        stderr: message,
+        cancelled: false,
+        ...(busy ? { busy: true } : {}),
+      }
+    }
+
+    const tracker = beginProgress(prepared.target)
+    const feed = makeProgressFeeder(tracker)
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    const collectStdout = (chunk: string | Buffer): void => {
+      const text = chunk.toString()
+      stdout = (stdout + text).slice(-256 * 1024)
+      feed(text)
+      syncProgress(tracker)
+    }
+    const collectStderr = (chunk: string | Buffer): void => {
+      const text = chunk.toString()
+      stderr = (stderr + text).slice(-64 * 1024)
+      feed(text)
+      syncProgress(tracker)
+    }
+    handle.stdout.on('data', collectStdout)
+    handle.stderr.on('data', collectStderr)
+
+    let active!: ActiveDesktopOperation
+    let timer: NodeJS.Timeout | undefined
+    const done = (async (): Promise<InstallResult> => {
+      try {
+        const outcome = await handle.done
+        const failed = outcome.exitCode !== 0 || outcome.signal !== null || timedOut
+        if (failed) progress.error = tracker.snapshot.error
+        const ignoredBuilds = tracker.snapshot.ignoredBuilds
+        return {
+          exitCode: outcome.exitCode,
+          timedOut,
+          stdout,
+          stderr,
+          cancelled: active.userCancelled,
+          ...(ignoredBuilds.length > 0 ? { ignoredBuilds } : {}),
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        progress.error = tracker.snapshot.error
+        return {
+          exitCode: 127,
+          timedOut,
+          stdout,
+          stderr: `${stderr}${stderr === '' ? '' : '\n'}${message}`,
+          cancelled: active.userCancelled,
+        }
+      } finally {
+        if (timer !== undefined) clearTimeout(timer)
+        progress.active = false
+        progress.cancelling = false
+        handle.stdout.off('data', collectStdout)
+        handle.stderr.off('data', collectStderr)
+        if (activeDesktopOperation === active) activeDesktopOperation = null
+      }
+    })()
+    active = { owner, cancel: () => { handle.cancel() }, done, userCancelled: false }
+    activeDesktopOperation = active
+    timer = setTimeout(() => {
+      timedOut = true
+      abort.abort(new Error('dsh-market: Desktop package operation timed out'))
+      // The public handle owns an explicit process-tree cancellation path.
+      // Use it as well as AbortSignal so a structurally compatible provider
+      // that does not observe the signal cannot strand the route or teardown.
+      handle.cancel()
+    }, timeoutMs)
+    timer.unref?.()
+    return done
+  }
+
+  const cancelOwned = (userCancelled: boolean): boolean => {
+    const active = activeDesktopOperation
+    if (active?.owner !== owner) return false
+    if (userCancelled) active.userCancelled = true
+    progress.cancelling = true
+    active.cancel()
+    return true
+  }
+
+  return {
+    runPlugin,
+    // The service is backed by Desktop's packaged pnpm; system discovery and
+    // global provisioning are neither needed nor allowed in this mode.
+    probePnpm: () => Promise.resolve(true),
+    provisionPnpm: () => Promise.resolve({ ok: true }),
+    cancelActive: () => cancelOwned(true),
+    dispose: async () => {
+      closed = true
+      const active = activeDesktopOperation
+      if (active?.owner !== owner) return
+      cancelOwned(false)
+      await active.done.catch(() => {})
+    },
+  }
 }
 
 /** Copy the tracker's snapshot into the singleton the status route reads. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,28 @@
  */
 
 import type { Context } from '@deepseek-ai/cordis'
+import { createDesktopPluginRuntime, type DesktopPnpmLike } from './dsh-cli.ts'
 import { mountMarketRoutes, type MarketConfig, type MarketHost } from './routes.ts'
 
 export const name = 'dsh-market'
 
 /** Optional cordis.yml configuration; profile defaults to `web`. */
-export type Config = Partial<MarketConfig>
+export type Config = Partial<Pick<MarketConfig, 'profile' | 'allowRestart'>>
+
+/** Structural subset of DSH Desktop's public `desktopProfiles` contract. */
+interface DesktopProfilesLike {
+  readonly current: {
+    readonly name: string
+    readonly dir: string
+  }
+}
+
+interface MarketEffectHost extends MarketHost {
+  effect(
+    callback: () => (() => void | Promise<void>),
+    label: string,
+  ): void
+}
 
 /**
  * Register the market against the host context.
@@ -29,14 +45,42 @@ function argvProfile(): string | undefined {
 }
 
 export function apply(ctx: Context, config?: Config): void {
-  const resolved: MarketConfig = {
-    profile: config?.profile ?? argvProfile() ?? 'web',
-    allowRestart: config?.allowRestart ?? true,
-  }
   ctx.inject(['webServer', 'loader'], (hostCtx: Context) => {
-    const host = hostCtx as unknown as MarketHost & {
-      effect(callback: () => () => void, label: string): void
+    const host = hostCtx as unknown as MarketEffectHost
+    const desktopProfiles = ctx.get('desktopProfiles') as DesktopProfilesLike | undefined
+    if (desktopProfiles === undefined) {
+      const resolved: MarketConfig = {
+        profile: config?.profile ?? argvProfile() ?? 'web',
+        allowRestart: config?.allowRestart ?? true,
+      }
+      host.effect(() => mountMarketRoutes(host, resolved), 'dsh-market: http routes')
+      return
     }
-    host.effect(() => mountMarketRoutes(host, resolved), 'dsh-market: http routes')
+
+    // Desktop's supported cross-environment contract guarantees that
+    // desktopProfiles exists before Loader entries mount, and prescribes this
+    // presence check plus a nested desktopPnpm injection:
+    // https://github.com/anywhere-labs/deepseek-harness-desktop/blob/4f68147091e585aaa1d815f99d30a657b3842d7c/dsh-plugin-desktop/docs/plugin-services.md#L190-L243
+    // Ordinary DSH keeps the existing CLI path above.
+    hostCtx.inject(['desktopPnpm'], (desktopCtx: Context) => {
+      const current = desktopProfiles.current
+      const service = (desktopCtx as unknown as { desktopPnpm: DesktopPnpmLike }).desktopPnpm
+      const runtime = createDesktopPluginRuntime(service, current.dir)
+      const resolved: MarketConfig = {
+        profile: current.name,
+        profileDirectory: current.dir,
+        // Relaunching a raw Electron process would bypass Desktop's launcher
+        // lifecycle. The shell remains responsible for restart in this mode.
+        allowRestart: false,
+      }
+      const desktopHost = desktopCtx as unknown as MarketEffectHost
+      desktopHost.effect(() => {
+        const disposeRoutes = mountMarketRoutes(host, resolved, runtime)
+        return async () => {
+          disposeRoutes()
+          await runtime.dispose()
+        }
+      }, 'dsh-market: Desktop http routes and package operations')
+    })
   })
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -67,18 +67,19 @@ export async function withHoistRecovery(run: PluginRunner, profile: string, plug
  * @returns overall success (true when nothing needed retargeting).
  */
 export async function retargetCollections(
-  run: PluginRunner, profile: string, before: Set<string>, target: string,
+  run: PluginRunner, profile: string, before: Set<string>, target: string, explicitDir?: string,
 ): Promise<boolean> {
   if (!target.startsWith('github:')) return true
-  const junk = Object.keys(readInstalled(profile)).filter((name) => {
+  const dir = profileDir(profile, explicitDir)
+  const junk = Object.keys(readInstalled(profile, dir)).filter((name) => {
     if (before.has(name)) return false
-    const root = join(profileDir(profile), 'node_modules', name)
+    const root = join(dir, 'node_modules', name)
     if (!existsSync(join(root, 'package.json'))) return true
     return !hasDshManifest(root)
   })
   let allOk = true
   for (const name of junk) {
-    const root = join(profileDir(profile), 'node_modules', name)
+    const root = join(dir, 'node_modules', name)
     const candidates = pluginSubdirs(root)
     logEvent('info', 'install', `${name}: collection repo (root declares no dsh manifest); plugins inside: ${candidates.join(', ') || 'none'}`)
     await run(profile, ['remove', name])
@@ -106,14 +107,15 @@ export async function retargetCollections(
  * @returns names kept and names removed as broken.
  */
 export async function validateAddedPlugins(
-  run: PluginRunner, profile: string, before: Set<string>,
+  run: PluginRunner, profile: string, before: Set<string>, explicitDir?: string,
 ): Promise<{ keep: string[]; removedBroken: string[] }> {
-  const addedNow = Object.keys(readInstalled(profile)).filter(n => !before.has(n))
+  const dir = profileDir(profile, explicitDir)
+  const addedNow = Object.keys(readInstalled(profile, dir)).filter(n => !before.has(n))
   const keep: string[] = []
   const removedBroken: string[] = []
   for (const n of addedNow) {
-    const dir = join(profileDir(profile), 'node_modules', n)
-    if (hasDshManifest(dir) && entryArtifactExists(dir)) {
+    const packageDir = join(dir, 'node_modules', n)
+    if (hasDshManifest(packageDir) && entryArtifactExists(packageDir)) {
       keep.push(n)
     } else {
       removedBroken.push(n)

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -8,8 +8,13 @@ import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
-/** Resolve a profile name to its directory under DSH_HOME (default ~/.dsh). */
-export function profileDir(profile: string): string {
+/**
+ * Resolve a profile name to its directory under DSH_HOME (default ~/.dsh).
+ * An explicit directory is used by hosts, such as DSH Desktop, that own the
+ * active profile location rather than deriving it from process environment.
+ */
+export function profileDir(profile: string, explicitDir?: string): string {
+  if (explicitDir !== undefined) return explicitDir
   const home = process.env.DSH_HOME ?? join(homedir(), '.dsh')
   return join(home, 'profiles', profile)
 }
@@ -28,9 +33,9 @@ const INBOX_BUNDLES = new Set([
 ])
 
 /** Community dependencies of the profile (in-box bundles filtered out). */
-export function readInstalled(profile: string): Record<string, string> {
+export function readInstalled(profile: string, explicitDir?: string): Record<string, string> {
   try {
-    const manifest = JSON.parse(readFileSync(join(profileDir(profile), 'package.json'), 'utf8')) as {
+    const manifest = JSON.parse(readFileSync(join(profileDir(profile, explicitDir), 'package.json'), 'utf8')) as {
       dependencies?: Record<string, string>
     }
     const installed: Record<string, string> = {}
@@ -48,9 +53,9 @@ export function readInstalled(profile: string): Record<string, string> {
  * readInstalled() filters out. This is the rollback snapshot (#65): restoring
  * a filtered view would delete @deepseek-ai/dsh-base and friends.
  */
-export function readManifestDeps(profile: string): Record<string, string> {
+export function readManifestDeps(profile: string, explicitDir?: string): Record<string, string> {
   try {
-    const manifest = JSON.parse(readFileSync(join(profileDir(profile), 'package.json'), 'utf8')) as {
+    const manifest = JSON.parse(readFileSync(join(profileDir(profile, explicitDir), 'package.json'), 'utf8')) as {
       dependencies?: Record<string, string>
     }
     return { ...manifest.dependencies }
@@ -70,8 +75,8 @@ export function readManifestDeps(profile: string): Record<string, string> {
  * manifest on the next run).
  * @returns names whose entries were dropped or reverted, empty when nothing changed.
  */
-export function restoreManifestDeps(profile: string, snapshot: Record<string, string>): string[] {
-  const file = join(profileDir(profile), 'package.json')
+export function restoreManifestDeps(profile: string, snapshot: Record<string, string>, explicitDir?: string): string[] {
+  const file = join(profileDir(profile, explicitDir), 'package.json')
   let manifest: { dependencies?: Record<string, string> }
   try {
     manifest = JSON.parse(readFileSync(file, 'utf8')) as { dependencies?: Record<string, string> }
@@ -89,10 +94,10 @@ export function restoreManifestDeps(profile: string, snapshot: Record<string, st
 }
 
 /** The version actually present in the profile's node_modules, or null. */
-export function readInstalledVersion(profile: string, name: string): string | null {
+export function readInstalledVersion(profile: string, name: string, explicitDir?: string): string | null {
   try {
     const manifest = JSON.parse(
-      readFileSync(join(profileDir(profile), 'node_modules', name, 'package.json'), 'utf8'),
+      readFileSync(join(profileDir(profile, explicitDir), 'node_modules', name, 'package.json'), 'utf8'),
     ) as { version?: string }
     return manifest.version ?? null
   } catch {
@@ -101,10 +106,10 @@ export function readInstalledVersion(profile: string, name: string): string | nu
 }
 
 /** Pinned commit per `owner/repo` from the profile lockfile's codeload tarball URLs. */
-export function readLockCommits(profile: string): Map<string, string> {
+export function readLockCommits(profile: string, explicitDir?: string): Map<string, string> {
   const commits = new Map<string, string>()
   try {
-    const lock = readFileSync(join(profileDir(profile), 'pnpm-lock.yaml'), 'utf8')
+    const lock = readFileSync(join(profileDir(profile, explicitDir), 'pnpm-lock.yaml'), 'utf8')
     for (const m of lock.matchAll(/codeload\.github\.com\/([^/\s]+\/[^/\s]+)\/tar\.gz\/([0-9a-f]{40})/g)) {
       commits.set(m[1].toLowerCase(), m[2])
     }
@@ -184,8 +189,8 @@ export function pluginSubdirs(root: string): string[] {
  * (#6 by @qichuang321.)
  * @returns every package now allowed.
  */
-export function setAllowBuilds(profile: string, packages: string[]): string[] {
-  const file = join(profileDir(profile), 'pnpm-workspace.yaml')
+export function setAllowBuilds(profile: string, packages: string[], explicitDir?: string): string[] {
+  const file = join(profileDir(profile, explicitDir), 'pnpm-workspace.yaml')
   let yaml = ''
   try { yaml = readFileSync(file, 'utf8') } catch { /* created below */ }
   const blockRe = /allowBuilds:\n((?:[ \t]+[^\n]*\n?)*)/

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -17,7 +17,10 @@ import {
   mountClientOnlyDeps, readDisabledThemes,
 } from './hot.ts'
 import { exportLogs, logEvent } from './log.ts'
-import { BOOT_ID, cancelActive, probePnpm, progress, provisionPnpm, runDshPlugin } from './dsh-cli.ts'
+import {
+  BOOT_ID, cancelActive, probePnpm, progress, provisionPnpm, runDshPlugin,
+  type PluginCommandRuntime,
+} from './dsh-cli.ts'
 import { profileDir, readInstalled, readInstalledVersion, readLockCommits, readManifestDeps, restoreManifestDeps, setAllowBuilds } from './profile.ts'
 import { findInstalledAlias, gitAllowBuildsKey, installTargetFor } from './sources.ts'
 import { isStaleUpdate, parseIgnoredBuilds, parsePrepareNotAllowed, RELEASE_AGE_OVERRIDE, retargetCollections, validateAddedPlugins, withHoistRecovery } from './install.ts'
@@ -49,6 +52,8 @@ export interface MarketHost {
 export interface MarketConfig {
   /** Profile the market installs into; matches the profile serving this UI. */
   profile: string
+  /** Host-authoritative profile directory; ordinary DSH derives it from DSH_HOME. */
+  profileDirectory?: string
   /** Detached self-restart is unsafe under systemd/launchd/pm2; operators can disable it (#14). */
   allowRestart?: boolean
 }
@@ -76,21 +81,30 @@ function blockedBuilds(result: { ignoredBuilds?: unknown; stdout: string; stderr
  * @param config - Validated market configuration.
  * @returns Disposer removing every registered route.
  */
-export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () => void {
-  if (!PROFILE_RE.test(config.profile)) {
+export function mountMarketRoutes(
+  host: MarketHost,
+  config: MarketConfig,
+  commandRuntime?: PluginCommandRuntime,
+): () => void {
+  // Ordinary DSH profile names cross the CLI boundary and keep the legacy
+  // allowlist. A host-authoritative explicit directory (DSH Desktop) may
+  // legitimately pair with a Unicode or spaced display/profile name.
+  if (config.profileDirectory === undefined && !PROFILE_RE.test(config.profile)) {
     throw new Error(`dsh-market: invalid profile name: ${config.profile}`)
   }
+  const activeProfileDir = profileDir(config.profile, config.profileDirectory)
+  const commands = commandRuntime ?? { runPlugin: runDshPlugin, probePnpm, provisionPnpm, cancelActive }
   // Boot-time wipe: stale hot-mount inputs from a previous session must never
   // survive into a composition where the bundle layer already covers them.
-  cleanHotDir(profileDir(config.profile))
+  cleanHotDir(activeProfileDir)
   // The user's persisted theme choice; activateTheme mutates and writes it.
-  const disabledThemes = readDisabledThemes(profileDir(config.profile))
-  const themes = createThemeManager(host, config.profile, disabledThemes)
+  const disabledThemes = readDisabledThemes(activeProfileDir)
+  const themes = createThemeManager(host, config.profile, disabledThemes, activeProfileDir)
 
   // Client-only packages (dsh.client without dsh.bundle) are invisible to the
   // bundle layer in every boot; the market shim-mounts them so their client
   // bundles are actually served.
-  void mountClientOnlyDeps(host, profileDir(config.profile)).then(async (mounted) => {
+  void mountClientOnlyDeps(host, activeProfileDir).then(async (mounted) => {
     if (mounted.length > 0) logEvent('info', 'boot', `client-only shims mounted: ${mounted.join(', ')}`)
     // Replay the user's theme choice: bundle-layer themes they switched away
     // from get live-disabled again (bundle trees are in-memory, so the
@@ -112,7 +126,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
 
   /** Dependency diff vs. a pre-operation snapshot (cancel aftermath). */
   function changedSince(before: Record<string, string>): { changed: string[]; partial: boolean } {
-    const now = readInstalled(config.profile)
+    const now = readInstalled(config.profile, activeProfileDir)
     const changed = new Set<string>()
     for (const [name, spec] of Object.entries(now)) if (before[name] !== spec) changed.add(name)
     for (const name of Object.keys(before)) if (now[name] === undefined) changed.add(name)
@@ -141,14 +155,14 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
    */
   async function dropStaleHotMounts(): Promise<void> {
     for (const name of listHotMounts()) {
-      if (existsSync(join(profileDir(config.profile), 'node_modules', name, 'package.json'))) continue
+      if (existsSync(join(activeProfileDir, 'node_modules', name, 'package.json'))) continue
       await hotUnmount(name)
       logEvent('warn', 'hot-sweep', `${name}: package removed outside the market — live mount dropped`)
     }
   }
 
   /** Every plugin command goes through the pnpm-drift recovery wrapper (#20). */
-  const runPlugin = (profile: string, args: string[]) => withHoistRecovery(runDshPlugin, profile, args)
+  const runPlugin = (profile: string, args: string[]) => withHoistRecovery(commands.runPlugin, profile, args)
 
   const disposers = [
     host.webServer.register({
@@ -179,10 +193,12 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           return
         }
         await dropStaleHotMounts()
-        const installed = readInstalled(config.profile)
+        const installed = readInstalled(config.profile, activeProfileDir)
         const activation: Record<string, ReturnType<typeof verifyActivation>> = {}
         const live = liveNames()
-        for (const name of Object.keys(installed)) activation[name] = verifyActivation(config.profile, name, live)
+        for (const name of Object.keys(installed)) {
+          activation[name] = verifyActivation(config.profile, name, live, activeProfileDir)
+        }
         sendJson(response, 200, {
           profile: config.profile,
           installed,
@@ -208,7 +224,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
         try {
           const body = (await readJsonBody(request)) as { name?: unknown }
           const name = typeof body.name === 'string' ? body.name : ''
-          const installed = readInstalled(config.profile)
+          const installed = readInstalled(config.profile, activeProfileDir)
           const themeNames = await themes.installedThemeNames()
           if (installed[name] === undefined || !themeNames.has(name)) {
             sendJson(response, 400, { error: 'not an installed theme' })
@@ -249,10 +265,10 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           ndjson: progress.ndjson,
           error: progress.error,
           cancelling: progress.cancelling,
-          pnpm: await probePnpm(),
+          pnpm: await commands.probePnpm(),
           boot: BOOT_ID,
           restart: restartAllowed(config),
-          installed: readInstalled(config.profile),
+          installed: readInstalled(config.profile, activeProfileDir),
         })
       },
     }),
@@ -295,7 +311,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
         }
         try {
           const force = (request.url ?? '').includes('force=1')
-          sendJson(response, 200, { updates: await checkUpdates(config.profile, force) })
+          sendJson(response, 200, { updates: await checkUpdates(config.profile, force, activeProfileDir) })
         } catch (error) {
           sendJson(response, 500, { error: error instanceof Error ? error.message : String(error) })
         }
@@ -323,7 +339,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           const body = (await readJsonBody(request)) as { name?: unknown; force?: unknown }
           const name = typeof body.name === 'string' ? body.name : ''
           const force = body.force === true
-          const spec = readInstalled(config.profile)[name]
+          const spec = readInstalled(config.profile, activeProfileDir)[name]
           if (spec === undefined) {
             sendJson(response, 400, { error: 'plugin is not installed' })
             return
@@ -332,7 +348,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             sendJson(response, 400, { error: 'locally linked plugins update from their checkout' })
             return
           }
-          const beforeInstalled = readInstalled(config.profile)
+          const beforeInstalled = readInstalled(config.profile, activeProfileDir)
           // Re-running add re-resolves the source: git HEAD for github specs,
           // dist-tag latest for registry installs.
           const isGit = spec.startsWith('github:')
@@ -343,7 +359,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           // `@latest`. Detection already hides the button; this guards the
           // route itself. Unreadable versions fall through and update as before.
           if (!isGit) {
-            const installedVersion = readInstalledVersion(config.profile, name)
+            const installedVersion = readInstalledVersion(config.profile, name, activeProfileDir)
             const registryLatest = await fetchNpmLatest(name)
             if (installedVersion !== null && registryLatest !== null && !isUpgrade(installedVersion, registryLatest)) {
               logEvent('info', 'update', `${name} refused: latest=${registryLatest} is not newer than installed=${installedVersion}`)
@@ -354,8 +370,10 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             }
           }
           const repoKey = isGit ? spec.slice('github:'.length).replace(/#.*$/, '').toLowerCase() : null
-          const beforeVersion = readInstalledVersion(config.profile, name)
-          const beforeCommit = repoKey !== null ? readLockCommits(config.profile).get(repoKey) ?? null : null
+          const beforeVersion = readInstalledVersion(config.profile, name, activeProfileDir)
+          const beforeCommit = repoKey !== null
+            ? readLockCommits(config.profile, activeProfileDir).get(repoKey) ?? null
+            : null
           installing = true
           try {
             // force: the user chose to install a fresh release without the
@@ -364,11 +382,11 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             // RAW manifest snapshot for failure rollback (#65) — pnpm writes
             // package.json before it finishes, so a hard-failed add leaves
             // ghost/bumped entries that break every later pnpm run.
-            const manifestBefore = readManifestDeps(config.profile)
+            const manifestBefore = readManifestDeps(config.profile, activeProfileDir)
             const result = await runPlugin(config.profile, addArgs)
             const cancelled = result.cancelled
             if ((result.exitCode !== 0 || result.timedOut) && !cancelled) {
-              const rolledBack = restoreManifestDeps(config.profile, manifestBefore)
+              const rolledBack = restoreManifestDeps(config.profile, manifestBefore, activeProfileDir)
               if (rolledBack.length > 0) logEvent('warn', 'update', `${name}: rolled back manifest residue of the failed run: ${rolledBack.join(', ')}`)
             }
             let ok = result.exitCode === 0 && !result.timedOut && !cancelled
@@ -378,15 +396,17 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
               stale = isStaleUpdate({
                 isGit,
                 beforeVersion,
-                afterVersion: readInstalledVersion(config.profile, name),
+                afterVersion: readInstalledVersion(config.profile, name, activeProfileDir),
                 beforeCommit,
-                afterCommit: repoKey !== null ? readLockCommits(config.profile).get(repoKey) ?? null : null,
+                afterCommit: repoKey !== null
+                  ? readLockCommits(config.profile, activeProfileDir).get(repoKey) ?? null
+                  : null,
               })
               if (stale) ok = false
             }
             if (ok) {
               invalidateUpdates()
-              activation = { [name]: verifyActivation(config.profile, name, liveNames()) }
+              activation = { [name]: verifyActivation(config.profile, name, liveNames(), activeProfileDir) }
             }
             // Diagnose the stale outcome with EVIDENCE (#45 by @ayingQAQ):
             // only blame pnpm's fresh-release wait when the target's latest
@@ -409,9 +429,10 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             logEvent(ok || cancelled ? 'info' : 'error', 'update',
               `${name} -> ${target} exit=${String(result.exitCode)}${result.timedOut ? ' TIMEOUT' : ''}${cancelled ? ' CANCELLED' : ''}${stale ? ` STALE(${staleReason ?? 'unknown'})` : ''}${ok || cancelled ? '' : ` stderr=${result.stderr.slice(-300)}`}`)
             // A user-cancelled run is a quiet outcome, not an error.
-            sendJson(response, ok || cancelled ? 200 : 502, {
+            sendJson(response, ok || cancelled ? 200 : result.busy === true ? 409 : 502, {
               ok,
               cancelled: cancelled || undefined,
+              busy: result.busy || undefined,
               stale: stale || undefined,
               partial: cancelDiff?.partial,
               changed: cancelDiff?.changed,
@@ -423,7 +444,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
               timedOut: result.timedOut,
               stdout: result.stdout,
               stderr: result.stderr,
-              installed: readInstalled(config.profile),
+              installed: readInstalled(config.profile, activeProfileDir),
             })
           } finally {
             installing = false
@@ -451,7 +472,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           return
         }
         try {
-          const result = await provisionPnpm()
+          const result = await commands.provisionPnpm()
           sendJson(response, 200, { ok: result.ok, error: result.hint })
         } catch (error) {
           sendJson(response, 500, { error: error instanceof Error ? error.message : String(error) })
@@ -532,7 +553,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           const requested = (Array.isArray(body.packages) ? body.packages.map(String).map(stripVersion) : [])
             .filter(name => PKG_RE.test(name))
           const installed = requested
-            .filter(name => existsSync(join(profileDir(config.profile), 'node_modules', name, 'package.json')))
+            .filter(name => existsSync(join(activeProfileDir, 'node_modules', name, 'package.json')))
           // Git-hosted plugins rejected by pnpm's FETCHER (#68) exist in
           // neither node_modules nor package.json — the only trusted anchor
           // left is the curated registry itself: a name that resolves to a
@@ -544,7 +565,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           // the github source is known: from the profile spec for installed
           // deps, from the curated registry for pending ones. The bare name
           // is kept alongside — it authorizes the npm-sourced case.
-          const specs = readInstalled(config.profile)
+          const specs = readInstalled(config.profile, activeProfileDir)
           const packages: string[] = []
           for (const name of requested) {
             if (installed.includes(name)) {
@@ -566,7 +587,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             sendJson(response, 400, { error: 'no installed packages given' })
             return
           }
-          const approved = setAllowBuilds(config.profile, packages)
+          const approved = setAllowBuilds(config.profile, packages, activeProfileDir)
           logEvent('info', 'approve-builds', `allowed build scripts: ${approved.join(', ')}`)
           sendJson(response, 200, { ok: true, approved })
         } catch (error) {
@@ -591,7 +612,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           return
         }
         // Cancel flow contributed in #6 by @qichuang321.
-        if (!cancelActive()) {
+        if (!commands.cancelActive()) {
           sendJson(response, 400, { error: 'no operation is running' })
           return
         }
@@ -624,12 +645,14 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             sendJson(response, 400, { error: 'the market cannot uninstall itself; use the dsh CLI' })
             return
           }
-          if (readInstalled(config.profile)[name] === undefined) {
+          if (readInstalled(config.profile, activeProfileDir)[name] === undefined) {
             sendJson(response, 400, { error: 'plugin is not installed' })
             return
           }
-          const beforeInstalled = readInstalled(config.profile)
-          const activation = { [name]: verifyActivation(config.profile, name, liveNames()) }
+          const beforeInstalled = readInstalled(config.profile, activeProfileDir)
+          const activation = {
+            [name]: verifyActivation(config.profile, name, liveNames(), activeProfileDir),
+          }
           installing = true
           try {
             const result = await runPlugin(config.profile, ['remove', name])
@@ -650,9 +673,10 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             }
             logEvent(ok || cancelled ? 'info' : 'error', 'uninstall',
               `${name} exit=${String(result.exitCode)}${cancelled ? ' CANCELLED' : ''}${ok ? ` live-removed=${String(hot)}` : cancelled ? '' : ` stderr=${result.stderr.slice(-300)}`}`)
-            sendJson(response, ok || cancelled ? 200 : 502, {
+            sendJson(response, ok || cancelled ? 200 : result.busy === true ? 409 : 502, {
               ok,
               cancelled: cancelled || undefined,
+              busy: result.busy || undefined,
               hot,
               partial: cancelDiff?.partial,
               changed: cancelDiff?.changed,
@@ -661,7 +685,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
               exitCode: result.exitCode,
               stdout: result.stdout,
               stderr: result.stderr,
-              installed: readInstalled(config.profile),
+              installed: readInstalled(config.profile, activeProfileDir),
             })
           } finally {
             installing = false
@@ -718,7 +742,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           // make the approve-builds flow dead-end, so a leftover that is the
           // SAME package/source (not a repo-only alias of a different entry)
           // and is not yet active (bundle layer or live mount) may be retried.
-          const installedNow = readInstalled(config.profile)
+          const installedNow = readInstalled(config.profile, activeProfileDir)
           const aliasOf = findInstalledAlias(entry, installedNow)
           // When the duplicate guard allows a retry of a leftover dep, that
           // name must be treated as "newly added" by the post-install
@@ -733,7 +757,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
               || String(installedNow[aliasOf] ?? '').replace(/^file:/, '').toLowerCase() === String(target).replace(/^file:/, '').toLowerCase()
             let active = false
             try {
-              const manifest = JSON.parse(readFileSync(join(profileDir(config.profile), 'package.json'), 'utf8')) as { dsh?: { profile?: { bundles?: string[] } } }
+              const manifest = JSON.parse(readFileSync(join(activeProfileDir, 'package.json'), 'utf8')) as { dsh?: { profile?: { bundles?: string[] } } }
               active = (manifest.dsh?.profile?.bundles ?? []).includes(aliasOf) || liveNames().has(aliasOf)
             } catch {
               // unreadable manifest — treat as active to stay safe
@@ -767,7 +791,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           }
           installing = true
           try {
-            const beforeSpecs = readInstalled(config.profile)
+            const beforeSpecs = readInstalled(config.profile, activeProfileDir)
             const before = new Set(Object.keys(beforeSpecs))
             if (retryAlias !== null) before.delete(retryAlias)
             // RAW manifest snapshot for failure rollback (#65): pnpm writes
@@ -775,11 +799,11 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             // run, so a hard-failed add leaves ghost dependencies that break
             // every later pnpm run — of anything. Cancelled runs keep their
             // partial state on purpose (the user sees the diff and decides).
-            const manifestBefore = readManifestDeps(config.profile)
+            const manifestBefore = readManifestDeps(config.profile, activeProfileDir)
             const result = await runPlugin(config.profile, ['add', target])
             const cancelled = result.cancelled
             if ((result.exitCode !== 0 || result.timedOut) && !cancelled) {
-              const rolledBack = restoreManifestDeps(config.profile, manifestBefore)
+              const rolledBack = restoreManifestDeps(config.profile, manifestBefore, activeProfileDir)
               if (rolledBack.length > 0) logEvent('warn', 'install', `${target}: rolled back manifest residue of the failed run: ${rolledBack.join(', ')}`)
             }
             let ok = result.exitCode === 0 && !result.timedOut && !cancelled
@@ -789,7 +813,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
               // Collection repos (e.g. skin monorepos) install as a junk
               // fileset with no root package.json; retarget to the real
               // plugin subdirectories via pnpm's #path: selector.
-              ok = await retargetCollections(runPlugin, config.profile, before, target)
+              ok = await retargetCollections(runPlugin, config.profile, before, target, activeProfileDir)
             }
             // Fake-success guard (#18): a clean exit that added nothing
             // installable must not read as success. Runs even when
@@ -798,7 +822,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
             let notAPlugin = false
             let removedBroken: string[] = []
             if (result.exitCode === 0 && !result.timedOut && !cancelled) {
-              const validated = await validateAddedPlugins(runPlugin, config.profile, before)
+              const validated = await validateAddedPlugins(runPlugin, config.profile, before, activeProfileDir)
               removedBroken = validated.removedBroken
               if (removedBroken.length > 0) {
                 logEvent('warn', 'install', `${target}: removed uninstallable pieces (no dsh manifest or missing build artifacts): ${removedBroken.join(', ')}`)
@@ -812,7 +836,7 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
                 ok = true
               }
             }
-            const installed = readInstalled(config.profile)
+            const installed = readInstalled(config.profile, activeProfileDir)
             let hot = false
             let activation: Record<string, ReturnType<typeof verifyActivation>> | undefined
             if (ok) {
@@ -824,20 +848,23 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
                 for (const name of added) {
                   const live = entry.category === 'theme'
                     ? await themes.activateTheme(name)
-                    : (await hotMount(host, profileDir(config.profile), name)).ok
+                    : (await hotMount(host, activeProfileDir, name)).ok
                   if (!live) hot = false
                 }
                 activation = {}
                 const live = liveNames()
-                for (const name of added) activation[name] = verifyActivation(config.profile, name, live)
+                for (const name of added) {
+                  activation[name] = verifyActivation(config.profile, name, live, activeProfileDir)
+                }
               }
             }
             logEvent(ok || cancelled ? 'info' : 'error', 'install',
               `${target} exit=${String(result.exitCode)}${result.timedOut ? ' TIMEOUT' : ''}${cancelled ? ' CANCELLED' : ''}${ok ? ` hot=${String(hot)}` : cancelled ? '' : ` stderr=${result.stderr.slice(-300)}`}`)
             const ignoredBuilds = blockedBuilds(result)
-            sendJson(response, ok || cancelled ? 200 : 502, {
+            sendJson(response, ok || cancelled ? 200 : result.busy === true ? 409 : 502, {
               ok,
               cancelled: cancelled || undefined,
+              busy: result.busy || undefined,
               hot,
               partial: cancelDiff?.partial,
               changed: cancelDiff?.changed,

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -36,7 +36,13 @@ export interface ThemeManager {
  * themes the user switched off — the caller owns reading it at boot and
  * replaying it; the manager mutates and persists it on switches.
  */
-export function createThemeManager(host: ThemeHost, profile: string, disabledThemes: Set<string>): ThemeManager {
+export function createThemeManager(
+  host: ThemeHost,
+  profile: string,
+  disabledThemes: Set<string>,
+  explicitDir?: string,
+): ThemeManager {
+  const activeProfileDir = profileDir(profile, explicitDir)
   /** Installed package names classified as themes by the registry's theme category. */
   async function installedThemeNames(): Promise<Set<string>> {
     const names = new Set<string>()
@@ -47,7 +53,7 @@ export function createThemeManager(host: ThemeHost, profile: string, disabledThe
       const themeRepos = new Set(
         themeEntries.map(p => repoOf(p.url)).filter((r): r is string => r !== null).map(r => r.toLowerCase()),
       )
-      for (const [name, spec] of Object.entries(readInstalled(profile))) {
+      for (const [name, spec] of Object.entries(readInstalled(profile, activeProfileDir))) {
         if (themeNames.has(name)) {
           names.add(name)
           continue
@@ -98,7 +104,6 @@ export function createThemeManager(host: ThemeHost, profile: string, disabledThe
    * it up. The choice persists in state.json and is replayed at boot.
    */
   async function activateTheme(name: string): Promise<boolean> {
-    const dir = profileDir(profile)
     const themes = await installedThemeNames()
     for (const other of themes) {
       if (other === name) continue
@@ -110,10 +115,10 @@ export function createThemeManager(host: ThemeHost, profile: string, disabledThe
       }
     }
     disabledThemes.delete(name)
-    writeDisabledThemes(dir, disabledThemes)
+    writeDisabledThemes(activeProfileDir, disabledThemes)
     if (listHotMounts().includes(name)) return true
     if (await setEntryDisabled(name, false)) return true
-    return (await hotMount(host, dir, name)).ok
+    return (await hotMount(host, activeProfileDir, name)).ok
   }
 
   return { installedThemeNames, setEntryDisabled, activateTheme }

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -4,7 +4,7 @@
  * dist-tag for registry installs — with a TTL cache.
  */
 
-import { readInstalled, readInstalledVersion, readLockCommits } from './profile.ts'
+import { profileDir, readInstalled, readInstalledVersion, readLockCommits } from './profile.ts'
 
 export interface UpdateStatus {
   kind: 'github' | 'npm' | 'linked'
@@ -15,7 +15,7 @@ export interface UpdateStatus {
 }
 
 const UPDATES_TTL_MS = 30 * 60 * 1000
-let updatesCache: { at: number; data: Record<string, UpdateStatus> } | null = null
+let updatesCache: { key: string; at: number; data: Record<string, UpdateStatus> } | null = null
 
 const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
 
@@ -120,13 +120,20 @@ export async function fetchNpmLatest(name: string): Promise<string | null> {
 }
 
 /** Per-plugin update checks; a failed check reports no update rather than failing the listing. */
-export async function checkUpdates(profile: string, force = false): Promise<Record<string, UpdateStatus>> {
-  if (!force && updatesCache && Date.now() - updatesCache.at < UPDATES_TTL_MS) return updatesCache.data
-  const installed = readInstalled(profile)
-  const lockCommits = readLockCommits(profile)
+export async function checkUpdates(
+  profile: string,
+  force = false,
+  explicitDir?: string,
+): Promise<Record<string, UpdateStatus>> {
+  const activeProfileDir = profileDir(profile, explicitDir)
+  if (!force && updatesCache?.key === activeProfileDir && Date.now() - updatesCache.at < UPDATES_TTL_MS) {
+    return updatesCache.data
+  }
+  const installed = readInstalled(profile, activeProfileDir)
+  const lockCommits = readLockCommits(profile, activeProfileDir)
   const result: Record<string, UpdateStatus> = {}
   await Promise.all(Object.entries(installed).map(async ([name, spec]) => {
-    const version = readInstalledVersion(profile, name)
+    const version = readInstalledVersion(profile, name, activeProfileDir)
     if (spec.startsWith('link:') || spec.startsWith('file:')) {
       result[name] = { kind: 'linked', version, current: null, latest: null, updateAvailable: false }
       return
@@ -153,6 +160,6 @@ export async function checkUpdates(profile: string, force = false): Promise<Reco
       result[name] = { kind: spec.startsWith('github:') ? 'github' : 'npm', version, current: null, latest: null, updateAvailable: false }
     }
   }))
-  updatesCache = { at: Date.now(), data: result }
+  updatesCache = { key: activeProfileDir, at: Date.now(), data: result }
   return result
 }

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -36,10 +36,10 @@ export interface ActivationResult {
 }
 
 /** The profile manifest's `dsh.profile.bundles` — what the CLI reconciled. */
-function readBundles(profile: string): Set<string> {
+function readBundles(profile: string, explicitDir?: string): Set<string> {
   try {
     const manifest = JSON.parse(
-      readFileSync(join(profileDir(profile), 'package.json'), 'utf8'),
+      readFileSync(join(profileDir(profile, explicitDir), 'package.json'), 'utf8'),
     ) as { dsh?: { profile?: { bundles?: unknown } } }
     const bundles = manifest.dsh?.profile?.bundles
     return new Set(Array.isArray(bundles) ? bundles.filter((n): n is string => typeof n === 'string') : [])
@@ -71,10 +71,10 @@ function liveIncludes(live: ReadonlySet<string>, packageName: string): boolean {
   return false
 }
 
-function readPkgDsh(profile: string, name: string): PkgDsh | null {
+function readPkgDsh(profile: string, name: string, explicitDir?: string): PkgDsh | null {
   try {
     const manifest = JSON.parse(
-      readFileSync(join(profileDir(profile), 'node_modules', name, 'package.json'), 'utf8'),
+      readFileSync(join(profileDir(profile, explicitDir), 'node_modules', name, 'package.json'), 'utf8'),
     ) as { dsh?: PkgDsh }
     return manifest.dsh ?? {}
   } catch {
@@ -82,9 +82,9 @@ function readPkgDsh(profile: string, name: string): PkgDsh | null {
   }
 }
 
-function patchTextOf(profile: string, name: string): string | null {
+function patchTextOf(profile: string, name: string, explicitDir?: string): string | null {
   try {
-    return readFileSync(join(profileDir(profile), 'node_modules', name, 'cordis.patch.yml'), 'utf8')
+    return readFileSync(join(profileDir(profile, explicitDir), 'node_modules', name, 'cordis.patch.yml'), 'utf8')
   } catch {
     return null
   }
@@ -99,16 +99,18 @@ export function verifyActivation(
   profile: string,
   name: string,
   live: ReadonlySet<string> = new Set(listHotMounts()),
+  explicitDir?: string,
 ): ActivationResult {
-  const bundles = readBundles(profile)
+  const activeProfileDir = profileDir(profile, explicitDir)
+  const bundles = readBundles(profile, activeProfileDir)
   const inBundles = bundles.has(name)
-  const dsh = readPkgDsh(profile, name)
+  const dsh = readPkgDsh(profile, name, activeProfileDir)
 
   if (dsh === null) {
     return { state: 'missing', reasons: ['未安装 / not installed'], bundle: inBundles, hot: false }
   }
 
-  const dir = join(profileDir(profile), 'node_modules', name)
+  const dir = join(activeProfileDir, 'node_modules', name)
   if (!hasDshManifest(dir)) {
     return {
       state: 'broken',
@@ -143,7 +145,7 @@ export function verifyActivation(
   }
 
   if (inBundles) {
-    const patch = patchTextOf(profile, name)
+    const patch = patchTextOf(profile, name, activeProfileDir)
     const complex = patch !== null && parseSimplePatch(patch) === null
     return {
       state: 'restart',

--- a/tests/desktop-runtime.spec.ts
+++ b/tests/desktop-runtime.spec.ts
@@ -1,0 +1,166 @@
+import { PassThrough } from 'node:stream'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  createDesktopPluginRuntime,
+  progress,
+  type DesktopPnpmLike,
+} from '../src/dsh-cli.ts'
+
+const roots: string[] = []
+
+function profileFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dshm-desktop-profile-'))
+  roots.push(dir)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), '{"dependencies":{}}')
+  writeFileSync(join(dir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+  return dir
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('DSH Desktop package runtime', () => {
+  it('uses the host profile directory and streams one managed runPlugin operation', async () => {
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let resolveDone!: (value: { exitCode: number | null; signal: NodeJS.Signals | null }) => void
+    const done = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>(resolve => {
+      resolveDone = resolve
+    })
+    const calls: { args: readonly string[]; dir: string; signal?: AbortSignal }[] = []
+    const service: DesktopPnpmLike = {
+      runPlugin(args, dir, signal) {
+        calls.push({ args, dir, signal })
+        return { stdout, stderr, done, cancel: () => {} }
+      },
+    }
+    const dir = profileFixture()
+    const runtime = createDesktopPluginRuntime(service, dir, '/tmp', 10_000)
+    const resultPromise = runtime.runPlugin('must-not-select-a-profile', ['add', 'example-plugin'])
+    stdout.write('{"name":"pnpm:progress","packageId":"example-plugin@1.0.0","status":"resolved"}\n')
+    stderr.write('checking package\n')
+    resolveDone({ exitCode: 0, signal: null })
+
+    await expect(resultPromise).resolves.toMatchObject({
+      exitCode: 0,
+      timedOut: false,
+      cancelled: false,
+      stderr: 'checking package\n',
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].args).toEqual(['add', '-w', 'example-plugin', '--reporter=ndjson'])
+    expect(calls[0].dir).toBe('/tmp')
+    expect(calls[0].signal).toBeInstanceOf(AbortSignal)
+    expect(progress.active).toBe(false)
+  })
+
+  it('cancels and awaits the owned operation during teardown, then rejects reuse', async () => {
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let resolveDone!: (value: { exitCode: number | null; signal: NodeJS.Signals | null }) => void
+    const done = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>(resolve => {
+      resolveDone = resolve
+    })
+    let cancelled = 0
+    const service: DesktopPnpmLike = {
+      runPlugin() {
+        return {
+          stdout,
+          stderr,
+          done,
+          cancel: () => {
+            cancelled += 1
+            resolveDone({ exitCode: null, signal: 'SIGTERM' })
+          },
+        }
+      },
+    }
+    const runtime = createDesktopPluginRuntime(service, profileFixture(), '/tmp', 10_000)
+    const resultPromise = runtime.runPlugin('desktop', ['remove', 'example-plugin'])
+    await runtime.dispose()
+
+    expect(cancelled).toBe(1)
+    await expect(resultPromise).resolves.toMatchObject({ exitCode: null, cancelled: false })
+    await expect(runtime.runPlugin('desktop', ['update'])).resolves.toMatchObject({
+      exitCode: 127,
+      stderr: expect.stringContaining('disposed'),
+    })
+  })
+
+  it('marks an explicit UI cancellation without provisioning system pnpm', async () => {
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let resolveDone!: (value: { exitCode: number | null; signal: NodeJS.Signals | null }) => void
+    const done = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>(resolve => {
+      resolveDone = resolve
+    })
+    const service: DesktopPnpmLike = {
+      runPlugin() {
+        return {
+          stdout,
+          stderr,
+          done,
+          cancel: () => resolveDone({ exitCode: null, signal: 'SIGTERM' }),
+        }
+      },
+    }
+    const runtime = createDesktopPluginRuntime(service, profileFixture(), '/tmp', 10_000)
+    const resultPromise = runtime.runPlugin('desktop', ['update'])
+    expect(await runtime.probePnpm()).toBe(true)
+    await expect(runtime.provisionPnpm()).resolves.toEqual({ ok: true })
+    expect(runtime.cancelActive()).toBe(true)
+    await expect(resultPromise).resolves.toMatchObject({ cancelled: true, timedOut: false })
+  })
+
+  it('preserves the Desktop generation-wide busy signal', async () => {
+    const service: DesktopPnpmLike = {
+      runPlugin() {
+        throw new Error('dsh-plugin-desktop: another desktop pnpm operation is already running')
+      },
+    }
+    const runtime = createDesktopPluginRuntime(service, profileFixture(), '/tmp', 10_000)
+    await expect(runtime.runPlugin('desktop', ['update'])).resolves.toMatchObject({
+      exitCode: 127,
+      busy: true,
+      cancelled: false,
+    })
+  })
+
+  it('cancels the operation handle when the market timeout expires', async () => {
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let resolveDone!: (value: { exitCode: number | null; signal: NodeJS.Signals | null }) => void
+    const done = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>(resolve => {
+      resolveDone = resolve
+    })
+    let cancelled = 0
+    const service: DesktopPnpmLike = {
+      runPlugin() {
+        return {
+          stdout,
+          stderr,
+          done,
+          // Deliberately ignore AbortSignal: the returned handle remains the
+          // required process-tree cancellation contract.
+          cancel: () => {
+            cancelled += 1
+            resolveDone({ exitCode: null, signal: 'SIGTERM' })
+          },
+        }
+      },
+    }
+    const runtime = createDesktopPluginRuntime(service, profileFixture(), '/tmp', 5)
+
+    await expect(runtime.runPlugin('desktop', ['update'])).resolves.toMatchObject({
+      exitCode: null,
+      timedOut: true,
+      cancelled: false,
+    })
+    expect(cancelled).toBe(1)
+  })
+})

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -248,7 +248,10 @@ interface Testbed {
   dispose(): void
 }
 
-function createTestbed(config: { allowRestart?: boolean } = {}): Testbed {
+function createTestbed(
+  config: { profile?: string; allowRestart?: boolean; profileDirectory?: string } = {},
+  runtime?: Parameters<typeof mountMarketRoutes>[2],
+): Testbed {
   const routes = new Map<string, Handler>()
   const loaderEntries: Testbed['loaderEntries'] = []
   const host = {
@@ -262,7 +265,7 @@ function createTestbed(config: { allowRestart?: boolean } = {}): Testbed {
     plugin: () => ({ await: () => Promise.resolve(), dispose: () => {} }),
     on: () => () => {},
   }
-  const dispose = mountMarketRoutes(host as never, { profile: 'web', ...config })
+  const dispose = mountMarketRoutes(host as never, { profile: 'web', ...config }, runtime)
   async function dispatch(method: string, path: string, body?: unknown, options?: { crossOrigin?: boolean }) {
     const handler = routes.get(path.split('?')[0])
     if (handler === undefined) throw new Error(`no route: ${path}`)
@@ -332,6 +335,146 @@ function installedSpec(name: string): string | undefined {
   const manifest = JSON.parse(readFileSync(join(profileDir('web'), 'package.json'), 'utf8'))
   return manifest.dependencies?.[name]
 }
+
+describe('host-provided profile and package-operation seams', () => {
+  it('uses the explicit profile directory and injected status/setup/cancel operations', async () => {
+    bed.dispose()
+    const explicitDir = join(home, 'desktop-owned-profile')
+    mkdirSync(explicitDir, { recursive: true })
+    writeFileSync(join(explicitDir, 'package.json'), '{"dependencies":{"desktop-only":"1.0.0"}}')
+    writeFileSync(join(explicitDir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+    fake.profileDir = explicitDir
+    const probe = vi.fn(() => Promise.resolve(true))
+    const provision = vi.fn(() => Promise.resolve({ ok: true }))
+    const cancel = vi.fn(() => true)
+    bed = createTestbed(
+      { profile: '工作 profile', profileDirectory: explicitDir, allowRestart: false },
+      { runPlugin: vi.fn() as never, probePnpm: probe, provisionPnpm: provision, cancelActive: cancel },
+    )
+
+    const installed = await bed.dispatch('GET', '/dsh-market/installed')
+    expect(installed.json).toMatchObject({
+      profile: '工作 profile',
+      installed: { 'desktop-only': '1.0.0' },
+    })
+    const status = await bed.dispatch('GET', '/dsh-market/status')
+    expect(status.json).toMatchObject({ pnpm: true, restart: false, installed: { 'desktop-only': '1.0.0' } })
+    expect(probe).toHaveBeenCalledOnce()
+    expect((await bed.dispatch('POST', '/dsh-market/setup-pnpm', {})).json.ok).toBe(true)
+    expect(provision).toHaveBeenCalledOnce()
+    expect((await bed.dispatch('POST', '/dsh-market/cancel', {})).status).toBe(200)
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('maps a generation-wide Desktop package-operation gate to conflict', async () => {
+    bed.dispose()
+    bed = createTestbed({}, {
+      runPlugin: () => Promise.resolve({
+        exitCode: 127,
+        timedOut: false,
+        stdout: '',
+        stderr: 'another desktop pnpm operation is already running',
+        cancelled: false,
+        busy: true,
+      }),
+      probePnpm: () => Promise.resolve(true),
+      provisionPnpm: () => Promise.resolve({ ok: true }),
+      cancelActive: () => false,
+    })
+
+    const result = await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+    expect(result.status).toBe(409)
+    expect(result.json).toMatchObject({ ok: false, busy: true })
+  })
+
+  it('writes build approvals and git keys only in the host-authoritative Desktop profile', async () => {
+    bed.dispose()
+    const explicitDir = join(home, 'desktop-owned-profile')
+    mkdirSync(join(explicitDir, 'node_modules', 'dsh-blue-whale'), { recursive: true })
+    writeFileSync(join(explicitDir, 'package.json'), JSON.stringify({
+      dependencies: { 'dsh-blue-whale': 'github:o/blue-whale' },
+    }))
+    writeFileSync(join(explicitDir, 'node_modules', 'dsh-blue-whale', 'package.json'), '{"name":"dsh-blue-whale"}')
+    writeFileSync(join(explicitDir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+    fake.profileDir = explicitDir
+    bed = createTestbed({ profile: '工作 profile', profileDirectory: explicitDir, allowRestart: false })
+
+    const approve = await bed.dispatch('POST', '/dsh-market/approve-builds', { packages: ['dsh-blue-whale'] })
+    expect(approve.status).toBe(200)
+    expect(approve.json.approved).toContain('dsh-blue-whale')
+    expect(approve.json.approved).toContain('dsh-blue-whale@git+https://github.com/o/blue-whale.git')
+    const desktopYaml = readFileSync(join(explicitDir, 'pnpm-workspace.yaml'), 'utf8')
+    expect(desktopYaml).toContain('dsh-blue-whale@git+https://github.com/o/blue-whale.git: true')
+    expect(readFileSync(join(profileDir('web'), 'pnpm-workspace.yaml'), 'utf8')).not.toContain('dsh-blue-whale')
+  })
+
+  it('rolls a failed Desktop install back in the host-authoritative profile only', async () => {
+    bed.dispose()
+    const explicitDir = join(home, 'desktop-owned-profile')
+    mkdirSync(explicitDir, { recursive: true })
+    writeFileSync(join(explicitDir, 'package.json'), JSON.stringify({ dependencies: { 'desktop-only': '1.0.0' } }))
+    writeFileSync(join(explicitDir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+    fake.profileDir = explicitDir
+    fake.npm['dsh-loop'] = {
+      latest: '1.0.0',
+      versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } },
+    }
+    fake.failAfterWriteStderrOnce = '[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/ghost: Not Found - 404'
+    bed = createTestbed({ profile: '工作 profile', profileDirectory: explicitDir, allowRestart: false })
+
+    const result = await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+    expect(result.status).toBe(502)
+    const desktopManifest = JSON.parse(readFileSync(join(explicitDir, 'package.json'), 'utf8'))
+    expect(desktopManifest.dependencies).toEqual({ 'desktop-only': '1.0.0' })
+    const ordinaryManifest = JSON.parse(readFileSync(join(profileDir('web'), 'package.json'), 'utf8'))
+    expect(ordinaryManifest.dependencies).toEqual({})
+  })
+
+  it('restores the previous Desktop pin when an update fails after a partial manifest write', async () => {
+    bed.dispose()
+    const explicitDir = join(home, 'desktop-owned-profile')
+    mkdirSync(join(explicitDir, 'node_modules', 'dsh-loop'), { recursive: true })
+    writeFileSync(join(explicitDir, 'package.json'), JSON.stringify({ dependencies: { 'dsh-loop': '^1.0.0' } }))
+    writeFileSync(join(explicitDir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+    writeFileSync(join(explicitDir, 'node_modules', 'dsh-loop', 'package.json'), JSON.stringify({
+      name: 'dsh-loop', version: '1.0.0', dsh: {}, main: 'lib/index.js',
+    }))
+    fake.profileDir = explicitDir
+    fake.npm['dsh-loop'] = {
+      latest: '1.2.0',
+      versions: { '1.2.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } },
+    }
+    fake.failAfterWriteStderrOnce = '[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/ghost: Not Found - 404'
+    vi.stubGlobal('fetch', () => Promise.resolve(new Response(JSON.stringify({ version: '1.2.0' }), { status: 200 })))
+    bed = createTestbed({ profile: '工作 profile', profileDirectory: explicitDir, allowRestart: false })
+
+    const result = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+    expect(result.status).toBe(502)
+    const desktopManifest = JSON.parse(readFileSync(join(explicitDir, 'package.json'), 'utf8'))
+    expect(desktopManifest.dependencies).toEqual({ 'dsh-loop': '^1.0.0' })
+    const ordinaryManifest = JSON.parse(readFileSync(join(profileDir('web'), 'package.json'), 'utf8'))
+    expect(ordinaryManifest.dependencies).toEqual({})
+  })
+
+  it('applies the same-name different-repo guard to the host-authoritative Desktop profile', async () => {
+    bed.dispose()
+    const explicitDir = join(home, 'desktop-owned-profile')
+    mkdirSync(explicitDir, { recursive: true })
+    writeFileSync(join(explicitDir, 'package.json'), JSON.stringify({
+      dependencies: { 'dsh-usage-stats': 'github:a1/dsh-usage-stats' },
+    }))
+    writeFileSync(join(explicitDir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+    fake.profileDir = explicitDir
+    bed = createTestbed({ profile: '工作 profile', profileDirectory: explicitDir, allowRestart: false })
+
+    const result = await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/a2/dsh-usage-stats' })
+    expect(result.status).toBe(400)
+    expect(String(result.json.error)).toContain('同名冲突')
+    expect(fake.calls).toEqual([])
+    const desktopManifest = JSON.parse(readFileSync(join(explicitDir, 'package.json'), 'utf8'))
+    expect(desktopManifest.dependencies['dsh-usage-stats']).toBe('github:a1/dsh-usage-stats')
+  })
+})
 
 describe('install flow', () => {
   it('installs a curated plugin end to end and reports it installed', async () => {

--- a/tests/index-desktop.spec.ts
+++ b/tests/index-desktop.spec.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  mounts: [] as { host: unknown; config: Record<string, unknown>; runtime?: unknown }[],
+  routeDisposals: 0,
+  runtimeDisposals: 0,
+  runtime: {
+    runPlugin: () => Promise.resolve({}),
+    probePnpm: () => Promise.resolve(true),
+    provisionPnpm: () => Promise.resolve({ ok: true }),
+    cancelActive: () => false,
+    dispose: () => {
+      state.runtimeDisposals += 1
+      return Promise.resolve()
+    },
+  },
+  factoryArgs: [] as unknown[][],
+}))
+
+vi.mock('../src/dsh-cli.ts', () => ({
+  createDesktopPluginRuntime: (...args: unknown[]) => {
+    state.factoryArgs.push(args)
+    return state.runtime
+  },
+}))
+
+vi.mock('../src/routes.ts', () => ({
+  mountMarketRoutes: (host: unknown, config: Record<string, unknown>, runtime?: unknown) => {
+    state.mounts.push({ host, config, runtime })
+    return () => { state.routeDisposals += 1 }
+  },
+}))
+
+import { apply } from '../src/index.ts'
+
+class FakeContext {
+  readonly injectCalls: string[][] = []
+  readonly effects: { label: string; dispose: () => void | Promise<void> }[] = []
+
+  constructor(private readonly services: Record<string, unknown>) {
+    Object.assign(this, services)
+  }
+
+  get(name: string): unknown {
+    return this.services[name]
+  }
+
+  inject(deps: string[], callback: (ctx: FakeContext) => void): void {
+    this.injectCalls.push(deps)
+    if (deps.every(name => this.services[name] !== undefined)) callback(this)
+  }
+
+  effect(callback: () => (() => void | Promise<void>), label: string): void {
+    this.effects.push({ label, dispose: callback() })
+  }
+}
+
+beforeEach(() => {
+  state.mounts = []
+  state.routeDisposals = 0
+  state.runtimeDisposals = 0
+  state.factoryArgs = []
+})
+
+describe('host adaptation', () => {
+  it('preserves the ordinary DSH profile and CLI runtime fallback', () => {
+    const ctx = new FakeContext({ webServer: {}, loader: {} })
+    apply(ctx as never, { profile: 'team', allowRestart: true })
+
+    expect(ctx.injectCalls).toEqual([['webServer', 'loader']])
+    expect(state.factoryArgs).toEqual([])
+    expect(state.mounts).toHaveLength(1)
+    expect(state.mounts[0]).toMatchObject({
+      config: { profile: 'team', allowRestart: true },
+      runtime: undefined,
+    })
+  })
+
+  it('uses the immutable Desktop profile and waits for desktopPnpm in a nested injection', async () => {
+    const desktopPnpm = { runPlugin: vi.fn() }
+    const ctx = new FakeContext({
+      webServer: {},
+      loader: {},
+      desktopProfiles: { current: { name: '工作 profile', dir: '/private/dsh/desktop' } },
+      desktopPnpm,
+    })
+    apply(ctx as never, { profile: 'must-not-win', allowRestart: true })
+
+    expect(ctx.injectCalls).toEqual([['webServer', 'loader'], ['desktopPnpm']])
+    expect(state.factoryArgs).toEqual([[desktopPnpm, '/private/dsh/desktop']])
+    expect(state.mounts).toHaveLength(1)
+    expect(state.mounts[0]).toMatchObject({
+      config: {
+        profile: '工作 profile',
+        profileDirectory: '/private/dsh/desktop',
+        allowRestart: false,
+      },
+      runtime: state.runtime,
+    })
+
+    expect(ctx.effects).toHaveLength(1)
+    await ctx.effects[0].dispose()
+    expect(state.routeDisposals).toBe(1)
+    expect(state.runtimeDisposals).toBe(1)
+  })
+
+  it('uses the documented pre-Loader desktopProfiles discriminator and never falls back to ambient CLI', () => {
+    const ctx = new FakeContext({
+      webServer: {},
+      loader: {},
+      desktopProfiles: { current: { name: 'desktop', dir: '/private/dsh/desktop' } },
+    })
+    apply(ctx as never)
+
+    expect(ctx.injectCalls).toEqual([['webServer', 'loader'], ['desktopPnpm']])
+    expect(state.mounts).toEqual([])
+    expect(state.factoryArgs).toEqual([])
+  })
+})


### PR DESCRIPTION
## What changed

- Detect DSH Desktop through the public generation-scoped `desktopProfiles` service.
- Keep the Desktop-only `desktopPnpm` dependency inside a nested `ctx.inject()` callback; ordinary DSH still uses the existing config/argv/CLI path.
- Use `desktopProfiles.current.name` and `.dir` as the authoritative profile identity and filesystem root, including Unicode/spaced profile names.
- Adapt `desktopPnpm.runPlugin()` streams, cancellation, timeout, teardown, and generation-wide busy errors to the existing market operation surface.
- Route status, setup, cancel, install, update, rollback, build approval, source/name guards, themes, and activation verification through the injected operation runtime and host-authoritative profile directory.
- Preserve a dependency-free boundary: there is no runtime import from or hard dependency on `dsh-plugin-desktop`.

## Rebase safety

This branch is rebased onto `main` at `eb7881f` (the 1.5.1 release, including #76/#77/#78). The newly added profile-sensitive paths all receive the same `activeProfileDir`:

- `setAllowBuilds` plus installed-spec lookup for `gitAllowBuildsKey`;
- `readManifestDeps` / `restoreManifestDeps` for failed install and update rollback;
- duplicate, inactive-leftover retry, and same-name/different-source guards;
- installed versions, lockfile commits, activation checks, and hot mounts.

The flow suite now uses a Desktop-owned directory whose profile name is intentionally not derivable from `$DSH_HOME`, and verifies build approval/git keys, failed-install rollback, failed-update rollback, and the same-name source guard against that directory while the ambient `web` profile remains unchanged.

## Desktop contract evidence

DSH Desktop's supported plugin contract explicitly guarantees that `desktopProfiles` is registered before Loader entries and prescribes the presence check plus nested `desktopPnpm` injection used here:

- [Supported cross-environment contract (pinned source)](https://github.com/anywhere-labs/deepseek-harness-desktop/blob/4f68147091e585aaa1d815f99d30a657b3842d7c/dsh-plugin-desktop/docs/plugin-services.md#L190-L243)
- [Launcher registration before Host boot proceeds (pinned source)](https://github.com/anywhere-labs/deepseek-harness-desktop/blob/4f68147091e585aaa1d815f99d30a657b3842d7c/dsh-plugin-desktop/src/main.ts#L159-L190)

## Lifecycle and failure behavior

- Desktop profile identity never falls back to `web` after `desktopProfiles` is present.
- Package work is cancelled and awaited when the owning Cordis effect is disposed.
- Timeout sends both the public `AbortSignal` and `handle.cancel()` process-tree cancellation paths; a regression test covers a provider that ignores the signal and settles only after `cancel()`.
- A Desktop generation-wide operation gate is returned as HTTP `409`, rather than flattened into a generic install failure.
- The existing self-restart endpoint remains available in ordinary DSH and is disabled in Desktop mode because restart is not part of the public plugin contract.

## Validation

- `npm ci` — lockfile install completed; audit reported 0 vulnerabilities
- `npm run check` — both TypeScript compiler faces, production build, and restart smoke passed
- `npm test` — 15 files, 141 tests passed
- `npm run test:compat` — 9 pnpm 9/10/11 compatibility tests passed
- `npm run test:web` — 5 tests discovered and skipped because this isolated checkout has no reachable DSH CLI
- `node scripts/preflight.mjs` / `validate-registry.mjs` / `smoke-spawn.mjs` — all passed (registry retained its 12 allowed display-name-collision warnings)
- `npm pack --ignore-scripts --dry-run --json` — 64 entries; package contains `LICENSE` and `lib/index.js`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- Independent final review: PASS after the timeout cancellation regression was fixed

## Real Desktop manual gate — not claimed

No installed or runnable DSH Desktop build was found on this machine, and this change did not install a system application. Therefore I have **not** performed or claimed a real Electron install + cancel + generation-busy `409` run. That remains an explicit maintainer/release-side manual gate before shipping a release; the fake-service and route tests above do not substitute for it.

GitHub has also classified the current fork CI run as [`action_required`](https://github.com/dsh-market/dsh-market/actions/runs/31919615441) without starting any jobs. A maintainer must approve that fork workflow before its Ubuntu, Windows, compatibility, and real-DSH web lanes can report.

## Disclosure

I maintain `@labmimors/dsh-mcp-lens`, a DSH plugin that would benefit from a Desktop-compatible marketplace. This patch is intentionally marketplace infrastructure for every curated plugin; it does not add or special-case MCP Lens.
