### PR TITLE
fix: an update of a running plugin reads as "restart", not "live"

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -33,7 +33,7 @@ import { checkUpdates, fetchNpmLatest, invalidateUpdates, isUpgrade, latestPubli
 import { createThemeManager, type LoaderEntry } from './themes.ts'
 import { readJsonBody, sameOrigin, sendJson } from './http.ts'
 import { restartAllowed, scheduleRestart, trustedRestartRequest, trustedDownloadRequest } from './restart.ts'
-import { activationAfterReplace, verifyActivation } from './verify.ts'
+import { activationAfterReplace, hasHostHalf, verifyActivation } from './verify.ts'
 import {
   disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
   readUserPatchState, removeRowBlocks, rowIdsForPackage,
@@ -1074,7 +1074,11 @@ export function mountMarketRoutes(
             // Captured BEFORE pnpm replaces the files: afterwards the loader
             // inventory reads exactly the same, because replacing a package
             // on disk does not unload the module the process already imported.
+            // A client-only package has no host half to go stale: its bundle
+            // is re-fetched from disk on the next page load, so an update to
+            // one needs a refresh, not a restart.
             const wasLive = verifyActivation(config.profile, name, liveNames(), activeProfileDir, disabled.has(name)).state === 'live'
+              && hasHostHalf(config.profile, name, activeProfileDir)
             const beforeVersion = readInstalledVersion(config.profile, name, activeProfileDir)
             const beforeCommit = repoKey !== null
               ? readLockCommits(config.profile, activeProfileDir).get(repoKey) ?? null

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -33,7 +33,7 @@ import { checkUpdates, fetchNpmLatest, invalidateUpdates, isUpgrade, latestPubli
 import { createThemeManager, type LoaderEntry } from './themes.ts'
 import { readJsonBody, sameOrigin, sendJson } from './http.ts'
 import { restartAllowed, scheduleRestart, trustedRestartRequest, trustedDownloadRequest } from './restart.ts'
-import { verifyActivation } from './verify.ts'
+import { activationAfterReplace, verifyActivation } from './verify.ts'
 import {
   disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
   readUserPatchState, removeRowBlocks, rowIdsForPackage,
@@ -1071,6 +1071,10 @@ export function mountMarketRoutes(
               }
             }
             const repoKey = isGit ? spec.slice('github:'.length).replace(/#.*$/, '').toLowerCase() : null
+            // Captured BEFORE pnpm replaces the files: afterwards the loader
+            // inventory reads exactly the same, because replacing a package
+            // on disk does not unload the module the process already imported.
+            const wasLive = verifyActivation(config.profile, name, liveNames(), activeProfileDir, disabled.has(name)).state === 'live'
             const beforeVersion = readInstalledVersion(config.profile, name, activeProfileDir)
             const beforeCommit = repoKey !== null
               ? readLockCommits(config.profile, activeProfileDir).get(repoKey) ?? null
@@ -1124,7 +1128,12 @@ export function mountMarketRoutes(
             }
             if (ok) {
               invalidateUpdates()
-              activation = { [name]: verifyActivation(config.profile, name, liveNames(), activeProfileDir, disabled.has(name)) }
+              activation = {
+                [name]: activationAfterReplace(
+                  verifyActivation(config.profile, name, liveNames(), activeProfileDir, disabled.has(name)),
+                  wasLive,
+                ),
+              }
             }
             // Diagnose the stale outcome with EVIDENCE (#45 by @ayingQAQ):
             // only blame pnpm's fresh-release wait when the target's latest

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -251,3 +251,35 @@ export function verifyActivation(
     hot: false,
   }
 }
+
+/**
+ * Correct a post-UPDATE verdict for a plugin that was already running.
+ *
+ * `verifyActivation` answers "is this name in the live loader inventory".
+ * That is the right question after an install and the wrong one after an
+ * update: the plugin was already live, so the answer stays "live" while the
+ * process keeps serving the module it imported at boot. Replacing files under
+ * a running composition does not re-import anything.
+ *
+ * Measured on a real host rather than reasoned about — updating the market
+ * from 1.11.3 to 1.12.2 left `/dsh-market/status` reporting 1.11.3 with an
+ * unchanged boot id, while the update route called it hot-loaded in the same
+ * response. The browser half genuinely does refresh (the host re-serves the
+ * client bundle from disk), which is what makes the wrong verdict credible:
+ * the UI visibly becomes the new version while the server half does not.
+ *
+ * Only a plugin that was ALREADY live is affected. One that was missing,
+ * broken or disabled beforehand has nothing loaded to shadow the new build,
+ * so its fresh mount really does run the new code.
+ * @param result the verdict computed from the loader inventory
+ * @param wasLive whether the plugin was live BEFORE the files were replaced
+ */
+export function activationAfterReplace(result: ActivationResult, wasLive: boolean): ActivationResult {
+  if (!wasLive || result.state !== 'live') return result
+  return {
+    ...result,
+    state: 'restart',
+    hot: false,
+    reasons: ['新版本已就位,但运行中的进程仍在使用启动时加载的旧模块——重启后生效(页面本身会立即变成新版,服务端不会) / the new build is in place, but the running process still serves the module it imported at boot — restart to apply (the page itself updates immediately; the server half does not)'],
+  }
+}

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -271,15 +271,39 @@ export function verifyActivation(
  * Only a plugin that was ALREADY live is affected. One that was missing,
  * broken or disabled beforehand has nothing loaded to shadow the new build,
  * so its fresh mount really does run the new code.
+ *
+ * Client-only packages are excluded for the same reason from the other end:
+ * they have no host half to go stale, and the browser fetches their bundle
+ * from disk on the next page load. Telling their users to restart would be
+ * #156 again, in a narrower place — see `hasHostHalf`.
  * @param result the verdict computed from the loader inventory
- * @param wasLive whether the plugin was live BEFORE the files were replaced
+ * @param hostHalfWasLive whether a HOST half was live BEFORE the replacement
  */
-export function activationAfterReplace(result: ActivationResult, wasLive: boolean): ActivationResult {
-  if (!wasLive || result.state !== 'live') return result
+export function activationAfterReplace(result: ActivationResult, hostHalfWasLive: boolean): ActivationResult {
+  if (!hostHalfWasLive || result.state !== 'live') return result
   return {
     ...result,
     state: 'restart',
     hot: false,
     reasons: ['新版本已就位,但运行中的进程仍在使用启动时加载的旧模块——重启后生效(页面本身会立即变成新版,服务端不会) / the new build is in place, but the running process still serves the module it imported at boot — restart to apply (the page itself updates immediately; the server half does not)'],
   }
+}
+
+/**
+ * Whether a package has a host (Node) half at all.
+ *
+ * A `dsh.client`-only package — themes, skins, most pure-UI plugins — runs
+ * no server code: the market shim-mounts it so the loader has a live row,
+ * and the browser re-fetches its bundle from disk on the next page load. An
+ * update to one takes effect on refresh, with no restart to ask for.
+ */
+export function hasHostHalf(profile: string, name: string, explicitDir?: string): boolean {
+  const dsh = readPkgDsh(profile, name, explicitDir)
+  if (dsh === null) return false
+  // Only a DEFINITE client-only package is excluded — the same test
+  // verifyActivation uses for its own verdict. Testing `dsh.bundle` on its
+  // own would read a package that declares neither key (`"dsh": {}`, which
+  // the bundle layer still loads) as client-only, and quietly disable the
+  // correction for it.
+  return !(dsh.bundle === undefined && dsh.client !== undefined)
 }

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -799,7 +799,16 @@ describe('update flow — no npm publishing required', () => {
     expect(r.status).toBe(200)
     expect(r.json.ok).toBe(true)
     expect(installedSpec('dsh-loop')).toBe('^1.2.0')
-    expect(r.json.activation['dsh-loop']).toMatchObject({ state: 'live' })
+    // NOT 'live'. This expectation used to say so, and it was wrong in a way
+    // only a real host could show: replacing a package on disk does not
+    // unload the module the process already imported, so the loader
+    // inventory keeps reporting the name and the verdict keeps reading
+    // "live" while the OLD build is what answers requests.
+    //
+    // Measured — the market updated from 1.11.3 to 1.12.2 with 1.12.2 on
+    // disk, `/dsh-market/status` still reporting 1.11.3, an unchanged boot
+    // id, and this route calling it hot-loaded in the same response.
+    expect(r.json.activation['dsh-loop']).toMatchObject({ state: 'restart', hot: false })
   })
 
   it('refuses an update whose new version has no entry artifact (#159)', async () => {

--- a/tests/verify.spec.ts
+++ b/tests/verify.spec.ts
@@ -236,3 +236,34 @@ describe('activationAfterReplace (post-update verdict)', () => {
     }
   })
 })
+
+describe('hasHostHalf (client-only updates need a refresh, not a restart)', () => {
+  it('is false for a dsh.client package with no dsh.bundle', async () => {
+    // Themes and skins. The market shim-mounts them so the loader has a live
+    // row, but no server code runs — the browser re-fetches their bundle from
+    // disk on the next page load. Asking these users to restart would repeat
+    // #156 in a narrower place.
+    const { hasHostHalf } = await import('../src/verify.ts')
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-hosthalf-'))
+    const pkg = join(dir, 'node_modules', 'theme-only')
+    mkdirSync(pkg, { recursive: true })
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: 'theme-only', dsh: { client: 'client/client.js' } }))
+    expect(hasHostHalf('web', 'theme-only', dir)).toBe(false)
+
+    const both = join(dir, 'node_modules', 'has-host')
+    mkdirSync(both, { recursive: true })
+    writeFileSync(join(both, 'package.json'), JSON.stringify({ name: 'has-host', dsh: { bundle: 'lib/index.js', client: 'client/client.js' } }))
+    expect(hasHostHalf('web', 'has-host', dir)).toBe(true)
+
+    // A package declaring NEITHER key still loads through the bundle layer,
+    // so it has a host half. Reading `dsh.bundle` alone would call this one
+    // client-only and silently switch the correction off for it.
+    const neither = join(dir, 'node_modules', 'bare')
+    mkdirSync(neither, { recursive: true })
+    writeFileSync(join(neither, 'package.json'), JSON.stringify({ name: 'bare', dsh: {} }))
+    expect(hasHostHalf('web', 'bare', dir)).toBe(true)
+
+    // A package that is not installed cannot have a stale host half either.
+    expect(hasHostHalf('web', 'absent', dir)).toBe(false)
+  })
+})

--- a/tests/verify.spec.ts
+++ b/tests/verify.spec.ts
@@ -199,3 +199,40 @@ describe('loader inventory beats manifest inference (#135)', () => {
     expect(verifyActivation('web', 'half-built', new Set())).toMatchObject({ state: 'broken' })
   })
 })
+
+describe('activationAfterReplace (post-update verdict)', () => {
+  const live = { state: 'live' as const, reasons: ['已热加载 / live'], bundle: true, hot: true }
+
+  it('downgrades a plugin that was already running to "restart"', async () => {
+    // Measured on a real host: updating the market 1.11.3 → 1.12.2 left the
+    // process reporting 1.11.3 with an unchanged boot id, while the update
+    // route answered "live / 已热加载" in the same response. The loader
+    // inventory cannot tell the two apart — the name was in it before the
+    // update and is in it after, because replacing files on disk does not
+    // unload an imported module.
+    const { activationAfterReplace } = await import('../src/verify.ts')
+    const result = activationAfterReplace(live, true)
+    expect(result.state).toBe('restart')
+    expect(result.hot).toBe(false)
+    expect(result.reasons.join(' ')).toContain('重启后生效')
+  })
+
+  it('leaves a plugin that was NOT running alone', async () => {
+    // Nothing was loaded to shadow the new build, so the fresh mount really
+    // does run the new code. Downgrading this case too would tell users to
+    // restart for a change that already took effect — the mistake #156 was.
+    const { activationAfterReplace } = await import('../src/verify.ts')
+    expect(activationAfterReplace(live, false)).toBe(live)
+  })
+
+  it('does not promote a non-live verdict', async () => {
+    // Only "live" is the wrong answer here. A missing or broken package must
+    // keep saying so; turning it into "restart" would hide a failed update
+    // behind an instruction that cannot fix it.
+    const { activationAfterReplace } = await import('../src/verify.ts')
+    for (const state of ['missing', 'restart', 'disabled', 'broken'] as const) {
+      const other = { ...live, state }
+      expect(activationAfterReplace(other, true)).toBe(other)
+    }
+  })
+})


### PR DESCRIPTION
Found while answering a user question: *"I upgraded the market from 1.0.3 and it seems to work already — why does it still say restart?"*

They were right that the UI was new. They were also right to be suspicious. Both halves of that are true, and the market was telling them something false about one of them.

## Measured, on a real host

Updating the market 1.11.3 → 1.12.2:

```
disk                      1.12.2
GET /dsh-market/status    version 1.11.3, boot id unchanged
POST /dsh-market/update   "state":"live","hot":true,"reasons":["已热加载(bundle patch)"]
```

The served client bundle was byte-identical to the 1.12.2 build on disk, so the **browser half genuinely did update**. The server half did not, and the route called it hot-loaded anyway.

## Why

```ts
activation = { [name]: verifyActivation(config.profile, name, liveNames(), …) }
```

`liveNames()` answers *"is this name in the running loader inventory"*. After an **install** that is exactly the right question. After an **update** it is the wrong one: the plugin was already in the inventory before pnpm touched anything, and replacing a package on disk does not unload the module the process imported at boot. The verdict is structurally incapable of distinguishing "old version still live" from "new version live".

This affects **every** update, not just the market updating itself. Self-update is only where it is easiest to prove, because the market can report its own version.

It is the mirror image of #135/#156 — there the market said "restart" about something already running; here it says "live" about something that is not.

## The fix

`activationAfterReplace(result, wasLive)` downgrades exactly one case: a verdict of `live` for a plugin that was **already live before the files were replaced**. `wasLive` is captured before pnpm runs, since afterwards the inventory reads identically.

Anything that was missing, broken or disabled beforehand is left alone — it has nothing loaded to shadow the new build, so its fresh mount really does run the new code. Downgrading that too would re-introduce #156.

## Verification

Red→green **on a real host**, not just in unit tests. The fixed build was overlaid onto an installed 1.11.3 (leaving its `package.json` version untouched, so the boot-time module is the fixed code), and the same self-update now answers:

```
state = restart      hot = False
reasons = 新版本已就位,但运行中的进程仍在使用启动时加载的旧模块——重启后生效
          (页面本身会立即变成新版,服务端不会)
```

with disk at 1.12.2 and the process still reporting 1.11.3 — the honest description of that state.

`tests/flows.spec.ts` asserted `state: 'live'` for this exact flow. That is how the bug stayed invisible for so long: the expectation encoded it. Corrected, with the measurement recorded in the comment rather than a bare value change.

Two mutants, both killed (disabling the correction entirely; ignoring `wasLive`). `npm test` 449 passed · `npm run check` clean.