### PR TITLE
fix(profile): quote reserved YAML keys in the allowBuilds block

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -242,6 +242,28 @@ export function pluginSubdirs(root: string): string[] {
  * (#6 by @qichuang321.)
  * @returns every package now allowed.
  */
+/**
+ * Quote a YAML block-mapping key when a plain scalar would be invalid.
+ * Scoped npm names start with `@` — a reserved YAML indicator — so an
+ * unquoted `@scope/pkg: true` entry breaks the whole pnpm-workspace.yaml
+ * for every later pnpm run in the profile (and for the market itself).
+ * Keys containing `: ` or ending with `:` are quoted for the same reason;
+ * git keys like `name@git+https://…` keep their existing plain form.
+ */
+function quoteYamlKey(key: string): string {
+  if (/^[-?:,[\]{}#&*!|>'"%@`]/.test(key) || /:(\s|$)/.test(key)) {
+    return `'${key.replace(/'/g, "''")}'`
+  }
+  return key
+}
+
+/**
+ * Allow the given packages' build scripts in the profile's
+ * pnpm-workspace.yaml `allowBuilds` block (the key dsh profiles use),
+ * merging with existing entries and leaving the rest of the yaml intact.
+ * (#6 by @qichuang321.)
+ * @returns every package now allowed.
+ */
 export function setAllowBuilds(profile: string, packages: string[], explicitDir?: string): string[] {
   const file = join(profileDir(profile, explicitDir), 'pnpm-workspace.yaml')
   let yaml = ''
@@ -259,7 +281,16 @@ export function setAllowBuilds(profile: string, packages: string[], explicitDir?
       // which breaks every later approval until the entry is dropped.
       const m = /^[ \t]+(\S.*?)\s*:\s*(true|false)?\s*$/.exec(line)
       if (m === null || m[1] === '') continue
-      map[m[1]] = m[2] ?? 'true'
+      // Entries this fix wrote may carry single/double quotes around the key
+      // (reserved indicators like `@` cannot start a plain scalar); strip
+      // them so the map key is the bare package name and a later rewrite
+      // never nests quotes.
+      let key = m[1]
+      if (key.length >= 2
+        && (key[0] === "'" && key[key.length - 1] === "'" || key[0] === '"' && key[key.length - 1] === '"')) {
+        key = key.slice(1, -1)
+      }
+      map[key] = m[2] ?? 'true'
     }
   }
   // Bare package names, or the server-derived stable git form
@@ -268,7 +299,7 @@ export function setAllowBuilds(profile: string, packages: string[], explicitDir?
   for (const pkg of packages) {
     if (/^[A-Za-z0-9@/_.-]+$/.test(pkg) || GIT_KEY_RE.test(pkg)) map[pkg] = 'true'
   }
-  const block = Object.entries(map).map(([k, v]) => `  ${k}: ${v}`).join('\n')
+  const block = Object.entries(map).map(([k, v]) => `  ${quoteYamlKey(k)}: ${v}`).join('\n')
   const blockText = `allowBuilds:\n${block}\n`
   writeFileSync(file, blockMatch !== null ? yaml.replace(blockRe, blockText) : `${yaml.replace(/\n?$/, '\n')}${blockText}`)
   return Object.keys(map)

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -199,6 +199,32 @@ describe('setAllowBuilds (#6)', () => {
     expect(yaml).toMatch(/plain: false/)
   })
 
+  it('quotes scoped `@` keys so the block stays valid YAML', async () => {
+    const { setAllowBuilds } = await import('../src/profile.ts')
+    const dir = writeProfile({})
+    writeFileSync(join(dir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+    const approved = setAllowBuilds('web', ['@deepseek-ai/dsh-subprocess-local', 'plain-pkg'])
+    expect(approved).toContain('@deepseek-ai/dsh-subprocess-local')
+    const yaml = readFileSync(join(dir, 'pnpm-workspace.yaml'), 'utf8')
+    // `@` cannot start a plain YAML scalar; the key must be quoted or pnpm
+    // fails to parse the workspace on every later run.
+    expect(yaml).toContain("'@deepseek-ai/dsh-subprocess-local': true")
+    expect(yaml).toMatch(/plain-pkg: true/)
+  })
+
+  it('round-trips an already-quoted scoped key without nesting quotes', async () => {
+    const { setAllowBuilds } = await import('../src/profile.ts')
+    const dir = writeProfile({})
+    writeFileSync(join(dir, 'pnpm-workspace.yaml'),
+      "packages:\n  - .\n\nallowBuilds:\n  '@google/genai': true\n")
+    const approved = setAllowBuilds('web', ['ssh2'])
+    expect(approved).toContain('@google/genai')
+    const yaml = readFileSync(join(dir, 'pnpm-workspace.yaml'), 'utf8')
+    expect(yaml).toContain("'@google/genai': true")
+    expect(yaml).not.toContain("''@google/genai''")
+    expect(yaml).toContain('ssh2: true')
+  })
+
   it('creates the block when the yaml has none', async () => {
     const { setAllowBuilds } = await import('../src/profile.ts')
     const dir = writeProfile({})


### PR DESCRIPTION
## Summary

`setAllowBuilds` in `src/profile.ts` writes package keys into the profile's `pnpm-workspace.yaml` `allowBuilds` block **verbatim**. Scoped npm names start with `@` — a reserved YAML indicator that cannot begin a plain scalar — so approving a build for e.g. `@deepseek-ai/dsh-subprocess-local` produces:

```yaml
allowBuilds:
  @deepseek-ai/dsh-subprocess-local: true
```

which is invalid YAML. Every later pnpm run in that profile (install, update, even the market's own flows) then fails with a misleading `bad indentation of a mapping entry` error — the file is bricked until manually repaired.

## Change

- **Emit side**: quote a key whenever a plain scalar cannot represent it — reserved leading indicators (`@ % ` " '` and friends), or `: ` / trailing `:`. Git keys like `name@git+https://github.com/owner/repo.git` (#68) keep their existing plain form.
- **Parse side**: when re-reading the block, strip surrounding single/double quotes from captured keys so a later rewrite never nests quotes (`''@scope/pkg''`).

## Tests

Two new cases in `tests/profile.spec.ts`:
- scoped `@` keys are written quoted and stay valid YAML,
- an already-quoted scoped key round-trips without quote nesting.

Verified locally: `vitest run tests/profile.spec.ts` — 13 tests passed (11 existing + 2 new); `tsc -p tsconfig.json --noEmit` clean.

This is the bug we hit on a real machine: the market approved a build for `@deepseek-ai/dsh-subprocess-local` while installing `dsh-browser`, and the resulting unquoted key broke `pnpm-workspace.yaml` for every subsequent operation.