### PR TITLE
fix(install): recognize pnpm fetch timeouts and retry with a longer fetchTimeout

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -16,7 +16,16 @@ import { logEvent } from './log.ts'
 export const RELEASE_AGE_OVERRIDE = '--config.minimumReleaseAge=0'
 
 /**
- * Run one plugin command with automatic recovery from two known pnpm traps:
+ * Longer per-request fetch timeout for one retried command. pnpm's default
+ * 60-second limit aborts large tarball downloads (github: sources fetch the
+ * WHOLE repo even for a `#path:` subdirectory plugin) on slow networks; a
+ * plain retry fails again at the same limit, so the recovery re-runs with
+ * this override once. Scoped to a single command like RELEASE_AGE_OVERRIDE.
+ */
+export const FETCH_TIMEOUT_OVERRIDE = '--config.fetchTimeout=600000'
+
+/**
+ * Run one plugin command with automatic recovery from three known pnpm traps:
  *
  * - pnpm-major drift (#20 bug 2): a modules directory built by a different
  *   pnpm major fails mutation; pnpm's documented remedy is one `install` to
@@ -26,6 +35,10 @@ export const RELEASE_AGE_OVERRIDE = '--config.minimumReleaseAge=0'
  *   retry once with the one-shot minimumReleaseAge bypass (safe: the young
  *   package is already installed; the bypass only lets pnpm touch the
  *   lockfile again).
+ * - per-request fetch timeout: large tarballs (github: sources fetch the
+ *   whole repo even for a `#path:` subdirectory) on slow networks blow
+ *   pnpm's default 60-second limit; a plain retry fails again at the same
+ *   limit, so retry once with a longer fetchTimeout.
  *
  * Any recognized failure that survives gets its bilingual explanation
  * appended to stderr so the UI shows an actionable message instead of a
@@ -58,6 +71,16 @@ export async function withHoistRecovery(run: PluginRunner, profile: string, plug
       // Do that retry ourselves instead of reporting a false failure.
       logEvent('warn', 'install', `transient network failure while pnpm replayed the dependency tree (#83) — retrying once`)
       result = await run(profile, pluginArgs)
+    } else if (
+      failure?.code === 'fetch-timeout'
+      && (pluginArgs[0] === 'add' || pluginArgs[0] === 'remove')
+      && !pluginArgs.includes(FETCH_TIMEOUT_OVERRIDE)
+    ) {
+      // Large tarball / slow network: pnpm's default 60s per-request limit
+      // aborted the download. A plain retry fails again at the same limit,
+      // so retry once with a longer fetchTimeout.
+      logEvent('warn', 'install', `pnpm's per-request fetch timeout aborted a large download — retrying once with ${FETCH_TIMEOUT_OVERRIDE}`)
+      result = await run(profile, [pluginArgs[0], FETCH_TIMEOUT_OVERRIDE, ...pluginArgs.slice(1)])
     }
   }
   if (!ok(result) && !result.cancelled) {

--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -36,7 +36,7 @@ export function pluginArgsFor(profileDir: string, pluginArgs: string[]): string[
 /** One recognized pnpm failure, with a bilingual explanation for the UI. */
 export interface PnpmFailure {
   code: 'adding-to-root' | 'not-a-workspace' | 'hoist-pattern-diff' | 'pnpm-missing' | 'release-age-violation'
-    | 'ignored-builds' | 'git-prepare-not-allowed' | 'fetch-404' | 'transient-network'
+    | 'ignored-builds' | 'git-prepare-not-allowed' | 'fetch-404' | 'transient-network' | 'fetch-timeout'
   /** Bilingual, actionable message shown to the user instead of the raw wall of text. */
   message: string
   /** True when re-running `pnpm install` in the profile is the documented recovery. */
@@ -51,6 +51,20 @@ export interface PnpmFailure {
  */
 export function isTransientPnpmFailure(output: string): boolean {
   return /ERR_PNPM_FETCH_5\d\d|ERR_PNPM_META_FETCH_FAIL|FetchError|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|socket hang up|network timeout/i.test(output)
+}
+
+/**
+ * pnpm's per-request fetch timeout: the abort surfaces as a DOMException
+ * ("The operation was aborted due to timeout", code 23) through undici —
+ * pnpm logs it as `GET … error (23)` before giving up. This is the failure
+ * shape for large tarballs (github: sources download the WHOLE repo, even
+ * for a `#path:` subdirectory plugin) on slow networks: pnpm's default
+ * 60-second limit is simply not enough, so a plain retry fails again at the
+ * same limit. The market's recovery re-runs once with a longer
+ * fetchTimeout (see withHoistRecovery).
+ */
+export function isFetchTimeoutFailure(output: string): boolean {
+  return /operation was aborted due to timeout|TimeoutError|error \(23\)/i.test(output)
 }
 
 /**
@@ -145,6 +159,17 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
       code: 'transient-network',
       recoverable: false,
       message: '拉取依赖时网络临时失败（不一定是你正在装的插件——安装会重放整个依赖树，任何一个既有依赖抖动都会中断）。已自动重试一次仍失败，请稍后再试 / a transient network failure while fetching dependencies (not necessarily the plugin you are installing — installs replay the whole dependency tree, so any existing dependency can hiccup); one automatic retry failed too — please try again shortly',
+    }
+  }
+  // pnpm's per-request fetch timeout (#…): large tarballs (github: sources
+  // fetch the whole repo even for a `#path:` subdirectory) on slow networks
+  // blow pnpm's default 60s limit. A plain retry fails again at the same
+  // limit, so withHoistRecovery retries with a longer fetchTimeout.
+  if (isFetchTimeoutFailure(output)) {
+    return {
+      code: 'fetch-timeout',
+      recoverable: false,
+      message: '下载超时：这个插件的安装包较大（github 源会下载整个仓库）或网络较慢，pnpm 默认的单次请求 60 秒限制不够用。市场已用更长的超时自动重试一次；若仍失败，请稍后再试或检查网络 / download timed out: this plugin ships a large tarball (github sources download the whole repository) or your network is slow, and pnpm\'s default 60-second per-request limit was not enough; the market retries once with a longer timeout — if it still fails, try again later or check the network',
     }
   }
   if (output.includes('pnpm not found on PATH')) {

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -9,7 +9,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { InstallResult } from '../src/dsh-cli.ts'
-import { isStaleUpdate, parseIgnoredBuilds, parsePrepareNotAllowed, retargetCollections, validateAddedPlugins } from '../src/install.ts'
+import {
+  FETCH_TIMEOUT_OVERRIDE, isStaleUpdate, parseIgnoredBuilds, parsePrepareNotAllowed,
+  retargetCollections, validateAddedPlugins, withHoistRecovery,
+} from '../src/install.ts'
 import { profileDir } from '../src/profile.ts'
 
 let home: string
@@ -23,6 +26,8 @@ afterEach(() => {
 })
 
 const ok: InstallResult = { exitCode: 0, timedOut: false, stdout: '', stderr: '', cancelled: false }
+
+const FETCH_TIMEOUT_STDERR = '[23] The operation was aborted due to timeout\n\nTimeoutError: The operation was aborted due to timeout'
 
 function recordingRunner(): { calls: string[][]; run: (profile: string, args: string[]) => Promise<InstallResult> } {
   const calls: string[][] = []
@@ -116,6 +121,40 @@ describe('validateAddedPlugins (#18 / #21)', () => {
     expect(keep.sort()).toEqual(['@linxin666/dsh-client-ui-skin-center', '@linxin666/dsh-skins'])
     expect(removedBroken).toEqual([])
     expect(calls).toEqual([])
+  })
+})
+
+describe('withHoistRecovery', () => {
+  it('retries a per-request fetch timeout once with a longer fetchTimeout (#…)', async () => {
+    const calls: string[][] = []
+    let failFirst = true
+    const run = async (_profile: string, args: string[]): Promise<InstallResult> => {
+      calls.push(args)
+      if (failFirst) {
+        failFirst = false
+        return { exitCode: 1, timedOut: false, stdout: '', stderr: FETCH_TIMEOUT_STDERR, cancelled: false }
+      }
+      return ok
+    }
+    const result = await withHoistRecovery(run, 'web', ['add', 'github:volcengine/OpenViking#path:/examples/dsh-memory-plugin'])
+    expect(result.exitCode).toBe(0)
+    expect(calls).toEqual([
+      ['add', 'github:volcengine/OpenViking#path:/examples/dsh-memory-plugin'],
+      ['add', FETCH_TIMEOUT_OVERRIDE, 'github:volcengine/OpenViking#path:/examples/dsh-memory-plugin'],
+    ])
+  })
+
+  it('does not double-apply the fetchTimeout override when it is already present', async () => {
+    const calls: string[][] = []
+    const run = async (_profile: string, args: string[]): Promise<InstallResult> => {
+      calls.push(args)
+      return { exitCode: 1, timedOut: false, stdout: '', stderr: FETCH_TIMEOUT_STDERR, cancelled: false }
+    }
+    const result = await withHoistRecovery(run, 'web', ['add', FETCH_TIMEOUT_OVERRIDE, 'dsh-loop'])
+    expect(result.exitCode).toBe(1)
+    expect(calls).toEqual([['add', FETCH_TIMEOUT_OVERRIDE, 'dsh-loop']])
+    // The final failure message is appended for the UI.
+    expect(result.stderr).toContain('下载超时')
   })
 })
 

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -79,6 +79,20 @@ describe('classifyPnpmFailure', () => {
     expect(classifyPnpmFailure('[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/ghost: Not Found - 404')?.code).toBe('fetch-404')
   })
 
+  it('recognizes pnpm\u2019s per-request fetch timeout as fetch-timeout, not transient (#…)', () => {
+    // The exact pnpm/undici abort shape for a large tarball that outlives the
+    // default 60s limit: DOMException "The operation was aborted due to
+    // timeout" (code 23), logged by pnpm as a retried GET error.
+    const abort = classifyPnpmFailure('[WARN] GET https://codeload.github.com/volcengine/OpenViking/tar.gz/dbf3fcccefe43616e4b1c3b60dfe36c2222e2dd6 error (23). Will retry in 10 seconds. 2 retries left.\n[23] The operation was aborted due to timeout\n\nTimeoutError: The operation was aborted due to timeout\n    at new DOMException (node:internal/per_context/domexception:76:18)')
+    expect(abort?.code).toBe('fetch-timeout')
+    expect(abort?.message).toContain('下载超时')
+    // The transient regex must NOT claim the same text — the two recoveries
+    // differ (plain retry vs longer fetchTimeout).
+    expect(classifyPnpmFailure('TimeoutError: The operation was aborted due to timeout')?.code).toBe('fetch-timeout')
+    // Unrelated shapes stay unrecognized.
+    expect(classifyPnpmFailure('some other failure')?.code).toBeUndefined()
+  })
+
   it('recognizes both build-script blocks: ignored builds (#69) and the git-prepare fetcher rejection (#68)', () => {
     const ignored = classifyPnpmFailure('[ERR_PNPM_IGNORED_BUILDS]\nIgnored build scripts: dsh-github-intelligence@https://codeload.github.com/z/r/tar.gz/abc.')
     expect(ignored?.code).toBe('ignored-builds')


### PR DESCRIPTION
## Summary

pnpm's per-request fetch timeout aborts large tarball downloads. A `github:` source fetches the **whole repository** even for a `#path:` subdirectory plugin, and on slow networks pnpm's default 60-second per-request limit is simply not enough — the download is aborted with a DOMException (`The operation was aborted due to timeout`, code 23), logged by pnpm as `GET … error (23)` with internal retries.

That abort shape was **not** recognized by `isTransientPnpmFailure`, so the market neither retried nor explained it — users saw a raw `TimeoutError` wall of text for a perfectly installable plugin. Worse, a plain retry (the transient-network recovery) would fail again at the same 60s limit.

## Change

- **`src/pnpm-compat.ts`**: classify the abort signature (`operation was aborted due to timeout`, `TimeoutError`, `error (23)`) as a new `fetch-timeout` failure with an actionable bilingual message.
- **`src/install.ts`**: `withHoistRecovery` retries `add`/`remove` once with `--config.fetchTimeout=600000` (one-shot override, scoped like `RELEASE_AGE_OVERRIDE`) — a 10-minute per-request budget that survives multi-hundred-MB monorepo tarballs on slow links.

## Tests

- `tests/pnpm-compat.spec.ts`: the exact pnpm/undici abort text classifies as `fetch-timeout` (and not `transient-network`); unrelated output stays unrecognized.
- `tests/install.spec.ts`: a fetch-timeout failure triggers exactly one retry carrying `FETCH_TIMEOUT_OVERRIDE`; an already-overridden argv is not retried again and the final failure message reaches the UI.

Local: 223/224 tests pass. The single failure (`tests/backup.spec.ts` symlink creation) also fails on a clean checkout on this machine — Windows requires elevation to create symlinks, unrelated to this change.

## Background

Encountered in the wild: installing `@openviking/dsh-memory-plugin` (`github:volcengine/OpenViking#path:/examples/dsh-memory-plugin`) — a ~100MB monorepo tarball on a network that reaches codeload at ~300KB/s — timed out repeatedly before the fix; with the longer fetchTimeout the same download completes.