### PR TITLE
feat(registry): add FrameFactory plugin

### DIFF
--- a/data/registry-snapshot.json
+++ b/data/registry-snapshot.json
@@ -3,7 +3,7 @@
  "url": "https://awesome-dsh-plugin.com",
  "source": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin",
  "updated": "2026-08-16",
- "count": 839,
+ "count": 840,
  "categories": {
   "ui": {
    "en": "UI Enhancements",
@@ -55,6 +55,21 @@
   }
  },
  "plugins": [
+  {
+   "name": "FrameFactory",
+   "owner": "anywhere-labs",
+   "url": "https://github.com/anywhere-labs/framefactory-plugin",
+   "page": "https://awesome-dsh-plugin.com/p/anywhere-labs/framefactory-plugin/",
+   "category": "skill",
+   "description": {
+    "en": "Content-production workflow skill for creator topics: title candidates, short-video scripts, visual plans, evidence checks, and a pre-publish quality checklist.",
+    "zh": "面向自媒体选题的内容生产工作流技能：标题候选、短视频脚本、视觉计划、证据核验与发布前质量检查。"
+   },
+   "npm": null,
+   "stars": 0,
+   "install": "dsh plugin --profile web add github:anywhere-labs/framefactory-plugin",
+   "added": "2026-08-16"
+  },
   {
    "name": "DSH-Right-Sidebar",
    "owner": "Limitinfinitude",


### PR DESCRIPTION
## What changed

- Add FrameFactory as the first public `anywhere-labs` content-workflow plugin in the curated registry.
- Include bilingual descriptions and the canonical GitHub installation target.
- Update the registry count from 839 to 840.

## Why

FrameFactory is a runnable MIT-licensed DSH plugin with a public repository, tests, and installation documentation. Listing it gives creators a discoverable first example for content-production workflows while keeping installation explicit through the existing DSH plugin command.

## Validation

- `npm test` in `anywhere-labs/framefactory-plugin` — 3 tests passed.
- `npm run validate:registry` — registry valid; existing display-name collisions remain warnings only.

The plugin is not bundled into Desktop; this PR only adds its curated catalog entry.