### PR TITLE
docs: add DeepSeek Harness Desktop to Friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Live from [awesome-dsh-plugin.com/plugins.json](https://awesome-dsh-plugin.com/p
 
 [dsh-desktop](https://github.com/dataelement/dsh-desktop) — a desktop app for DeepSeek Harness: run and manage a local Harness without installing Node.js yourself. Ships with this plugin market preset as the default. [dshdesktop.com](https://dshdesktop.com)
 
+### DeepSeek Harness Desktop (hairyf)
+
+[deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop) — a native desktop app for DeepSeek Harness: one-click local install and launch with no Node.js setup required. On first run it offers to install this plugin market as a recommended preset.
+
 ### DSH Get
 
 [DSH Get](https://www.dshget.com/) — a searchable web directory for discovering DeepSeek Harness plugins: category filters, bilingual descriptions, install commands and per-plugin detail pages. Its normalized catalog snapshot is public at [bobby-sheng/dshget-data](https://github.com/bobby-sheng/dshget-data).

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Live from [awesome-dsh-plugin.com/plugins.json](https://awesome-dsh-plugin.com/p
 
 ### DeepSeek Harness Desktop (hairyf)
 
-[deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop) — a native desktop app for DeepSeek Harness: one-click local install and launch with no Node.js setup required. On first run it offers to install this plugin market as a recommended preset.
+[deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop) — a native desktop app for DeepSeek Harness built with **Tauri** (Rust + Web): one-click local install and launch with no Node.js setup required. On first run it offers to install this plugin market as a recommended preset.
 
 ### DSH Get
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,6 +73,10 @@ dsh plugin --profile web add dshmarket
 
 [dsh-desktop](https://github.com/dataelement/dsh-desktop)——DeepSeek Harness 桌面客户端：无需自装 Node.js 即可运行和管理本地 Harness，并默认预置本插件市场。[dshdesktop.com](https://dshdesktop.com)
 
+### DeepSeek Harness Desktop（hairyf）
+
+[deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop)——DeepSeek Harness 原生桌面客户端：一键本地安装并启动，无需自装 Node.js；首次启动可选择安装本插件市场作为推荐插件。
+
 ### DSH Get
 
 [DSH Get](https://www.dshget.com/)——DeepSeek Harness 插件的网页检索目录：分类筛选、中英描述、安装命令与插件详情页；其规范化的目录快照公开在 [bobby-sheng/dshget-data](https://github.com/bobby-sheng/dshget-data)。

--- a/README.zh.md
+++ b/README.zh.md
@@ -75,7 +75,7 @@ dsh plugin --profile web add dshmarket
 
 ### DeepSeek Harness Desktop（hairyf）
 
-[deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop)——DeepSeek Harness 原生桌面客户端：一键本地安装并启动，无需自装 Node.js；首次启动可选择安装本插件市场作为推荐插件。
+[deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop)——基于 **Tauri**（Rust + Web）构建的 DeepSeek Harness 原生桌面客户端：一键本地安装并启动，无需自装 Node.js；首次启动可选择安装本插件市场作为推荐插件。
 
 ### DSH Get
 


### PR DESCRIPTION
Add [deepseek-harness-desktop](https://github.com/hairyf/deepseek-harness-desktop) to the **Friends** / **友情链接** section in both READMEs.

This is a Tauri-based desktop app for DeepSeek Harness that offers one-click local install/launch; on first run it lists **DSH Market** as a recommended plugin to install. Listing it alongside the existing DSH Desktop entry keeps the desktop-app cross-links reciprocal.