### PR TITLE
ci: publish prerelease tags to a beta channel instead of latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,19 @@ jobs:
             echo "tag v$TAG != package.json $PKG" >&2
             exit 1
           fi
-      - run: npm publish
+      # A prerelease tag (v1.14.0-beta.1) publishes under the `beta` dist-tag
+      # and NEVER moves `latest`. Without this every fix reached every user the
+      # moment it was tagged, before anyone had clicked the thing it changed —
+      # which is how 1.13.0 shipped a restart button that could not work.
+      - name: choose the npm dist-tag
+        id: channel
+        run: |
+          TAG=${GITHUB_REF_NAME#v}
+          case "$TAG" in
+            *-*) echo "dist=beta"    >> "$GITHUB_OUTPUT"; echo "pre=true"  >> "$GITHUB_OUTPUT" ;;
+            *)   echo "dist=latest"  >> "$GITHUB_OUTPUT"; echo "pre=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+      - run: npm publish --tag ${{ steps.channel.outputs.dist }}
       - name: create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -40,5 +52,6 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --title "dshmarket ${GITHUB_REF_NAME#v}" \
             --generate-notes \
-            --notes "npm: https://www.npmjs.com/package/dshmarket/v/${GITHUB_REF_NAME#v}"
+            ${{ steps.channel.outputs.pre == 'true' && '--prerelease' || '' }} \
+            --notes "npm: https://www.npmjs.com/package/dshmarket/v/${GITHUB_REF_NAME#v} · dist-tag: ${{ steps.channel.outputs.dist }}"
 


### PR DESCRIPTION
Every tag went straight to `latest`. Today that put **three releases** in front of every user within a few hours — and 1.13.0 among them shipped a "restart now" button that **could not work**.

That fault was only visible by clicking it. Nobody had, because the only way to try a change was to release it to everyone.

## The change

A tag carrying a prerelease suffix publishes under the `beta` dist-tag and is marked prerelease on GitHub. `latest` moves only for a plain version tag.

```
v1.14.0-beta.1  →  npm dist-tag: beta    (latest untouched)
v1.14.0         →  npm dist-tag: latest
```

Trying a candidate becomes:

```sh
dsh plugin --profile web add dshmarket@beta
```

The same `npm run check`, preflight and tag/version-match steps run either way — a beta is a real build, not a looser one. The only difference is who gets it by default.