### PR TITLE
fix: guard hotMount activation with a timeout so a wedged plugin cannot lock the market

### DIFF
--- a/src/hot.ts
+++ b/src/hot.ts
@@ -38,6 +38,14 @@ interface HotContext {
 
 const HOT_DIR = '.dsh-market'
 
+/**
+ * Ceiling for one hot-mount activation, env-overridable like the install
+ * timeout in dsh-cli.ts. An activation that exceeds it is treated as wedged
+ * (typically a plugin pending on a service nothing provides) and falls back
+ * to restart activation.
+ */
+const HOT_MOUNT_TIMEOUT_MS = Number(process.env.DSH_MARKET_HOT_MOUNT_TIMEOUT_MS) || 10000
+
 let hotTreeClass: unknown | null | undefined
 
 /**
@@ -239,6 +247,26 @@ let hotSequence = 0
 
 const hotHandles = new Map<string, PluginHandle>()
 
+/** Activation did not settle within HOT_MOUNT_TIMEOUT_MS. */
+class ActivationTimeout extends Error {}
+
+/**
+ * Race an activation awaitable against the hot-mount ceiling. The handlers
+ * stay attached to the original promise, so a late rejection after a timeout
+ * can never surface as an unhandled rejection.
+ */
+function raceActivationTimeout<T>(awaitable: T | Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new ActivationTimeout(`activation did not settle within ${HOT_MOUNT_TIMEOUT_MS / 1000}s — the plugin may be waiting on a service that never arrives`))
+    }, HOT_MOUNT_TIMEOUT_MS)
+    Promise.resolve(awaitable).then(
+      value => { clearTimeout(timer); resolve(value) },
+      error => { clearTimeout(timer); reject(error) },
+    )
+  })
+}
+
 /** Outcome of one hot-mount attempt; `reason` explains non-`ok` results. */
 export interface HotMountResult {
   ok: boolean
@@ -328,7 +356,19 @@ export async function hotMount(ctx: HotContext, profileDir: string, packageName:
       .join('')
     writeFileSync(file, yml)
     const handle = ctx.plugin(HotTree, { path: pathToFileURL(file).href })
-    await handle.await()
+    try {
+      await raceActivationTimeout(handle.await())
+    } catch (error) {
+      if (error instanceof ActivationTimeout) {
+        // A wedged activation would otherwise hold this request open forever:
+        // the route's `finally { installing = false }` never runs, so every
+        // later install/update/uninstall gets 409'd until a host restart.
+        // Unwind the half-mounted subtree best-effort; disposal never blocks
+        // the reply, and the caller falls back to restart activation.
+        try { Promise.resolve(handle.dispose()).catch(() => {}) } catch { /* best effort */ }
+      }
+      throw error
+    }
     hotHandles.set(packageName, handle)
     ctx.logger?.info?.(`[dsh-market] hot-mounted ${packageName}`)
     logEvent('info', 'hot-mount', `${packageName}: live${shimNames.has(packageName) ? ' (client-only shim)' : ''}`)

--- a/tests/hot.spec.ts
+++ b/tests/hot.spec.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { hotUnmount, listHotMounts, mountClientOnlyDeps } from '../src/hot.ts'
+import { hotMount, hotUnmount, listHotMounts, mountClientOnlyDeps } from '../src/hot.ts'
 
 // The harness-vendored Include class is not importable in the unit lane;
 // a minimal stand-in lets hotMount succeed so the skip logic is observable.
@@ -56,6 +56,39 @@ describe('mountClientOnlyDeps vs the user patch layer (#58)', () => {
       expect(mounted).toContain('dsh-free-plugin')
       expect(mounted).not.toContain('@deepseek-ai/dsh-client-ui-aqua')
     } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('hotMount activation timeout guard', () => {
+  it('falls back to restart and disposes the subtree when activation never settles', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-hot-'))
+    try {
+      clientOnlyPkg(dir, 'dsh-wedged-plugin')
+      let disposed = false
+      // A fiber waiting on a service that never arrives: await() never
+      // settles. Without the guard the route hangs forever — its
+      // `finally { installing = false }` never runs and every later install/
+      // update/uninstall gets 409'd until a host restart.
+      const wedgedCtx = {
+        plugin: () => ({
+          await: () => new Promise<never>(() => {}),
+          dispose: () => { disposed = true },
+        }),
+      }
+      vi.useFakeTimers()
+      const pending = hotMount(wedgedCtx, dir, 'dsh-wedged-plugin')
+      const assertion = pending.then(result => {
+        expect(result.ok).toBe(false)
+        expect(result.reason).toContain('did not settle')
+        expect(disposed).toBe(true)
+        expect(listHotMounts()).not.toContain('dsh-wedged-plugin')
+      })
+      await vi.advanceTimersByTimeAsync(10000)
+      await assertion
+    } finally {
+      vi.useRealTimers()
       rmSync(dir, { recursive: true, force: true })
     }
   })


### PR DESCRIPTION
### For code changes / 代码改动

- [x] `npm test` and `npm run check` pass locally / 本地通过
- [x] Tests cover the change — for a bug fix, one that fails without it / 新增测试覆盖改动；bug 修复请确保测试在修复前是红的
- [x] No version bump in `package.json` — releases are a maintainer action / 不要改版本号，发版由维护者操作
- [x] `client/client.js` rebuilt with `npm run build:client` if you touched `src/client/` / 改动前端后重建产物 — server-only change, no client files touched

<!-- What changed and why / 改动内容与原因 -->

## Problem / 问题

`hotMount()` awaited `handle.await()` with no ceiling. When a freshly installed
plugin's activation never settles — typically a fiber pending on a service
nothing provides — the HTTP request hangs forever:

1. The route's `finally { installing = false }` never runs, so `installing`
   stays `true` and **every later install/update/uninstall is 409'd**
   ("another install is already running") until a host restart.
2. On the client it shows up as the infinite-spinner symptom (cf. #138).
3. Boot-time mounts (`mountClientOnlyDeps`) loop through `hotMount`, so a
   single stuck client-only package can hang the whole market startup.

This mirrors the route-level guard added for the Gist channel in #144 ("a
wedged gh CLI can never leave the client hanging") — the same class of
hazard, one layer down.

## Change / 改动

`src/hot.ts` (server-only):

- Race the activation against a **10s ceiling**, env-overridable via
  `DSH_MARKET_HOT_MOUNT_TIMEOUT_MS` (mirrors `INSTALL_TIMEOUT_MS` in
  `dsh-cli.ts`).
- On timeout: unwind the half-mounted subtree best-effort via
  `handle.dispose()` (disposal never blocks the reply), and fall back to the
  existing restart-required path with a `reason` that names the timeout.
- Handlers stay attached to the original promise, so a **late rejection
  after a timeout cannot surface as an unhandled rejection**.
- Non-timeout activation failures keep the previous behavior exactly.

## Test plan / 测试

`tests/hot.spec.ts`: a fiber whose `await()` never settles
(`new Promise(() => {})`), mounted through a fake context under fake timers.

- **Before this change**: the test times out after 20s — it hangs exactly
  like the route did.
- **After**: the mount reports `ok: false` with the timeout reason,
  `dispose()` ran, and the package is not listed as live.

Full local gates: `npm test` (355 passed, 1 skipped) and `npm run check`
(typecheck + build + restart-smoke) both green.

Related (not claiming to fix): #129 — the timeout reason feeds the same
"restart will fix it" messaging path this PR improves.