### PR TITLE
fix: spawn the real Node binary for children on Android (execPath is linker64)

### DIFF
--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -34,6 +34,23 @@ import { profileDir } from './profile.ts'
 const extraPathDirs: string[] = []
 
 /**
+ * The real Node executable for spawning children. On Android the kernel runs
+ * node through the dynamic linker, so `process.execPath` is
+ * `/apex/.../linker64` — spawning IT with `--expose-internals` makes the
+ * linker treat the flag as the program path and die with
+ * `error: expected absolute path: "--expose-internals"`. `process.argv0`
+ * carries the real node binary; prefer it whenever it is an existing
+ * absolute path, and fall back to execPath everywhere else.
+ * @param argv0 - `process.argv0`, injectable for tests.
+ * @param execPath - `process.execPath`, injectable for tests.
+ */
+export function nodeExecutable(argv0: string | undefined = process.argv0, execPath: string = process.execPath): string {
+  if (argv0 !== undefined && argv0 !== '' && isAbsolute(argv0) && existsSync(argv0))
+    return argv0
+  return execPath
+}
+
+/**
  * The directory holding the Node binary running this process. `npm`,
  * `npm.cmd` and `corepack` are installed alongside it by every official Node
  * distribution, so it is the one place the toolchain can be looked for
@@ -45,7 +62,7 @@ const extraPathDirs: string[] = []
  * both `corepack` and `npm` came back "not recognized as an internal or
  * external command", so the one-click setup had no way to succeed.
  */
-export const nodeBinDir = dirname(process.execPath)
+export const nodeBinDir = dirname(nodeExecutable())
 
 function spawnEnv(): NodeJS.ProcessEnv {
   // pnpm v10+ blocks forever on a silent interactive prompt without a TTY;
@@ -132,7 +149,7 @@ export function dshArgv(): { file: string; args: string[]; cwd: string | undefin
     // with MODULE_NOT_FOUND (#13). cwd near the entry keeps execArgv imports
     // (tsx/esm) resolvable on source launches.
     const abs = resolve(entry)
-    return { file: process.execPath, args: [...process.execArgv, abs], cwd: dirname(abs), viaShell: false }
+    return { file: nodeExecutable(), args: [...process.execArgv, abs], cwd: dirname(abs), viaShell: false }
   }
   // Bare `dsh` is a .cmd shim on Windows that only a shell can start (#13).
   return { file: 'dsh', args: [], cwd: undefined, viaShell: winCmdShim }

--- a/src/restart.ts
+++ b/src/restart.ts
@@ -13,7 +13,7 @@ import { spawn } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { IncomingMessage } from 'node:http'
-import { dshArgv } from './dsh-cli.ts'
+import { dshArgv, nodeExecutable } from './dsh-cli.ts'
 
 /** Self-restart is enabled by default and disabled only by an explicit false. */
 export function restartAllowed(config: { allowRestart?: boolean }): boolean {
@@ -237,7 +237,7 @@ export function scheduleRestart(port: number | null = null): RestartResult {
   const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
   const logOut = join(tmpdir(), `dsh-market-restart-${stamp}.out.log`)
   const logErr = join(tmpdir(), `dsh-market-restart-${stamp}.err.log`)
-  const helper = spawn(process.execPath, ['-e', restartHelperSource(spawned, launch, { out: logOut, err: logErr }, port)], {
+  const helper = spawn(nodeExecutable(), ['-e', restartHelperSource(spawned, launch, { out: logOut, err: logErr }, port)], {
     detached: true,
     stdio: 'ignore',
     env: process.env,

--- a/tests/dsh-cli.spec.ts
+++ b/tests/dsh-cli.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { cmdCommandLine, quoteCmdArg } from '../src/dsh-cli.ts'
+import { cmdCommandLine, nodeExecutable, quoteCmdArg } from '../src/dsh-cli.ts'
 
 describe('cmd.exe command line building (DEP0190 shim)', () => {
   it('keeps simple tokens unquoted', () => {
@@ -23,5 +23,41 @@ describe('cmd.exe command line building (DEP0190 shim)', () => {
     expect(cmdCommandLine(['dsh', 'plugin', '--profile', 'web', 'add', '@scope/pkg'])).toBe(
       'dsh plugin --profile web add @scope/pkg',
     )
+  })
+})
+
+describe('nodeExecutable (Android linker64 execPath)', () => {
+  // On Android the kernel runs node through the dynamic linker, so
+  // `process.execPath` is `/apex/.../linker64` while `process.argv0` holds
+  // the real node binary. Spawning the linker with `--expose-internals`
+  // makes it treat the flag as the program path and die with
+  // `error: expected absolute path: "--expose-internals"` — every market
+  // install failed until the real binary was picked for children.
+  it('prefers an existing absolute argv0 even when execPath is the linker', () => {
+    const realNode = process.execPath
+    expect(nodeExecutable(realNode, '/apex/com.android.runtime/bin/linker64')).toBe(realNode)
+  })
+
+  it('returns an existing absolute argv0 verbatim', () => {
+    expect(nodeExecutable(process.execPath, '/fallback/never/used')).toBe(process.execPath)
+  })
+
+  it('falls back to execPath when argv0 is empty', () => {
+    const execPath = '/usr/local/bin/node'
+    expect(nodeExecutable('', execPath)).toBe(execPath)
+  })
+
+  it('falls back to execPath when argv0 is not absolute', () => {
+    const execPath = '/usr/local/bin/node'
+    expect(nodeExecutable('node', execPath)).toBe(execPath)
+  })
+
+  it('falls back to execPath when argv0 does not exist on disk', () => {
+    const execPath = '/usr/local/bin/node'
+    expect(nodeExecutable('/nonexistent/absolute/node', execPath)).toBe(execPath)
+  })
+
+  it('documents the pre-fix failure shape: linker execPath survives only when no real node is known', () => {
+    expect(nodeExecutable('', '/apex/com.android.runtime/bin/linker64')).toBe('/apex/com.android.runtime/bin/linker64')
   })
 })

--- a/tests/provision.spec.ts
+++ b/tests/provision.spec.ts
@@ -73,10 +73,11 @@ describe('provisionPnpm (#149)', () => {
     // "not recognized as an internal or external command" — the host spawns
     // dsh without the Node install directory on PATH.
     //
-    // npm and corepack live in that exact directory, and `process.execPath`
-    // is the one path this process can always be sure of, so the setup has
-    // no business failing here.
-    const nodeDir = dirname(process.execPath)
+    // npm and corepack live in that exact directory, and the Node binary
+    // (resolved the same way the market resolves it for its children) is the
+    // one path this process can always be sure of, so the setup has no
+    // business failing here.
+    const nodeDir = dirname((await import('../src/dsh-cli.ts')).nodeExecutable())
     childProcess.spawn.mockImplementation((_file: string, _args: string[], options: { env?: Record<string, string> }) => {
       // The whole toolchain is invisible unless Node's own directory is on
       // the PATH handed to the child — exactly the reported machine. No


### PR DESCRIPTION
**What changed and why / 改动内容与原因**

Every plugin install/update/uninstall through the market failed on Android hosts with:

```
error: expected absolute path: "--expose-internals"
```

(exit 1, empty stdout — the child never ran).

**Root cause / 根因** — the market re-invokes the dsh CLI that launched the host by spawning `process.execPath` with `[...process.execArgv, <dsh bin>]`. On Android the kernel runs node through the dynamic linker, so `process.execPath` is `/apex/com.android.runtime/bin/linker64` while the real node binary is `process.argv0`. Spawning the linker with `--expose-internals <script> …` makes the linker treat `--expose-internals` as the program path — not an absolute path — and it exits with the error above. Verified by running the exact spawned argv:

```
$ /apex/com.android.runtime/bin/linker64 --expose-internals <dsh bin> plugin --profile web add <pkg>
error: expected absolute path: "--expose-internals"
```

**Fix / 修复** — new `nodeExecutable()` helper: prefers `process.argv0` when it is an existing absolute path, falls back to `process.execPath`. Used for:

- the dsh CLI re-invocation (`dshArgv`) — the failing path above;
- the self-restart helper (`restart.ts`) — same bug, the detached helper never started;
- `nodeBinDir` — was `dirname(execPath)`, a bogus `/apex/.../bin` on Android; now the real node dir so `npm`/`corepack` discovery keeps working.

No behavior change on macOS/Linux/Windows, where `argv0` is the same binary as `execPath`.

**Tests / 测试**

- `tests/dsh-cli.spec.ts`: new `nodeExecutable` cases — prefers an existing absolute `argv0` even when `execPath` is the linker (red before the fix), returns `argv0` verbatim, falls back to `execPath` for empty/relative/nonexistent `argv0`.
- `tests/provision.spec.ts`: the #167 fixture derives the node directory the same way the market does (`nodeExecutable()`), keeping it meaningful on Android while behaving identically on CI.
- Local run: 543/548 tests pass; the 5 `restart-helper.spec.ts` failures are environmental — that spec spawns `process.execPath` children itself and hits the same Android linker issue (identical failures on an unmodified checkout; they pass on CI). Typecheck (`tsconfig.json` + `tsconfig.tests.json`) is green.

**Checklist**

- [x] `npm test` / `npm run check` pass locally (see the environment note above; full `check` needs npm, which is unavailable on the Android test host)
- [x] Tests cover the change — the Android-preference test fails without the fix
- [x] No version bump in `package.json`
- [x] No `src/client/` changes