### PR TITLE
test(e2e): assert what category filtering IS, not what today's catalog looks like

### DIFF
--- a/tests/web/market.e2e.ts
+++ b/tests/web/market.e2e.ts
@@ -85,17 +85,36 @@ describe.skipIf(!HAS_DSH)('web e2e: plugin market', () => {
     await search.fill('')
     await page.waitForTimeout(200)
 
-    // Category chips are data-driven; click the second chip (first is All).
-    // Same reasoning: a big category fills a whole page, so assert on the
-    // grid CONTENT changing rather than the count shrinking.
-    const beforeCats = await gridNames()
+    // Category chips are data-driven, and so was the assertion that used to
+    // live here: it compared the visible grid before and after, which holds
+    // only while the chosen category does not happen to own the top of the
+    // default sort. It stopped holding the day the live catalog grew past
+    // ~1300 entries, and both CI platforms went red on a change that touched
+    // none of this.
+    //
+    // The TOTAL PAGE COUNT is the property that actually defines filtering:
+    // narrowing to one category of several must leave fewer pages than "All",
+    // whatever today's catalog looks like and whichever chip is second.
+    const pages = async (): Promise<number> => {
+      const label = await page.locator('[class*="pageInfo"]').first().textContent()
+      // "第 3 / 56 页" / "Page 3 of 56" — the last number is the total.
+      const numbers = (label ?? '').match(/\d+/gu) ?? []
+      return Number(numbers[numbers.length - 1] ?? 0)
+    }
+
+    const allPages = await pages()
+    expect(allPages).toBeGreaterThan(1)
     const chips = page.locator('[class*="catsWrap"] [data-chip="1"]')
     await chips.nth(1).click()
     await page.waitForTimeout(400)
     const categorized = await gridNames()
     expect(categorized.length).toBeGreaterThanOrEqual(1)
-    expect(categorized).not.toEqual(beforeCats)
+    expect(await pages(), 'a category must hold fewer pages than the whole catalog').toBeLessThan(allPages)
     await chips.nth(0).click() // back to All
+    await page.waitForTimeout(400)
+    // ...and clearing the filter restores the full catalog, so a chip that
+    // silently stuck would not read as a pass.
+    expect(await pages()).toBe(allPages)
   })
 
   it('the installed tab lists the market itself', async () => {


### PR DESCRIPTION
**main is red**, on both platforms, from a change that touched none of this.

```
AssertionError: expected [ 'dsh-status-rotator', …(23) ]
                to not deeply equal [ 'dsh-status-rotator', …(23) ]
```

## It is not the commit it landed on

The failing spec fails identically on `946d765`, the commit *before* the merge that CI blamed. It also passed on the PR run ~10 minutes earlier, on the same tree. Same code, different answer — the input changed, not the program.

## What actually broke

The assertion compared the visible grid before and after clicking a category chip:

```ts
expect(categorized).not.toEqual(beforeCats)
```

That holds only while the chosen category does **not** own the top of the default sort. The suite talks to the live registry, which just passed ~1300 entries; `ui` — the category that happens to sit second — now fills the entire first page by itself. So the grid is byte-identical with and without the filter, and the test called a working filter broken.

The old comment even shows the reasoning that led here: an earlier version asserted the count shrank, that broke on a big category, and it was changed to compare content. Same class of bug, one step further along.

## The fix

Assert the property that *defines* filtering: **narrowing to one category of several must leave fewer pages than "All"**. True whatever the catalog looks like today and whichever chip is second.

Clearing the filter now has to restore the original page count as well, so a chip that silently stuck cannot read as a pass — the previous version had no such check.

## Verification

Mutation-checked. Dropping the category predicate in `visiblePlugins`:

```
× search and category filter the grid
AssertionError: a category must hold fewer pages than the whole catalog:
  expected 56 to be less than 56
```

Restored → 6 passed. The failure message names the property rather than dumping two 24-element arrays that look the same.

## Left undone, deliberately

This suite fetches the **live** registry, which is why a catalog refresh on someone else's schedule can turn our CI red with no commit involved. Pinning it to the bundled snapshot is the real fix for that and is a separate change: this one removes the assertion's dependence on the data's *shape*, not the suite's dependence on the network.