### PR TITLE
fix(cli): avoid Node DEP0190 shell+argv spawn on Windows

### DIFF
--- a/scripts/smoke-spawn.mjs
+++ b/scripts/smoke-spawn.mjs
@@ -2,16 +2,29 @@
 /**
  * Cross-platform smoke for the tool-spawning pattern used by routes.ts.
  * On Windows, npm/corepack/pnpm are `.cmd` shims that node:child_process
- * cannot start without a shell (#2/#3/#5) — this guards the `shell` flag
- * from regressing. Runs in CI on windows-latest and ubuntu-latest.
+ * cannot start without a shell (#2/#3/#5) — this guards the cmd.exe shim
+ * path from regressing. Runs in CI on windows-latest and ubuntu-latest.
  */
 import { spawn } from 'node:child_process'
 
-const winCmdShim = process.platform === 'win32'
+const CMD_METACHARS = /[\s"&|<>^()%!]/
+
+const quoteCmdArg = (arg) => (
+  CMD_METACHARS.test(arg) ? `"${arg.replace(/"/g, '""')}"` : arg
+)
 
 function probe(file, args) {
   return new Promise((resolve) => {
-    const child = spawn(file, args, { stdio: 'ignore', shell: winCmdShim })
+    let child
+    if (process.platform === 'win32') {
+      const command = [file, ...args].map(quoteCmdArg).join(' ')
+      child = spawn(process.env.ComSpec ?? 'cmd.exe', ['/d', '/s', '/c', `"${command}"`], {
+        stdio: 'ignore',
+        windowsVerbatimArguments: true,
+      })
+    } else {
+      child = spawn(file, args, { stdio: 'ignore' })
+    }
     child.on('error', () => resolve(false))
     child.on('close', (code) => resolve(code === 0))
   })
@@ -30,4 +43,4 @@ if (!results[1]) {
   console.error(`smoke failed on ${process.platform}: spawn pnpm --version did not exit 0 (is pnpm set up in CI?)`)
   process.exit(1)
 }
-console.log(`smoke ok on ${process.platform}: npm + pnpm spawn with shell=${String(winCmdShim)}`)
+console.log(`smoke ok on ${process.platform}: npm + pnpm spawn via ${process.platform === 'win32' ? 'cmd.exe shim' : 'direct spawn'}`)

--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawn } from 'node:child_process'
-import type { ChildProcess } from 'node:child_process'
+import type { ChildProcess, SpawnOptions } from 'node:child_process'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { logEvent } from './log.ts'
@@ -42,6 +42,56 @@ const INSTALL_TIMEOUT_MS = Number(process.env.DSH_MARKET_INSTALL_TIMEOUT_MS) || 
  * cannot start them (ENOENT / EINVAL). Same pattern as dsh's `plugin` forwarder.
  */
 export const winCmdShim = process.platform === 'win32'
+
+/** Characters cmd.exe treats as syntax even inside a token. */
+const CMD_METACHARS = /[\s"&|<>^()%!]/
+
+/**
+ * Quote one argv token for a cmd.exe `/c` command line. cmd only groups with
+ * double quotes, so a token that needs quoting gets wrapped and embedded
+ * quotes are doubled.
+ */
+export function quoteCmdArg(arg: string): string {
+  if (!CMD_METACHARS.test(arg)) return arg
+  return `"${arg.replace(/"/g, '""')}"`
+}
+
+/**
+ * Build a cmd.exe command line from argv. Only the Windows shim path uses
+ * this: cmd re-parses the joined string, so every token is quoted before
+ * joining.
+ */
+export function cmdCommandLine(argv: readonly string[]): string {
+  return argv.map(quoteCmdArg).join(' ')
+}
+
+/** cmd.exe resolved once; the Windows shim path only. */
+const COMSPEC = process.env.ComSpec ?? 'cmd.exe'
+
+/** Spawn options plus the explicit shim switch used by callers. */
+type SpawnShimOptions = SpawnOptions & { viaShell?: boolean }
+
+/**
+ * Spawn a command, avoiding Node's deprecated `shell: true` + argv
+ * combination (DEP0190). Windows `.cmd` shims cannot start without a shell,
+ * so the shim path routes through `cmd.exe /d /s /c` with an explicitly
+ * built, quoted command line; every other invocation spawns directly with
+ * `shell: false`.
+ */
+function spawnShim(file: string, args: readonly string[], options: SpawnShimOptions): ChildProcess {
+  const { viaShell = false, ...spawnOptions } = options
+  if (!viaShell) {
+    return spawn(file, [...args], { ...spawnOptions, shell: false })
+  }
+  if (process.platform !== 'win32') {
+    return spawn(file, [...args], { ...spawnOptions, shell: false })
+  }
+  return spawn(COMSPEC, ['/d', '/s', '/c', `"${cmdCommandLine([file, ...args])}"`], {
+    ...spawnOptions,
+    shell: false,
+    windowsVerbatimArguments: true,
+  })
+}
 
 /**
  * Argv re-invoking the CLI that launched this host process, so installs work
@@ -190,7 +240,7 @@ let pnpmReady = false
 export function probePnpm(): Promise<boolean> {
   if (pnpmReady) return Promise.resolve(true)
   return new Promise((resolvePromise) => {
-    const child = spawn('pnpm', ['--version'], { stdio: 'ignore', shell: winCmdShim, env: spawnEnv() })
+    const child = spawnShim('pnpm', ['--version'], { stdio: 'ignore', viaShell: winCmdShim, env: spawnEnv() })
     child.on('error', () => resolvePromise(false))
     child.on('close', (code) => {
       pnpmReady = code === 0
@@ -201,16 +251,16 @@ export function probePnpm(): Promise<boolean> {
 
 function runQuiet(file: string, args: string[], timeoutMs: number): Promise<{ code: number | null; output: string }> {
   return new Promise((resolvePromise) => {
-    const child = spawn(file, args, {
+    const child = spawnShim(file, args, {
       env: spawnEnv(),
       stdio: ['ignore', 'pipe', 'pipe'],
-      shell: winCmdShim,
+      viaShell: winCmdShim,
     })
     let output = ''
     const timer = setTimeout(() => killChild(child), timeoutMs)
     const collect = (chunk: Buffer): void => { output = (output + chunk.toString()).slice(-8 * 1024) }
-    child.stdout.on('data', collect)
-    child.stderr.on('data', collect)
+    child.stdout?.on('data', collect)
+    child.stderr?.on('data', collect)
     child.on('error', (error) => { clearTimeout(timer); resolvePromise({ code: 127, output: error.message }) })
     child.on('close', (code) => { clearTimeout(timer); resolvePromise({ code, output }) })
   })
@@ -359,14 +409,14 @@ export function runDshPlugin(profile: string, pluginArgs: string[]): Promise<Ins
   const tracker = beginProgress(prepared.target)
   const feed = makeProgressFeeder(tracker)
   return new Promise((resolvePromise) => {
-    const child = spawn(file, [...args, 'plugin', '--profile', profile, ...pluginArgs], {
+    const child = spawnShim(file, [...args, 'plugin', '--profile', profile, ...pluginArgs], {
       cwd,
       // pnpm v10 blocks forever on a silent interactive prompt without a TTY
       // (observed on re-add over a pinned git spec); CI mode forces it to act
       // or fail instead of asking.
       env: spawnEnv(),
       stdio: ['ignore', 'pipe', 'pipe'],
-      shell: viaShell,
+      viaShell,
       // Own process group on POSIX so cancel/timeout can kill the whole
       // tree (dsh wrapper + pnpm grandchild) with one group signal.
       detached: process.platform !== 'win32',
@@ -380,13 +430,13 @@ export function runDshPlugin(profile: string, pluginArgs: string[]): Promise<Ins
       timedOut = true
       killTree(child)
     }, INSTALL_TIMEOUT_MS)
-    child.stdout.on('data', (chunk: Buffer) => {
+    child.stdout?.on('data', (chunk: Buffer) => {
       const text = chunk.toString()
       stdout = (stdout + text).slice(-256 * 1024)
       feed(text)
       syncProgress(tracker)
     })
-    child.stderr.on('data', (chunk: Buffer) => {
+    child.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString()
       stderr = (stderr + text).slice(-64 * 1024)
       feed(text)

--- a/tests/dsh-cli.spec.ts
+++ b/tests/dsh-cli.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { cmdCommandLine, quoteCmdArg } from '../src/dsh-cli.ts'
+
+describe('cmd.exe command line building (DEP0190 shim)', () => {
+  it('keeps simple tokens unquoted', () => {
+    expect(quoteCmdArg('pnpm')).toBe('pnpm')
+    expect(quoteCmdArg('--version')).toBe('--version')
+    expect(cmdCommandLine(['pnpm', '--version'])).toBe('pnpm --version')
+  })
+
+  it('quotes tokens containing whitespace or cmd metacharacters', () => {
+    expect(quoteCmdArg('C:\\Program Files\\nodejs\\node.exe')).toBe('"C:\\Program Files\\nodejs\\node.exe"')
+    expect(quoteCmdArg('a&b')).toBe('"a&b"')
+    expect(quoteCmdArg('x|y')).toBe('"x|y"')
+    expect(quoteCmdArg('x^y')).toBe('"x^y"')
+  })
+
+  it('doubles embedded double quotes', () => {
+    expect(quoteCmdArg('say "hi"')).toBe('"say ""hi"""')
+  })
+
+  it('joins argv in order for the dsh plugin forwarder', () => {
+    expect(cmdCommandLine(['dsh', 'plugin', '--profile', 'web', 'add', '@scope/pkg'])).toBe(
+      'dsh plugin --profile web add @scope/pkg',
+    )
+  })
+})


### PR DESCRIPTION
## Problem

Node 24 emits `DEP0190 DeprecationWarning` on every market status probe
(`pnpm --version`) and on install/update runs on Windows, because
`spawn(file, args, { shell: true })` passes argv alongside a shell — Node
concatenates the arguments unescaped, which is deprecated.

Windows `pnpm`/`npm`/`dsh` are `.cmd` shims that still require a shell, so
the flag cannot simply be removed.

## Change

- Add `spawnShim()`: the Windows shim path builds an explicitly quoted
  command line (`quoteCmdArg` / `cmdCommandLine`) and spawns
  `cmd.exe /d /s /c` with `shell: false` + `windowsVerbatimArguments`.
- Migrate `probePnpm`, `runQuiet`, and `runDshPlugin` to `spawnShim`.
  POSIX behavior is unchanged (direct, shell-free spawn).
- Update `scripts/smoke-spawn.mjs` to exercise the same shim path in CI.
- Add unit tests for cmd.exe quoting and command-line assembly.

## Verification

- `npm run typecheck`
- `npm test` — 131 passed
- `npm run build`
- `node scripts/preflight.mjs`
- `node scripts/restart-smoke.mjs`
- `node scripts/smoke-spawn.mjs` — `smoke ok on win32: npm + pnpm spawn via cmd.exe shim`
- `probePnpm()` on Windows returns `true` with no DEP0190 warning