### PR TITLE
fix: clear pending restart after successful hot mount

### DIFF
--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -249,7 +249,12 @@ export function MarketSection(props: MarketSectionProps) {
 
   useEffect(() => {
     if (bootId === null) return
-    if (doneUrls.length === 0 && updatedNames.length === 0 && removedCount === 0) return
+    if (doneUrls.length === 0 && updatedNames.length === 0 && removedCount === 0) {
+      // Nothing pending: drop any stale entry (e.g. a hot mount cleared the
+      // only doneUrl) so a same-boot remount cannot resurrect the banner (#73).
+      sessionStorage.removeItem('dshm-restart')
+      return
+    }
     sessionStorage.setItem('dshm-restart', JSON.stringify({
       boot: bootId,
       doneUrls,

--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -438,6 +438,10 @@ export function MarketSection(props: MarketSectionProps) {
             setActivationWarnings(warns)
           }
           if (body.hot) {
+            // The status-poll recovery path may have already counted this URL
+            // as pending-restart before the install response confirmed a hot
+            // mount; a hot plugin must not stay in doneUrls (#73).
+            setDoneUrls(urls => urls.filter(url => url !== plugin.url))
             setHotUrls(urls => urls.includes(plugin.url) ? urls : urls.concat(plugin.url))
             setHotNames(names => names.includes(plugin.name) ? names : names.concat(plugin.name))
           } else {

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -336,6 +336,8 @@ describe('status-poll / install-response race (#73)', () => {
       await vi.advanceTimersByTimeAsync(2100)
       await vi.waitFor(() => {
         expect(screen.getAllByText(re(en.restartBanner)).length).toBeGreaterThan(0)
+        // The premature entry must also be persisted under the current boot.
+        expect(sessionStorage.getItem('dshm-restart')).toContain('dsh-loop')
       })
       // The real /install response arrives: hot mount confirmed.
       resolveInstall(new Response(JSON.stringify({
@@ -344,12 +346,22 @@ describe('status-poll / install-response race (#73)', () => {
         installed: { 'dsh-loop': '^1.0.0' },
         activation: { 'dsh-loop': { state: 'live', reasons: ['live via hot mount'], bundle: true, hot: true } },
       }), { status: 200 }))
-      // The stale pending-restart entry must be dropped: no restart banner.
+      // The stale pending-restart entry must be dropped — both in memory (no
+      // restart banner) and in the persisted session state.
       await vi.waitFor(() => {
         expect(screen.queryAllByText(re(en.restartBanner)).length).toBe(0)
+        expect(sessionStorage.getItem('dshm-restart')).toBeNull()
       })
       // Stable counterpart: the hot banner still shows the live mount.
       expect(screen.getAllByText(re(en.hotBanner)).length).toBeGreaterThan(0)
+      // A same-boot remount must not resurrect the banner from stale storage.
+      cleanup()
+      sessionStorage.removeItem('dshm-tab')
+      render(<MarketSection {...props()} />)
+      await vi.waitFor(() => { screen.getByRole('button', { name: en.tabInstalled }) })
+      await vi.waitFor(() => {
+        expect(screen.queryAllByText(re(en.restartBanner)).length).toBe(0)
+      })
     } finally {
       vi.useRealTimers()
     }

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -6,7 +6,7 @@
  * endpoints, stubbed with fixture payloads.
  */
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MarketSection } from '../../src/client/MarketSection.tsx'
 import { en } from '../../src/client/locales.ts'
@@ -39,6 +39,9 @@ function stubFetch(overrides: Record<string, unknown> = {}): void {
 // Snapshot objects must be referentially stable — useSyncExternalStore
 // treats a fresh object per call as an endless change feed.
 const LOCALE_SNAPSHOT = { active: 'en' }
+
+/** Escape a locale string so it can be used inside a RegExp literal. */
+const re = (s: string) => new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
 
 function props() {
   return {
@@ -288,5 +291,67 @@ describe('P0-2 activation states in the Installed tab', () => {
     expect(screen.getByText(en.stateLive)).toBeTruthy()
     // The reason is behind a disclosure; the chip itself must not claim success.
     expect(screen.getByText(en.stateRestart).textContent).toContain(en.stateRestart)
+  })
+})
+
+describe('status-poll / install-response race (#73)', () => {
+  it('clears the premature pending-restart entry once the install response confirms a hot mount', async () => {
+    vi.useFakeTimers()
+    try {
+      // The /install response is held open (deferred) while the status poll runs.
+      let resolveInstall: (value: Response) => void = () => {}
+      const installGate = new Promise<Response>(res => { resolveInstall = res })
+      vi.stubGlobal('fetch', (url: string) => {
+        const path = String(url).split('?')[0]
+        const payload =
+          path === '/dsh-market/registry' ? { source: 'snapshot', registry: REGISTRY }
+          : path === '/dsh-market/installed' ? { profile: 'web', installed: {}, live: [] }
+          // Poll recovery precondition: host idle AND dsh-loop already installed.
+          : path === '/dsh-market/status' ? { active: false, pnpm: true, boot: 'boot-1', restart: true, installed: { 'dsh-loop': '^1.0.0' } }
+          : path === '/dsh-market/updates' ? { updates: {} }
+          : path === '/dsh-market/install' ? installGate
+          : null
+        if (payload === null) return Promise.reject(new Error(`unstubbed fetch: ${String(url)}`))
+        if (payload instanceof Promise) return payload
+        return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }))
+      })
+      render(<MarketSection {...props()} />)
+      await vi.waitFor(() => { screen.getByText('dsh-loop') })
+      // The module-level installed cache from earlier tests can briefly make
+      // dsh-loop look already-installed (no Install button); wait until the
+      // mount-time refreshInstalled applies the empty fixture.
+      await vi.waitFor(() => { screen.getByRole('button', { name: en.tabInstalled }) })
+      // Grid order is by stars, not registry order — target dsh-loop's own card.
+      let card: HTMLElement | null = screen.getByText('dsh-loop')
+      while (card !== null && within(card).queryAllByRole('button', { name: en.install }).length === 0) {
+        card = card.parentElement
+      }
+      expect(card).not.toBeNull()
+      fireEvent.click(within(card!).getByRole('button', { name: en.install }))
+      await vi.waitFor(() => { screen.getByRole('button', { name: en.confirm }) })
+      fireEvent.click(screen.getByRole('button', { name: en.confirm }))
+      // The /install response is still pending; the 2s status poll now sees
+      // idle + installed and the recovery path counts dsh-loop as a pending
+      // restart even though the mount may still come back hot.
+      await vi.advanceTimersByTimeAsync(2100)
+      await vi.waitFor(() => {
+        expect(screen.getAllByText(re(en.restartBanner)).length).toBeGreaterThan(0)
+      })
+      // The real /install response arrives: hot mount confirmed.
+      resolveInstall(new Response(JSON.stringify({
+        ok: true,
+        hot: true,
+        installed: { 'dsh-loop': '^1.0.0' },
+        activation: { 'dsh-loop': { state: 'live', reasons: ['live via hot mount'], bundle: true, hot: true } },
+      }), { status: 200 }))
+      // The stale pending-restart entry must be dropped: no restart banner.
+      await vi.waitFor(() => {
+        expect(screen.queryAllByText(re(en.restartBanner)).length).toBe(0)
+      })
+      // Stable counterpart: the hot banner still shows the live mount.
+      expect(screen.getAllByText(re(en.hotBanner)).length).toBeGreaterThan(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })


### PR DESCRIPTION
Fixes #73

### Summary

* Clear stale `doneUrls` state when the final `/dsh-market/install` response confirms a successful hot mount (`hot: true`), so a hot-loaded plugin is no longer counted toward the pending-restart banner.
* Drop the persisted `dshm-restart` session entry once nothing is pending anymore, so a same-boot remount/reload cannot resurrect the banner from stale storage.
* Add a regression test that genuinely reproduces the race between the `/dsh-market/status` poll recovery path and the deferred `/dsh-market/install` response, and asserts that both the in-memory banner and the persisted session state converge.

### Root cause

While an install is in flight, the 2s `/dsh-market/status` poll has a recovery path for lost HTTP responses: if the host is idle and the plugin already appears in `status.installed`, it records the URL in `doneUrls` (pending restart) before the final install response arrives. When that response later returns `{ "ok": true, "hot": true }`, the hot-mount branch only added the URL to `hotUrls`/`hotNames` and never removed it from `doneUrls`, leaving the plugin in both lists. `pendingRestart = doneUrls.length + updatedNames.length + removedCount` then kept the "restart DeepSeek Harness to apply" banner visible even though the plugin was already live via hot mount. Because the pending-restart state is persisted to `sessionStorage` under the current boot id, the stale entry survived a same-boot remount/reload and re-armed the banner.

### Validation

* `npm test` — 93 passed (12 files), including the new regression test
* `npm run typecheck` — passed
* `npm run check` — passed (typecheck, build, `scripts/restart-smoke.mjs` ok)
* `git diff --check` — clean
