### PR TITLE
fix: never report or apply a downgrade as an update (#64)

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -21,7 +21,7 @@ import { BOOT_ID, cancelActive, probePnpm, progress, provisionPnpm, runDshPlugin
 import { profileDir, readInstalled, readInstalledVersion, readLockCommits, setAllowBuilds } from './profile.ts'
 import { findInstalledAlias, installTargetFor } from './sources.ts'
 import { isStaleUpdate, parseIgnoredBuilds, RELEASE_AGE_OVERRIDE, retargetCollections, validateAddedPlugins, withHoistRecovery } from './install.ts'
-import { checkUpdates, invalidateUpdates, latestPublishedRecently } from './updates.ts'
+import { checkUpdates, fetchNpmLatest, invalidateUpdates, isUpgrade, latestPublishedRecently } from './updates.ts'
 import { createThemeManager, type LoaderEntry } from './themes.ts'
 import { readJsonBody, sameOrigin, sendJson } from './http.ts'
 import { restartAllowed, scheduleRestart, trustedRestartRequest } from './restart.ts'
@@ -322,6 +322,22 @@ export function mountMarketRoutes(host: MarketHost, config: MarketConfig): () =>
           // dist-tag latest for registry installs.
           const isGit = spec.startsWith('github:')
           const target = isGit ? spec.replace(/#.*$/, '') : `${name}@latest`
+          // Never let `@latest` walk a profile BACKWARDS (#64 by @ZeroOrigin64):
+          // a package whose latest dist-tag was left on an older release turns
+          // this update into a downgrade that also rewrites an exact pin to
+          // `@latest`. Detection already hides the button; this guards the
+          // route itself. Unreadable versions fall through and update as before.
+          if (!isGit) {
+            const installedVersion = readInstalledVersion(config.profile, name)
+            const registryLatest = await fetchNpmLatest(name)
+            if (installedVersion !== null && registryLatest !== null && !isUpgrade(installedVersion, registryLatest)) {
+              logEvent('info', 'update', `${name} refused: latest=${registryLatest} is not newer than installed=${installedVersion}`)
+              sendJson(response, 400, {
+                error: `已是最新：registry 的 latest 是 ${registryLatest}，不高于已装的 ${installedVersion}，更新会造成降级。 / Already current: the registry's latest (${registryLatest}) is not newer than the installed ${installedVersion}, so updating would downgrade it.`,
+              })
+              return
+            }
+          }
           const repoKey = isGit ? spec.slice('github:'.length).replace(/#.*$/, '').toLowerCase() : null
           const beforeVersion = readInstalledVersion(config.profile, name)
           const beforeCommit = repoKey !== null ? readLockCommits(config.profile).get(repoKey) ?? null : null

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -17,6 +17,59 @@ export interface UpdateStatus {
 const UPDATES_TTL_MS = 30 * 60 * 1000
 let updatesCache: { at: number; data: Record<string, UpdateStatus> } | null = null
 
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+
+function parseSemver(v: string): { core: number[]; pre: string[] } | null {
+  const m = SEMVER.exec(v.trim())
+  if (m === null) return null
+  return { core: [Number(m[1]), Number(m[2]), Number(m[3])], pre: m[4] === undefined ? [] : m[4].split('.') }
+}
+
+/**
+ * Semver precedence: negative / 0 / positive like a comparator, or null when
+ * either side isn't a plain semver version. Build metadata is ignored, a
+ * release outranks any prerelease of the same core, and prerelease
+ * identifiers compare numerically when both are numeric (so `rc.10` > `rc.9`).
+ */
+export function compareVersions(a: string, b: string): number | null {
+  const pa = parseSemver(a)
+  const pb = parseSemver(b)
+  if (pa === null || pb === null) return null
+  for (let i = 0; i < 3; i++) {
+    if (pa.core[i] !== pb.core[i]) return pa.core[i] - pb.core[i]
+  }
+  if (pa.pre.length === 0 || pb.pre.length === 0) return pb.pre.length - pa.pre.length
+  for (let i = 0; i < Math.max(pa.pre.length, pb.pre.length); i++) {
+    const x = pa.pre[i]
+    const y = pb.pre[i]
+    if (x === undefined) return -1
+    if (y === undefined) return 1
+    if (x === y) continue
+    const nx = /^\d+$/.test(x)
+    const ny = /^\d+$/.test(y)
+    if (nx && ny) return Number(x) - Number(y)
+    if (nx !== ny) return nx ? -1 : 1
+    return x < y ? -1 : 1
+  }
+  return 0
+}
+
+/**
+ * True only when the registry's `latest` is semantically HIGHER than what the
+ * profile has (#64 by @ZeroOrigin64). A plain `!==` also fires when a
+ * package's `latest` dist-tag is left pointing at an OLDER release than the
+ * pinned install — clicking "update" then rewrote the exact pin to `@latest`
+ * and downgraded the profile until it no longer booted.
+ *
+ * Undecidable inputs (missing or non-semver versions) report no update:
+ * without a direction we cannot promise the "update" isn't a downgrade.
+ */
+export function isUpgrade(installed: string | null, latest: string | null): boolean {
+  if (installed === null || latest === null) return false
+  const cmp = compareVersions(latest, installed)
+  return cmp !== null && cmp > 0
+}
+
 /** Drop the cached listing (after a successful install/update/uninstall). */
 export function invalidateUpdates(): void {
   updatesCache = null
@@ -56,6 +109,16 @@ export async function latestPublishedRecently(name: string, windowMs = 26 * 60 *
   }
 }
 
+/** The registry's current `latest` version for a package, or null when it can't be read. */
+export async function fetchNpmLatest(name: string): Promise<string | null> {
+  try {
+    const meta = (await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(name)}/latest`)) as { version?: string }
+    return typeof meta.version === 'string' ? meta.version : null
+  } catch {
+    return null
+  }
+}
+
 /** Per-plugin update checks; a failed check reports no update rather than failing the listing. */
 export async function checkUpdates(profile: string, force = false): Promise<Record<string, UpdateStatus>> {
   if (!force && updatesCache && Date.now() - updatesCache.at < UPDATES_TTL_MS) return updatesCache.data
@@ -83,7 +146,7 @@ export async function checkUpdates(profile: string, force = false): Promise<Reco
         const latest = typeof meta.version === 'string' ? meta.version : null
         result[name] = {
           kind: 'npm', version, current: version, latest,
-          updateAvailable: version !== null && latest !== null && version !== latest,
+          updateAvailable: isUpgrade(version, latest),
         }
       }
     } catch {

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -407,6 +407,21 @@ describe('update flow — no npm publishing required', () => {
     expect(r.json.activation['dsh-loop']).toMatchObject({ state: 'live' })
   })
 
+  it('never offers or performs a downgrade when the latest dist-tag is older (#64 by @ZeroOrigin64)', async () => {
+    // A package whose `latest` tag was left on its first release while newer
+    // prereleases shipped: latest 0.0.1 is BELOW the installed 1.0.0.
+    advanceNpmLatest('0.0.1')
+    const specBefore = installedSpec('dsh-loop')
+    const updates = await bed.dispatch('GET', '/dsh-market/updates?force=1')
+    expect(updates.json.updates['dsh-loop']).toMatchObject({ kind: 'npm', current: '1.0.0', latest: '0.0.1', updateAvailable: false })
+    // Even called directly, the route refuses rather than rewriting the pin to `@latest`.
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+    expect(r.status).toBe(400)
+    expect(String(r.json.error)).toContain('0.0.1')
+    expect(installedSpec('dsh-loop')).toBe(specBefore)
+    expect(fake.calls.some(c => c.includes('dsh-loop@latest'))).toBe(false)
+  })
+
   it('surfaces the silent fresh-release hold as an actionable error, and force applies it (#22)', async () => {
     advanceNpmLatest('1.2.0') // published 1h ago — inside the safety window
     fake.staleUpdates = true // pnpm keeps 1.0.0 and exits 0

--- a/tests/updates.spec.ts
+++ b/tests/updates.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Version-direction unit tests for update detection (#64).
+ *
+ * The reported failure: `@deepseek-ai/dsh-web-fetch-http` was pinned at
+ * 0.1.0-rc.6 while the registry's `latest` dist-tag was still on the first
+ * release, 0.0.1-rc.5. Detection compared with `!==`, so the older tag read
+ * as "an update", and applying it downgraded the profile until it wouldn't
+ * boot. Direction — not inequality — is what decides.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { compareVersions, isUpgrade } from '../src/updates.ts'
+
+describe('compareVersions', () => {
+  it('orders by major, minor, then patch', () => {
+    expect(compareVersions('2.0.0', '1.9.9')).toBeGreaterThan(0)
+    expect(compareVersions('1.2.0', '1.10.0')).toBeLessThan(0)
+    expect(compareVersions('1.2.3', '1.2.10')).toBeLessThan(0)
+    expect(compareVersions('1.2.3', '1.2.3')).toBe(0)
+  })
+
+  it('compares numerically, not lexically', () => {
+    expect(compareVersions('1.0.10', '1.0.9')).toBeGreaterThan(0)
+  })
+
+  it('ranks a release above any prerelease of the same core', () => {
+    expect(compareVersions('1.0.0', '1.0.0-rc.1')).toBeGreaterThan(0)
+    expect(compareVersions('1.0.0-rc.1', '1.0.0')).toBeLessThan(0)
+  })
+
+  it('orders prerelease identifiers per semver precedence', () => {
+    expect(compareVersions('1.0.0-rc.10', '1.0.0-rc.9')).toBeGreaterThan(0)
+    expect(compareVersions('1.0.0-alpha', '1.0.0-beta')).toBeLessThan(0)
+    expect(compareVersions('1.0.0-rc.1', '1.0.0-rc')).toBeGreaterThan(0)
+    // Numeric identifiers rank below alphanumeric ones.
+    expect(compareVersions('1.0.0-1', '1.0.0-alpha')).toBeLessThan(0)
+  })
+
+  it('reproduces the precedence chain from the semver spec', () => {
+    const ordered = [
+      '1.0.0-alpha', '1.0.0-alpha.1', '1.0.0-alpha.beta', '1.0.0-beta',
+      '1.0.0-beta.2', '1.0.0-beta.11', '1.0.0-rc.1', '1.0.0',
+    ]
+    for (let i = 0; i < ordered.length - 1; i++) {
+      expect(compareVersions(ordered[i], ordered[i + 1])).toBeLessThan(0)
+      expect(compareVersions(ordered[i + 1], ordered[i])).toBeGreaterThan(0)
+    }
+  })
+
+  it('ignores build metadata', () => {
+    expect(compareVersions('1.2.3+build.5', '1.2.3')).toBe(0)
+  })
+
+  it('returns null when either side is not plain semver', () => {
+    expect(compareVersions('^1.2.3', '1.2.3')).toBeNull()
+    expect(compareVersions('1.2', '1.2.3')).toBeNull()
+    expect(compareVersions('latest', '1.2.3')).toBeNull()
+  })
+})
+
+describe('isUpgrade', () => {
+  it('reports an upgrade only when latest is genuinely newer', () => {
+    expect(isUpgrade('1.0.0', '1.2.0')).toBe(true)
+    expect(isUpgrade('1.0.0-rc.1', '1.0.0')).toBe(true)
+  })
+
+  it('does not treat an equal version as an update', () => {
+    expect(isUpgrade('1.2.0', '1.2.0')).toBe(false)
+  })
+
+  it('does not treat a LOWER latest dist-tag as an update (#64)', () => {
+    // The exact versions from the report.
+    expect(isUpgrade('0.1.0-rc.6', '0.0.1-rc.5')).toBe(false)
+    expect(isUpgrade('2.0.0', '1.9.9')).toBe(false)
+  })
+
+  it('reports no update when a version is missing or undecidable', () => {
+    expect(isUpgrade(null, '1.2.0')).toBe(false)
+    expect(isUpgrade('1.0.0', null)).toBe(false)
+    expect(isUpgrade('not-a-version', '1.2.0')).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #64 (reported by @ZeroOrigin64, who isolated the root cause and both contributing factors).

## What was wrong

Update detection compared the installed version against the registry's `latest` dist-tag with `!==`:

```js
updateAvailable = version !== null && latest !== null && version !== latest
```

That fires in **both** directions. When a package's `latest` tag points at an *older* release than what the profile has pinned, the market flagged "update available" — and applying it rewrote the exact pin to `@latest` and walked the profile backwards until it no longer booted.

Worse, the downgrade was reported as **success**: `isStaleUpdate` only checks whether the version *changed*, and on a downgrade it did. The user saw "updated", and only found out at the next restart.

## What changed

**`src/updates.ts`** — added a semver comparator and `isUpgrade()`; detection now requires the registry version to be strictly *higher*. Undecidable inputs (missing or non-semver versions) report no update: without a direction we cannot promise an "update" is not a downgrade.

No client change needed — with `updateAvailable: false` the existing branch in `MarketSection` already renders `upToDate`.

**`src/routes.ts`** — guarded the update route itself, not just the detection that hides the button. The route is reachable directly, and the damage (exact pin overwritten with `@latest`, real downgrade) is not something a user can undo or even attribute to us. Network or version-read failures fall through and update as before, so a failed lookup never blocks a legitimate update.

## Tests

- `tests/updates.spec.ts` (new) — comparator and `isUpgrade`, including the semver spec's full precedence chain (`1.0.0-alpha` < `alpha.1` < `alpha.beta` < `beta` < `beta.2` < `beta.11` < `rc.1` < `1.0.0`) and the reported `0.1.0-rc.6` vs `0.0.1-rc.5` case
- `tests/flows.spec.ts` — end-to-end: a lower `latest` yields `updateAvailable: false`, the route returns 400, the spec is unchanged, and `@latest` is never executed

`npm test` 104 passed · `npm run test:compat` 9 passed · `npm run typecheck` · `npm run build`

## The registry side is upstream's, and it is wider than three packages

The reported tags are real and still live. Checking the scope, **every** `@deepseek-ai/dsh-*` package I sampled has the same broken tag — 15/15, not the 3 in the report:

| package | latest | next | highest |
|---|---|---|---|
| dsh-base | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-web-app | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-headless | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-web | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-web-fetch-http | 0.0.1-rc.5 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-web-search-exa | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-web-search-perplexity | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-client-{connection,runtime,locale} | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-client-ui-{settings,theme,primitives} | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |
| dsh-timeout, dsh-invariants | 0.0.1-rc.1 | 0.1.0-rc.6 | 0.1.0-rc.6 |

Their release pipeline moves `next` and never `latest`, so `latest` is stuck on each package's first publish. That is theirs to fix, and it is being reported upstream. This PR does not depend on it: it makes the market immune for *any* package whose tags are in this state.

Note that this fix does not get those users onto a newer version — it only stops the market from moving them to an older one. `latest` still resolves to the old release until upstream retags.