### PR TITLE
fix: the restart helper waits for the port instead of guessing at 1500ms (#177)

### DIFF
--- a/src/restart.ts
+++ b/src/restart.ts
@@ -20,6 +20,26 @@ export function restartAllowed(config: { allowRestart?: boolean }): boolean {
   return config.allowRestart !== false
 }
 
+/**
+ * The port this process is serving on, read off the request that asked for
+ * the restart.
+ *
+ * The alternative is to parse it out of the launch argv, which is wrong for
+ * every host that binds from config or an env var. The Host header is what
+ * the browser actually reached us on, so it is the port the replacement has
+ * to take over — and it is already validated against Origin by the guard
+ * below before any of this runs.
+ * @returns the port, or null when the header carries none (a default port).
+ */
+export function servingPort(request: Pick<IncomingMessage, 'headers'>): number | null {
+  const host = request.headers.host
+  if (host === undefined) return null
+  const match = /:(\d{1,5})$/u.exec(host)
+  if (match === null) return null
+  const port = Number(match[1])
+  return Number.isInteger(port) && port > 0 && port < 65536 ? port : null
+}
+
 /** Whether a process-control request came from this Web host on loopback. */
 export function trustedRestartRequest(request: Pick<IncomingMessage, 'headers' | 'socket'>): boolean {
   const address = request.socket.remoteAddress
@@ -113,36 +133,105 @@ export interface RestartResult {
 }
 
 /**
- * Relaunch this exact DSH entry after a short detached handoff, then stop
- * this process. The helper outlives us (detached + unref), waits for our
- * port to free up, and logs the replacement's output under tmpdir.
+ * Source for the detached helper that outlives this process and brings the
+ * replacement up.
+ *
+ * Extracted so the waiting can be tested by RUNNING it, which is the only
+ * way this class of bug shows itself: every part of the old helper looked
+ * right in isolation.
+ *
+ * What it fixes (#177, reported on Windows 11, reproducible every time): the
+ * helper slept a flat 1500ms and spawned. The old process had exited, but
+ * the listening socket had not been released yet, so the replacement died
+ * instantly with EADDRINUSE — and the spawn was wrapped in `catch {}`, so
+ * nothing was written anywhere. The user saw a restart button that did
+ * nothing. The docstring above it even claimed the helper "waits for our
+ * port to free up"; it never did.
+ *
+ * So: wait for the port to actually go quiet, then start, then CHECK that
+ * something came up, and write a diagnosis when it did not. A restart that
+ * fails must leave evidence — this one is invisible by construction, since
+ * the process that would have logged it is the one that just exited.
+ * @param port - the port the replacement must bind; when unknown, the helper
+ *   falls back to the old fixed delay, which is better than nothing.
  */
-export function scheduleRestart(): RestartResult {
-  const launch = restartLaunch()
-  const spawned = respawnInvocation(launch)
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
-  const logOut = join(tmpdir(), `dsh-market-restart-${stamp}.out.log`)
-  const logErr = join(tmpdir(), `dsh-market-restart-${stamp}.err.log`)
-  const helperCode = [
+export function restartHelperSource(
+  spawned: { file: string; args: string[]; viaShell: boolean; detached: boolean },
+  launch: { cwd: string },
+  logs: { out: string; err: string },
+  port: number | null,
+): string {
+  return [
     "const { spawn } = require('node:child_process')",
     "const fs = require('node:fs')",
+    "const net = require('node:net')",
     `const file = ${JSON.stringify(spawned.file)}`,
     `const args = ${JSON.stringify(spawned.args)}`,
     `const cwd = ${JSON.stringify(launch.cwd)}`,
     `const viaShell = ${JSON.stringify(spawned.viaShell)}`,
     `const detached = ${JSON.stringify(spawned.detached)}`,
-    `const logOut = ${JSON.stringify(logOut)}`,
-    `const logErr = ${JSON.stringify(logErr)}`,
-    'setTimeout(() => {',
+    `const logOut = ${JSON.stringify(logs.out)}`,
+    `const logErr = ${JSON.stringify(logs.err)}`,
+    `const port = ${JSON.stringify(port)}`,
+    'const sleep = (ms) => new Promise(r => setTimeout(r, ms))',
+    'const note = (line) => { try { fs.appendFileSync(logErr, `[dsh-market] ${line}\n`) } catch {} }',
+    // "Free" means nothing accepts a connection. Checked by connecting rather
+    // than by binding: binding to test would itself hold the port for the
+    // moment the replacement needs it.
+    'const listening = () => new Promise((resolve) => {',
+    '  const probe = net.connect({ host: "127.0.0.1", port })',
+    '  const done = (value) => { probe.destroy(); resolve(value) }',
+    '  probe.on("connect", () => done(true))',
+    '  probe.on("error", () => done(false))',
+    '  setTimeout(() => done(false), 500)',
+    '})',
+    'const main = async () => {',
+    '  if (port) {',
+    '    const until = Date.now() + 30000',
+    '    while (Date.now() < until && await listening()) await sleep(250)',
+    '    if (await listening()) note(`port ${port} was still in use after 30s; starting anyway`)',
+    // A released socket can still be in TIME_WAIT for a moment on Windows.
+    '    await sleep(300)',
+    '  } else {',
+    '    await sleep(1500)',
+    '  }',
+    '  let child',
     '  try {',
     '    const out = fs.openSync(logOut, "a")',
     '    const err = fs.openSync(logErr, "a")',
-    '    const child = spawn(file, args, { cwd, detached, stdio: ["ignore", out, err], env: process.env, shell: viaShell })',
+    '    child = spawn(file, args, { cwd, detached, stdio: ["ignore", out, err], env: process.env, shell: viaShell })',
+    // spawn reports a missing or unexecutable file ASYNCHRONOUSLY; the
+    // try/catch below only covers the synchronous throw, so without this
+    // listener that failure is exactly as silent as the bug being fixed.
+    '    child.on("error", (error) => note(`could not start the replacement: ${error && error.message ? error.message : error}`))',
     '    child.unref()',
-    '  } catch {}',
-    '}, 1500)',
+    '  } catch (error) {',
+    '    note(`could not start the replacement: ${error && error.message ? error.message : error}`)',
+    '    return',
+    '  }',
+    '  if (!port) return',
+    '  const upBy = Date.now() + 20000',
+    '  while (Date.now() < upBy && !(await listening())) await sleep(500)',
+    '  if (!(await listening())) note(`the replacement did not bind port ${port} within 20s — see the output log beside this one`)',
+    '}',
+    'main()',
   ].join('\n')
-  const helper = spawn(process.execPath, ['-e', helperCode], {
+}
+
+/**
+ * Relaunch this exact DSH entry after a detached handoff, then stop this
+ * process. The helper outlives us (detached + unref), waits for our port to
+ * be released before starting the replacement, and logs under tmpdir.
+ * @param port - the port this process is serving on, so the helper can wait
+ *   for it rather than guessing at a delay.
+ */
+export function scheduleRestart(port: number | null = null): RestartResult {
+  const launch = restartLaunch()
+  const spawned = respawnInvocation(launch)
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+  const logOut = join(tmpdir(), `dsh-market-restart-${stamp}.out.log`)
+  const logErr = join(tmpdir(), `dsh-market-restart-${stamp}.err.log`)
+  const helper = spawn(process.execPath, ['-e', restartHelperSource(spawned, launch, { out: logOut, err: logErr }, port)], {
     detached: true,
     stdio: 'ignore',
     env: process.env,

--- a/src/restart.ts
+++ b/src/restart.ts
@@ -209,7 +209,13 @@ export function restartHelperSource(
     '    note(`could not start the replacement: ${error && error.message ? error.message : error}`)',
     '    return',
     '  }',
-    '  if (!port) return',
+    // Outliving the spawn matters on Windows: a helper that exits the
+    // instant it has spawned can take the replacement with it, because the
+    // child is in its process group and has not detached yet. The port path
+    // below already lingers while it polls; this is the same guarantee for
+    // the path that has no port to poll. CI on windows-latest caught it —
+    // locally it passes either way.
+    "  if (!port) { await sleep(3000); return }",
     '  const upBy = Date.now() + 20000',
     '  while (Date.now() < upBy && !(await listening())) await sleep(500)',
     '  if (!(await listening())) note(`the replacement did not bind port ${port} within 20s — see the output log beside this one`)',

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -32,7 +32,7 @@ import { isStaleUpdate, parseIgnoredBuilds, parsePrepareNotAllowed, RELEASE_AGE_
 import { checkUpdates, fetchNpmLatest, invalidateUpdates, isUpgrade, latestPublishedRecently } from './updates.ts'
 import { createThemeManager, type LoaderEntry } from './themes.ts'
 import { readJsonBody, sameOrigin, sendJson } from './http.ts'
-import { restartAllowed, scheduleRestart, trustedRestartRequest, trustedDownloadRequest } from './restart.ts'
+import { restartAllowed, scheduleRestart, servingPort, trustedRestartRequest, trustedDownloadRequest } from './restart.ts'
 import { activationAfterReplace, hasHostHalf, verifyActivation } from './verify.ts'
 import {
   disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
@@ -1374,7 +1374,7 @@ export function mountMarketRoutes(
         }
         restarting = true
         try {
-          const result = scheduleRestart()
+          const result = scheduleRestart(servingPort(request))
           logEvent('info', 'restart', `scheduled pid=${String(result.pid)} helper=${String(result.helperPid)}`)
           sendJson(response, 202, { ok: true, boot: BOOT_ID, ...result })
         } catch (error) {

--- a/tests/restart-helper.spec.ts
+++ b/tests/restart-helper.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * The detached restart helper, tested by RUNNING it.
+ *
+ * #177: on Windows the helper slept a flat 1500ms, spawned the replacement,
+ * and swallowed the result. The old process had exited but its listening
+ * socket had not been released, so the replacement died instantly with
+ * EADDRINUSE and nothing was written anywhere — the restart button appeared
+ * to do nothing, every time.
+ *
+ * Every piece of that helper read correctly on its own, which is why this
+ * spec starts a real server, holds the port, and runs the real helper source
+ * against it. Asserting on the generated string would only prove the string
+ * contains the words.
+ */
+
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { restartHelperSource, servingPort } from '../src/restart.ts'
+
+const cleanups: Array<() => void | Promise<void>> = []
+afterEach(async () => {
+  for (const done of cleanups.splice(0)) await done()
+})
+
+/** Occupy a port the way the outgoing DSH does, and hand back a release. */
+async function hold(): Promise<{ port: number; release: () => Promise<void> }> {
+  const server = createServer(socket => socket.end())
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as { port: number }).port
+  let closed = false
+  const release = async (): Promise<void> => {
+    if (closed) return
+    closed = true
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  }
+  cleanups.push(release)
+  return { port, release }
+}
+
+/**
+ * Run the helper with a stand-in "DSH" that only records that it started.
+ * The marker file is the evidence: its absence means the helper is still
+ * waiting, its presence means it launched.
+ */
+function runHelper(port: number | null, marker: string, logs: { out: string; err: string }): { kill: () => void } {
+  const source = restartHelperSource(
+    {
+      file: process.execPath,
+      args: ['-e', `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'started')`],
+      viaShell: false,
+      detached: false,
+    },
+    { cwd: process.cwd() },
+    logs,
+    port,
+  )
+  const child = spawn(process.execPath, ['-e', source], { stdio: 'ignore' })
+  cleanups.push(() => { child.kill() })
+  return { kill: () => { child.kill() } }
+}
+
+const wait = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+/** Poll until the predicate holds, or give up — never a bare sleep. */
+async function until(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await wait(100)
+  }
+  return predicate()
+}
+
+describe('restartHelperSource (#177)', () => {
+  it('does not start the replacement while the old port is still held', async () => {
+    const { port, release } = await hold()
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-restart-'))
+    const marker = join(dir, 'started.txt')
+    runHelper(port, marker, { out: join(dir, 'out.log'), err: join(dir, 'err.log') })
+
+    // Comfortably past the 1500ms the old helper waited before spawning
+    // regardless of the port — this is the exact window in which it produced
+    // an EADDRINUSE the user never saw.
+    await wait(2500)
+    expect(existsSync(marker), 'the replacement started while the port was still in use').toBe(false)
+
+    await release()
+    expect(await until(() => existsSync(marker), 8000), 'the replacement never started after the port freed').toBe(true)
+  }, 30_000)
+
+  it('starts promptly once nothing is listening', async () => {
+    const { port, release } = await hold()
+    await release()
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-restart-'))
+    const marker = join(dir, 'started.txt')
+    runHelper(port, marker, { out: join(dir, 'out.log'), err: join(dir, 'err.log') })
+    // Waiting for a free port must not become its own delay.
+    expect(await until(() => existsSync(marker), 8000)).toBe(true)
+  }, 30_000)
+
+  it('records a replacement that started and then died, instead of swallowing it', async () => {
+    // The old helper wrapped the whole thing in `catch {}`. A restart that
+    // fails leaves nobody to report it — the process that would have logged
+    // it is the one that just exited — so the helper has to.
+    //
+    // The port is FREE here on purpose: holding it would make the helper
+    // report "still in use" and this spec would pass without ever reaching
+    // the check it exists for.
+    const { port, release } = await hold()
+    await release()
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-restart-'))
+    const errLog = join(dir, 'err.log')
+    const source = restartHelperSource(
+      { file: process.execPath, args: ['-e', 'process.exit(1)'], viaShell: false, detached: false },
+      { cwd: process.cwd() },
+      { out: join(dir, 'out.log'), err: errLog },
+      port,
+    )
+    const quick = source.replace('Date.now() + 20000', 'Date.now() + 1200')
+    const child = spawn(process.execPath, ['-e', quick], { stdio: 'ignore' })
+    cleanups.push(() => { child.kill() })
+
+    const wrote = await until(() => existsSync(errLog) && readFileSync(errLog, 'utf8').includes('did not bind'), 15_000)
+    expect(wrote, 'a replacement that died left no trace anywhere').toBe(true)
+  }, 30_000)
+
+  it('records a replacement that could not be started at all', async () => {
+    // spawn reports a missing executable through an asynchronous `error`
+    // event, which the try/catch around it never sees. Without a listener
+    // this failure is precisely as silent as #177 itself.
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-restart-'))
+    const errLog = join(dir, 'err.log')
+    const source = restartHelperSource(
+      { file: join(dir, 'no-such-dsh-binary'), args: [], viaShell: false, detached: false },
+      { cwd: process.cwd() },
+      { out: join(dir, 'out.log'), err: errLog },
+      null,
+    )
+    const child = spawn(process.execPath, ['-e', source], { stdio: 'ignore' })
+    cleanups.push(() => { child.kill() })
+
+    const wrote = await until(() => existsSync(errLog) && readFileSync(errLog, 'utf8').includes('could not start'), 15_000)
+    expect(wrote, 'a restart that never launched left no trace anywhere').toBe(true)
+  }, 30_000)
+
+  it('falls back to the old fixed delay when the port is unknown', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-restart-'))
+    const marker = join(dir, 'started.txt')
+    runHelper(null, marker, { out: join(dir, 'out.log'), err: join(dir, 'err.log') })
+    expect(await until(() => existsSync(marker), 8000)).toBe(true)
+  }, 30_000)
+})
+
+describe('servingPort', () => {
+  it('reads the port the browser actually reached us on', () => {
+    expect(servingPort({ headers: { host: '127.0.0.1:3080' } })).toBe(3080)
+    expect(servingPort({ headers: { host: 'localhost:8080' } })).toBe(8080)
+  })
+
+  it('answers null rather than guessing', () => {
+    // A default-port host carries none, and the helper's fallback delay is
+    // the right behaviour there — inventing 80 would make it wait on a port
+    // this process never held.
+    expect(servingPort({ headers: { host: 'localhost' } })).toBeNull()
+    expect(servingPort({ headers: {} })).toBeNull()
+    expect(servingPort({ headers: { host: '127.0.0.1:99999' } })).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #177. Reported from Windows 11, **reproducible every time**: clicking restart did nothing at all.

## What was happening

```js
setTimeout(() => {
  try {
    const child = spawn(file, args, …)   // 1500ms after we asked to die
    child.unref()
  } catch {}                             // ← and if it failed, nobody hears
}, 1500)
```

The outgoing process had exited by then, but its **listening socket had not been released**. The replacement died instantly with `EADDRINUSE`, and the empty catch meant nothing was written anywhere. The only process that could have reported the failure is the one that just exited.

The docstring above that block already claimed the helper *"waits for our port to free up"*. It never did — that was the intent, not the code.

## The fix

1. **Wait for the port to actually go quiet**, polling by *connecting* rather than by binding — binding to test would itself hold the port the replacement needs.
2. **Then start**, then check that something came up, and write a diagnosis when nothing did.
3. The port comes from the **Host header of the request that asked for the restart** — the address the browser really reached us on. Parsing argv instead would be wrong for any host that binds from config or an env var.
4. `spawn` reports a missing executable through an **asynchronous `error` event**, which the try/catch never saw. That failure was precisely as silent as the bug being fixed; it has a listener now.

## Verification

Tested by **running the real helper against a really held port** — every piece of the old one read correctly in isolation, so asserting on the generated string would only prove it contains the right words.

```ts
runHelper(port, marker, logs)
await wait(2500)                    // well past the old 1500ms spawn
expect(existsSync(marker)).toBe(false)   // still waiting, as it must
await release()
expect(await until(() => existsSync(marker), 8000)).toBe(true)
```

Mutants killed:

| mutant | result |
|---|---|
| don't wait for the port (the original bug) | ✅ killed |
| swallow the async spawn error | ✅ killed |
| skip the did-it-come-up check | ✅ killed |

**Not pinned by a test:** the 300ms settle after the port goes quiet, which guards a Windows socket still in TIME_WAIT. No test here can tell its presence from its absence, so I am not claiming coverage it does not have.

## A note on how this got missed

Earlier today I looked for exactly this failure, found zero reports across 99 issues, and concluded it was speculative. That reasoning was wrong in a way worth writing down: a bug that swallows its own error is never reported as the thing it is. It gets reported as "点了没反应" — and I had searched for `EADDRINUSE`, 端口, 双进程.