### PR TITLE
fix(backup): browser download navigation sends no Origin header — 403

### DIFF
--- a/src/restart.ts
+++ b/src/restart.ts
@@ -39,6 +39,33 @@ export function trustedRestartRequest(request: Pick<IncomingMessage, 'headers' |
   }
 }
 
+/**
+ * Whether a download navigation may fetch a sensitive GET export.
+ * Browsers do NOT send an Origin header on same-origin GET navigations
+ * (`<a href="/..." download>`), so unlike process-control requests a missing
+ * Origin is the NORMAL shape of a user-initiated download and must pass.
+ * Keep the rest of the posture: loopback peer only, no proxy forwarding
+ * headers, and — when an Origin IS present (fetch/CORS attempts) — it must
+ * still match Host so a cross-origin page cannot read the export.
+ */
+export function trustedDownloadRequest(request: Pick<IncomingMessage, 'headers' | 'socket'>): boolean {
+  const address = request.socket.remoteAddress
+  if (address !== '127.0.0.1' && address !== '::1' && address !== '::ffff:127.0.0.1') return false
+  if (request.headers.forwarded !== undefined
+    || request.headers['x-forwarded-for'] !== undefined
+    || request.headers['x-real-ip'] !== undefined) return false
+  const origin = request.headers.origin
+  const host = request.headers.host
+  if (host === undefined) return false
+  if (origin === undefined) return true // plain browser download navigation
+  try {
+    const parsed = new URL(origin)
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.host === host
+  } catch {
+    return false
+  }
+}
+
 /** The exact boot invocation the detached restart helper replays. */
 export function restartLaunch(): { file: string; args: string[]; cwd: string; viaShell: boolean } {
   const launch = dshArgv()

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -27,7 +27,7 @@ import { isStaleUpdate, parseIgnoredBuilds, parsePrepareNotAllowed, RELEASE_AGE_
 import { checkUpdates, fetchNpmLatest, invalidateUpdates, isUpgrade, latestPublishedRecently } from './updates.ts'
 import { createThemeManager, type LoaderEntry } from './themes.ts'
 import { readJsonBody, sameOrigin, sendJson } from './http.ts'
-import { restartAllowed, scheduleRestart, trustedRestartRequest } from './restart.ts'
+import { restartAllowed, scheduleRestart, trustedRestartRequest, trustedDownloadRequest } from './restart.ts'
 import { verifyActivation } from './verify.ts'
 import {
   createProfileBackup, downloadWebdav, MAX_BACKUP_BYTES, restoreProfileBackup, secretFileCount, uploadWebdav,
@@ -248,9 +248,11 @@ export function mountMarketRoutes(
           return
         }
         // Profile exports carry configuration that may include credentials
-        // (config.toml, .env, …), so they are limited to same-origin loopback
-        // requests exactly like process control (review #63).
-        if (!trustedRestartRequest(request)) {
+        // (config.toml, .env, …), so they stay limited to loopback peers
+        // without proxy forwarding (review #63). Unlike process control,
+        // browsers omit the Origin header on `<a download>` GET navigations,
+        // so a missing Origin passes; a present one must still match Host.
+        if (!trustedDownloadRequest(request)) {
           sendJson(response, 403, { error: 'backup export is limited to same-origin loopback requests' })
           return
         }

--- a/tests/restart.spec.ts
+++ b/tests/restart.spec.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { respawnInvocation } from '../src/restart.ts'
+import { respawnInvocation, trustedDownloadRequest } from '../src/restart.ts'
 
 const LAUNCH = { file: 'C:\\Program Files\\nodejs\\node.exe', args: ['--import', 'tsx/esm', 'bin.ts', '--profile', 'web'], viaShell: false }
 
@@ -34,5 +34,38 @@ describe('respawnInvocation (#40)', () => {
   it('keeps the plain detached spawn on POSIX', () => {
     const spawned = respawnInvocation({ file: 'node', args: ['bin.ts'], viaShell: false }, 'darwin')
     expect(spawned).toEqual({ file: 'node', args: ['bin.ts'], viaShell: false, detached: true })
+  })
+})
+
+/**
+ * The backup export is a GET navigation (`<a href="/dsh-market/backup"
+ * download>`), and browsers do NOT send an Origin header on same-origin GET
+ * navigations — so the download trust check must treat a missing Origin as
+ * the normal user-initiated shape, unlike process control.
+ */
+describe('trustedDownloadRequest', () => {
+  const req = (headers: Record<string, string>, remoteAddress = '127.0.0.1') =>
+    ({ headers, socket: { remoteAddress } }) as unknown as Parameters<typeof trustedDownloadRequest>[0]
+
+  it('accepts a plain download navigation without an Origin header', () => {
+    expect(trustedDownloadRequest(req({ host: '127.0.0.1:3080' }))).toBe(true)
+  })
+
+  it('accepts a same-origin Origin header (fetch-style request)', () => {
+    expect(trustedDownloadRequest(req({ host: '127.0.0.1:3080', origin: 'http://127.0.0.1:3080' }))).toBe(true)
+  })
+
+  it('refuses a cross-origin Origin so another page cannot read the export', () => {
+    expect(trustedDownloadRequest(req({ host: '127.0.0.1:3080', origin: 'http://evil.example' }))).toBe(false)
+    expect(trustedDownloadRequest(req({ host: '127.0.0.1:3080', origin: 'not a url' }))).toBe(false)
+  })
+
+  it('keeps the process-control posture: loopback peer, no proxy headers', () => {
+    expect(trustedDownloadRequest(req({ host: 'x' }, '192.168.1.5'))).toBe(false)
+    expect(trustedDownloadRequest(req({ host: 'x' }, '10.0.0.2'))).toBe(false)
+    expect(trustedDownloadRequest(req({ host: 'x', forwarded: 'for=1.2.3.4' }))).toBe(false)
+    expect(trustedDownloadRequest(req({ host: 'x', 'x-forwarded-for': '1.2.3.4' }))).toBe(false)
+    expect(trustedDownloadRequest(req({ host: 'x', 'x-real-ip': '1.2.3.4' }))).toBe(false)
+    expect(trustedDownloadRequest(req({}, '127.0.0.1'))).toBe(false) // Host required
   })
 })


### PR DESCRIPTION
## 问题 | Problem

在「备份与恢复」点击下载备份，浏览器下载栏显示 **`backup.json — File wasn`t available on site`**，下载失败。

Clicking the download button in the backup & restore section fails: the browser download bar shows **`backup.json — File wasn`t available on site`**.

## 根因 | Root cause

下载按钮是 `<a href="/dsh-market/backup" download>`。浏览器对**同源 GET 导航**请求不发送 `Origin` 头，而该路由复用了为 POST 进程控制设计的 `trustedRestartRequest`——它要求 `origin !== undefined`，于是导航请求被 403。

实测对照（curl）：带 `Origin` 头 → 200；不带 → 403。文件名显示为 `backup.json`（URL 末段 + 403 响应的 JSON content-type 推断）而非 `content-disposition` 中的 `dsh-dshmarket-backup-<ts>.json`，证明请求死在 403 分支。

The export link is a GET navigation. Browsers send **no Origin header** on same-origin GET navigations, but the route reuses `trustedRestartRequest` (designed for POST process control), which requires Origin to be present → 403 for every plain download click. A present-Origin request (curl/fetch) works, which makes the bug look intermittent.

## 修复 | Fix

新增 `trustedDownloadRequest` 并让 `/dsh-market/backup` 使用它：

- 保持：仅 loopback 直连、拒绝 `forwarded` / `x-forwarded-for` / `x-real-ip`、`Host` 必填
- 变化：**Origin 缺失视为普通浏览器下载导航，放行**
- 不变：Origin 存在时仍须与 Host 匹配（跨域页面无法读取导出内容）；`/dsh-market/restart` 继续使用严格的 `trustedRestartRequest`

Keeps the loopback-only peer check, proxy-header refusal, and Host requirement; a **missing** Origin is now accepted as the normal download-navigation shape, while a present Origin must still match Host. Process control keeps the strict check.

## 测试 | Tests

- `tests/restart.spec.ts` 新增 4 个用例：无 Origin 放行、同源 Origin 放行、跨域/非法 Origin 拒绝、非 loopback / 代理头 / 缺 Host 拒绝
- 全量：17 个测试文件 / **159 passed**；`tsc --noEmit` 通过

4 new cases in `tests/restart.spec.ts`; full suite 159 passed, typecheck clean.

复现环境：dshmarket 1.7.0 (beb8576)，macOS，Chrome。修复后下载成功产出完整的 `dsh-profile-backup` v0.2 导出（已验证内容与 profile 逐字节一致）。