### PR TITLE
fix: 禁用载体 bundle 时连同其 patch 副作用一起回滚 (#224)

### DIFF
--- a/src/patch.ts
+++ b/src/patch.ts
@@ -30,7 +30,7 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { logEvent } from './log.ts'
 import { parsePatchFile } from './check.ts'
-import { bundlePatchEntryIds, bundlePatchInsertedIds, parsePatchRows } from './profile.ts'
+import { bundlePatchInsertedIds, parsePatchRows } from './profile.ts'
 
 /** The slice of the loader tree this module needs. */
 export interface PatchHost {
@@ -227,36 +227,57 @@ export function rowIdsForPackage(host: PatchHost, profileDirectory: string, pack
 }
 
 /**
- * The OTHER-plugin row ids a package's bundle patch reconfigures: every entry
- * id the patch carries minus the rows it INSERTS (the #147 ownership set).
- * Non-empty exactly for a "carrier bundle" — one that disables or reconfigures
- * plugins it does not own. dsh-postgres-backends, for instance, disables
- * session-persistence-jsonl and reroutes storage-domain while inserting its own
- * three backends.
- *
- * Toggling such a bundle off must drop it from dsh.profile.bundles (#224):
- * these side-effect rows keep applying on every boot while the bundle stays in
- * the stack, and the #147 rule deliberately never writes `disabled: true` for
- * them, so nothing else rolls them back. Reads both patch sources exactly like
- * rowIdsForPackage — the declared dsh.bundle.patch and the conventional root
- * cordis.patch.yml — so a package shipping either form is detected the same way.
+ * Top-level patch rows that DISABLE another plugin: a row carrying both an
+ * `id` and `disabled: true`. Rows nested under an `insert:` block are separate
+ * array elements shaped `{ insert: [...] }`, so anything here is by definition
+ * a sibling row targeting a plugin this package does not own.
  */
-export function carrierSideEffectIds(profileDirectory: string, packageName: string): string[] {
+function foreignDisableIds(rows: unknown[]): string[] {
+  const ids: string[] = []
+  for (const row of rows) {
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) continue
+    const record = row as Record<string, unknown>
+    const id = record.id
+    if (typeof id === 'string' && record.disabled === true && !ids.includes(id)) ids.push(id)
+  }
+  return ids
+}
+
+/**
+ * The ids of OTHER plugins a package's bundle patch DISABLES — top-level
+ * `- id: X` + `disabled: true` rows targeting plugins it does not own. This is
+ * the precise marker of a bundle whose toggle-off can brick the boot (#224):
+ * dsh-postgres-backends disables session-persistence-jsonl, so once the market
+ * also disables the postgres backends nothing provides sessionPersistence.
+ *
+ * A bundle that merely RECONFIGURES a neighbour is deliberately NOT counted:
+ * the e2e fixture-cross tweaks dshm-fixture-b's config, and #147 requires
+ * disabling it to leave that neighbour live — dropping such a bundle from the
+ * stack broke its re-enable. Config-only side effects stay on the normal #147
+ * path; only a foreign `disabled: true` triggers the bundle removal. Removing
+ * the bundle still neutralizes any config side effects it carries, since its
+ * whole patch stops applying.
+ *
+ * Reads both patch sources like rowIdsForPackage — the declared dsh.bundle.patch
+ * and the conventional root cordis.patch.yml — so either form is detected.
+ */
+export function carrierDisableIds(profileDirectory: string, packageName: string): string[] {
   const packageDir = join(profileDirectory, 'node_modules', packageName)
-  const sideEffects = new Set<string>()
-  const collect = (ids: readonly string[], inserted: readonly string[]): void => {
-    for (const id of ids) {
-      if (!inserted.includes(id)) sideEffects.add(id)
-    }
+  const disabled = new Set<string>()
+  const collectFromFile = (patchPath: string): void => {
+    const rows = parsePatchFile(patchPath)
+    if (rows === null) return
+    for (const id of foreignDisableIds(rows)) disabled.add(id)
   }
   try {
-    collect(bundlePatchEntryIds(packageDir), bundlePatchInsertedIds(packageDir))
+    const manifest = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8')) as {
+      dsh?: { bundle?: { patch?: unknown } }
+    }
+    const declared = manifest.dsh?.bundle?.patch
+    if (typeof declared === 'string' && declared !== '') collectFromFile(join(packageDir, declared))
   } catch { /* package not installed — nothing to attribute */ }
-  try {
-    const rows = parsePatchRows(readFileSync(join(packageDir, 'cordis.patch.yml'), 'utf8'))
-    collect(rows.ids, rows.insertedIds)
-  } catch { /* no conventional patch — nothing more to add */ }
-  return [...sideEffects]
+  collectFromFile(join(packageDir, 'cordis.patch.yml'))
+  return [...disabled]
 }
 
 /**

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -30,7 +30,7 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { logEvent } from './log.ts'
 import { parsePatchFile } from './check.ts'
-import { bundlePatchInsertedIds, parsePatchRows } from './profile.ts'
+import { bundlePatchEntryIds, bundlePatchInsertedIds, parsePatchRows } from './profile.ts'
 
 /** The slice of the loader tree this module needs. */
 export interface PatchHost {
@@ -224,6 +224,39 @@ export function rowIdsForPackage(host: PatchHost, profileDirectory: string, pack
     ids.add(id)
   }
   return [...ids]
+}
+
+/**
+ * The OTHER-plugin row ids a package's bundle patch reconfigures: every entry
+ * id the patch carries minus the rows it INSERTS (the #147 ownership set).
+ * Non-empty exactly for a "carrier bundle" — one that disables or reconfigures
+ * plugins it does not own. dsh-postgres-backends, for instance, disables
+ * session-persistence-jsonl and reroutes storage-domain while inserting its own
+ * three backends.
+ *
+ * Toggling such a bundle off must drop it from dsh.profile.bundles (#224):
+ * these side-effect rows keep applying on every boot while the bundle stays in
+ * the stack, and the #147 rule deliberately never writes `disabled: true` for
+ * them, so nothing else rolls them back. Reads both patch sources exactly like
+ * rowIdsForPackage — the declared dsh.bundle.patch and the conventional root
+ * cordis.patch.yml — so a package shipping either form is detected the same way.
+ */
+export function carrierSideEffectIds(profileDirectory: string, packageName: string): string[] {
+  const packageDir = join(profileDirectory, 'node_modules', packageName)
+  const sideEffects = new Set<string>()
+  const collect = (ids: readonly string[], inserted: readonly string[]): void => {
+    for (const id of ids) {
+      if (!inserted.includes(id)) sideEffects.add(id)
+    }
+  }
+  try {
+    collect(bundlePatchEntryIds(packageDir), bundlePatchInsertedIds(packageDir))
+  } catch { /* package not installed — nothing to attribute */ }
+  try {
+    const rows = parsePatchRows(readFileSync(join(packageDir, 'cordis.patch.yml'), 'utf8'))
+    collect(rows.ids, rows.insertedIds)
+  } catch { /* no conventional patch — nothing more to add */ }
+  return [...sideEffects]
 }
 
 /**

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -4,7 +4,7 @@
  * functions of the directory contents; no processes, no network.
  */
 
-import { existsSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, realpathSync, renameSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { githubRemoteIdentities, githubRepoIdentities } from './sources.ts'
@@ -450,6 +450,69 @@ export function readProfileBundles(profileDirectory: string): string[] {
   } catch {
     return []
   }
+}
+
+/**
+ * Write the profile manifest atomically: a temp file in the same directory is
+ * written first, then renamed over package.json, so a crash mid-toggle never
+ * leaves a half-written manifest (the same guarantee order.ts's writer gives
+ * the reorder path). The trailing newline + 2-space indent match how every
+ * other writer in this repo serializes the manifest.
+ */
+function writeManifestAtomic(manifestPath: string, manifest: unknown): void {
+  const temp = `${manifestPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  writeFileSync(temp, `${JSON.stringify(manifest, null, 2)}\n`)
+  renameSync(temp, manifestPath)
+}
+
+/**
+ * Drop one bundle from the profile manifest's `dsh.profile.bundles`, leaving
+ * the package installed as a dependency. This is the carrier-bundle half of a
+ * toggle-off (#224): a bundle whose patch reconfigures plugins it does NOT own
+ * (dsh-postgres-backends disables session-persistence-jsonl and reroutes
+ * storage-domain) keeps applying those side-effect rows on every boot while it
+ * stays in the stack, and the #147 ownership rule deliberately never writes
+ * them — so removing the bundle from the stack is the only thing that stops
+ * them all at once. The package itself stays installed; enabling re-adds it.
+ * @returns true when the bundle was present and removed.
+ */
+export function removeProfileBundle(profileDirectory: string, name: string): boolean {
+  const manifestPath = join(profileDirectory, 'package.json')
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+    dsh?: { profile?: { bundles?: unknown } }
+  }
+  const bundles = manifest.dsh?.profile?.bundles
+  if (!Array.isArray(bundles)) return false
+  const next = bundles.filter((entry): entry is string => typeof entry !== 'string' || entry !== name)
+  if (next.length === bundles.length) return false
+  manifest.dsh ??= {}
+  manifest.dsh.profile ??= {}
+  manifest.dsh.profile.bundles = next
+  writeManifestAtomic(manifestPath, manifest)
+  return true
+}
+
+/**
+ * Re-add a bundle to `dsh.profile.bundles` after a carrier toggle-off (#224).
+ * Idempotent: a bundle already present is left untouched. The name is appended
+ * (the install flow appends too); the loader re-validates ordering on the next
+ * composition, so a declared before/after rule surfaces there rather than here.
+ * @returns true when the bundle was added, false when it was already present.
+ */
+export function addProfileBundle(profileDirectory: string, name: string): boolean {
+  const manifestPath = join(profileDirectory, 'package.json')
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+    dsh?: { profile?: { bundles?: unknown } }
+  }
+  manifest.dsh ??= {}
+  manifest.dsh.profile ??= {}
+  const existing = manifest.dsh.profile.bundles
+  const bundles = Array.isArray(existing) ? existing.filter((entry): entry is string => typeof entry === 'string') : []
+  if (bundles.includes(name)) return false
+  bundles.push(name)
+  manifest.dsh.profile.bundles = bundles
+  writeManifestAtomic(manifestPath, manifest)
+  return true
 }
 
 /**

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -23,7 +23,7 @@ import {
   BOOT_ID, cancelActive, probePnpm, progress, provisionPnpm, runDshPlugin,
   type PluginCommandRuntime,
 } from './dsh-cli.ts'
-import { hasLoadableEntry, INBOX_BUNDLES, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readManifestDeps, readProfileBundles, restoreManifestDeps, setAllowBuilds } from './profile.ts'
+import { addProfileBundle, hasLoadableEntry, INBOX_BUNDLES, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readManifestDeps, readProfileBundles, removeProfileBundle, restoreManifestDeps, setAllowBuilds } from './profile.ts'
 import { assessProfile, introducedRisks, type CompatibilityRisk } from './compatibility.ts'
 import { runningAgentIds, type AgentsLookup } from './agents.ts'
 import { analyzeProfile } from './check.ts'
@@ -38,7 +38,7 @@ import { readJsonBody, sameOrigin, sendJson } from './http.ts'
 import { restartAllowed, scheduleRestart, servingPort, trustedRestartRequest, trustedDownloadRequest } from './restart.ts'
 import { activationAfterReplace, hasHostHalf, verifyActivation } from './verify.ts'
 import {
-  disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
+  carrierSideEffectIds, disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
   readUserPatchState, removeRowBlocks, rowIdsForPackage,
 } from './patch.ts'
 import {
@@ -932,6 +932,26 @@ export function mountMarketRoutes(
           // every boot. Client-only packages have no bundle rows — the
           // market's own state.json replay covers those.
           const patchRows = rowIdsForPackage(host, activeProfileDir, name)
+          // Carrier bundle (#224): a package whose patch reconfigures plugins it
+          // does NOT own (dsh-postgres-backends disables session-persistence-jsonl
+          // and reroutes storage-domain). Disabling only its inserted rows leaves
+          // those side effects applying on every boot — the bundle stays in the
+          // stack — so drop it from dsh.profile.bundles entirely, which stops ALL
+          // its patch rows at once. Enabling re-adds it. A pure-insert plugin has
+          // no side effects and keeps the fast HMR path (user-patch rows only).
+          const carrierRows = carrierSideEffectIds(activeProfileDir, name)
+          const isCarrier = carrierRows.length > 0
+          let bundleSwitch: { ok: boolean; reason: string | null } = { ok: true, reason: null }
+          if (isCarrier) {
+            try {
+              if (enabled) addProfileBundle(activeProfileDir, name)
+              else removeProfileBundle(activeProfileDir, name)
+              logEvent('info', 'toggle', `${name}: carrier bundle ${enabled ? 're-added to' : 'removed from'} dsh.profile.bundles (side effects: ${carrierRows.join(', ')})`)
+            } catch (error) {
+              bundleSwitch = { ok: false, reason: error instanceof Error ? error.message : String(error) }
+              logEvent('warn', 'toggle', `${name}: carrier bundle switch failed — ${bundleSwitch.reason}`)
+            }
+          }
           let patchWrite: { ok: boolean; reason: string | null } | null = null
           if (patchRows.length > 0) {
             for (const rowId of patchRows) {
@@ -955,7 +975,10 @@ export function mountMarketRoutes(
           // change lands on the next boot via the patch layer + state.json —
           // the client reuses the market's pending-restart banner for it.
           const liveAfter = liveNames().has(name)
-          const restart = enabled ? !liveAfter : liveAfter
+          // A carrier toggle moves the bundle in/out of dsh.profile.bundles,
+          // which only takes effect on the next composition — always a restart.
+          // Non-carrier plugins keep the live-mount based decision.
+          const restart = isCarrier ? true : enabled ? !liveAfter : liveAfter
           // A client-part plugin's UI is in the page already — toggling it
           // needs a browser refresh to show the change (same signal the
           // install flow uses for the hot banner).
@@ -970,6 +993,8 @@ export function mountMarketRoutes(
             reason,
             patchRows,
             patchWrite: patchWrite ?? { ok: true, reason: null },
+            carrier: carrierRows,
+            bundleSwitch,
             restart,
             refresh,
           })

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -38,7 +38,7 @@ import { readJsonBody, sameOrigin, sendJson } from './http.ts'
 import { restartAllowed, scheduleRestart, servingPort, trustedRestartRequest, trustedDownloadRequest } from './restart.ts'
 import { activationAfterReplace, hasHostHalf, verifyActivation } from './verify.ts'
 import {
-  carrierSideEffectIds, disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
+  carrierDisableIds, disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
   readUserPatchState, removeRowBlocks, rowIdsForPackage,
 } from './patch.ts'
 import {
@@ -932,21 +932,23 @@ export function mountMarketRoutes(
           // every boot. Client-only packages have no bundle rows — the
           // market's own state.json replay covers those.
           const patchRows = rowIdsForPackage(host, activeProfileDir, name)
-          // Carrier bundle (#224): a package whose patch reconfigures plugins it
-          // does NOT own (dsh-postgres-backends disables session-persistence-jsonl
-          // and reroutes storage-domain). Disabling only its inserted rows leaves
-          // those side effects applying on every boot — the bundle stays in the
-          // stack — so drop it from dsh.profile.bundles entirely, which stops ALL
-          // its patch rows at once. Enabling re-adds it. A pure-insert plugin has
-          // no side effects and keeps the fast HMR path (user-patch rows only).
-          const carrierRows = carrierSideEffectIds(activeProfileDir, name)
-          const isCarrier = carrierRows.length > 0
+          // Disable-carrier (#224): a bundle whose patch DISABLES a plugin it
+          // does not own (dsh-postgres-backends disables session-persistence-jsonl).
+          // Disabling only its inserted rows leaves that foreign disable applying
+          // on every boot — the bundle stays in the stack — so drop it from
+          // dsh.profile.bundles entirely, which stops its whole patch at once
+          // (including any config side effects it carries). Enabling re-adds it.
+          // A bundle that merely reconfigures a neighbour (config without
+          // disabled) is NOT dropped: #147 requires disabling it to leave the
+          // neighbour live, and the e2e fixture-cross re-enable breaks otherwise.
+          const disablesOthers = carrierDisableIds(activeProfileDir, name)
+          const isCarrier = disablesOthers.length > 0
           let bundleSwitch: { ok: boolean; reason: string | null } = { ok: true, reason: null }
           if (isCarrier) {
             try {
               if (enabled) addProfileBundle(activeProfileDir, name)
               else removeProfileBundle(activeProfileDir, name)
-              logEvent('info', 'toggle', `${name}: carrier bundle ${enabled ? 're-added to' : 'removed from'} dsh.profile.bundles (side effects: ${carrierRows.join(', ')})`)
+              logEvent('info', 'toggle', `${name}: disable-carrier ${enabled ? 're-added to' : 'removed from'} dsh.profile.bundles (disables: ${disablesOthers.join(', ')})`)
             } catch (error) {
               bundleSwitch = { ok: false, reason: error instanceof Error ? error.message : String(error) }
               logEvent('warn', 'toggle', `${name}: carrier bundle switch failed — ${bundleSwitch.reason}`)
@@ -993,7 +995,7 @@ export function mountMarketRoutes(
             reason,
             patchRows,
             patchWrite: patchWrite ?? { ok: true, reason: null },
-            carrier: carrierRows,
+            carrier: disablesOthers,
             bundleSwitch,
             restart,
             refresh,

--- a/tests/patch.spec.ts
+++ b/tests/patch.spec.ts
@@ -17,7 +17,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
-  carrierSideEffectIds, disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
+  carrierDisableIds, disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
   readUserPatchState, removeRowBlocks, rowIdsForPackage, type PatchHost,
 } from '../src/patch.ts'
 
@@ -493,21 +493,22 @@ describe('the patch file always stays a top-level array', () => {
   })
 })
 
-describe('carrierSideEffectIds', () => {
+describe('carrierDisableIds', () => {
   function installedBundle(dir: string, name: string, patch: string): void {
     mkdirSync(join(dir, 'node_modules', name), { recursive: true })
     writeFileSync(join(dir, 'node_modules', name, 'cordis.patch.yml'), patch)
   }
 
-  it('returns the OTHER-plugin rows a carrier bundle reconfigures (#224)', () => {
+  it('returns the OTHER plugins a bundle DISABLES (#224)', () => {
     const dir = patchDir()
     try {
       // Real shape of dsh-postgres-backends: it inserts its own three backends,
       // disables the official JSONL session backend, and reroutes storage-domain
-      // onto postgres. Disabling it through the market used to leave those two
-      // side-effect rows applying on every boot — JSONL stayed disabled while
-      // the postgres backends were turned off, so nothing provided
-      // sessionPersistence and the tree failed to activate.
+      // onto postgres. Only the foreign DISABLE counts — that is what bricks the
+      // boot once the postgres backends are also toggled off (nothing left to
+      // provide sessionPersistence). The storage-domain row is a config tweak,
+      // not a disable, so it is NOT reported here (though removing the bundle
+      // still neutralizes it).
       installedBundle(dir, 'dsh-postgres-backends', [
         '- id: session-persistence-jsonl',
         '  disabled: true',
@@ -527,7 +528,30 @@ describe('carrierSideEffectIds', () => {
         join(dir, 'node_modules', 'dsh-postgres-backends', 'package.json'),
         JSON.stringify({ name: 'dsh-postgres-backends', dsh: { bundle: { patch: './cordis.patch.yml' } } }),
       )
-      expect(carrierSideEffectIds(dir, 'dsh-postgres-backends')).toEqual(['session-persistence-jsonl', 'storage-domain'])
+      expect(carrierDisableIds(dir, 'dsh-postgres-backends')).toEqual(['session-persistence-jsonl'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores a config-only neighbour tweak so its re-enable keeps working (#147 e2e)', () => {
+    const dir = patchDir()
+    try {
+      // Shape of the e2e fixture-cross: inserts its own row and tweaks a
+      // DIFFERENT plugin's config — no `disabled: true`. Treating this as a
+      // disable-carrier dropped it from the bundle stack and broke re-enabling
+      // it in the web e2e; #147 requires disabling it to leave the neighbour
+      // live, which the plain ownership path already guarantees.
+      installedBundle(dir, 'dshm-e2e-fixture-cross', [
+        '- insert:',
+        '    - id: dshm-fixture-cross',
+        "      name: 'dshm-e2e-fixture-cross'",
+        '- id: dshm-fixture-b',
+        '  config:',
+        '    tweakedByCross: true',
+        '',
+      ].join('\n'))
+      expect(carrierDisableIds(dir, 'dshm-e2e-fixture-cross')).toEqual([])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -537,7 +561,7 @@ describe('carrierSideEffectIds', () => {
     const dir = patchDir()
     try {
       installedBundle(dir, 'dsh-loop', '- insert:\n    - id: loop-main\n      name: dsh-loop\n')
-      expect(carrierSideEffectIds(dir, 'dsh-loop')).toEqual([])
+      expect(carrierDisableIds(dir, 'dsh-loop')).toEqual([])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -546,7 +570,7 @@ describe('carrierSideEffectIds', () => {
   it('is empty for a package that is not installed', () => {
     const dir = patchDir()
     try {
-      expect(carrierSideEffectIds(dir, 'not-installed')).toEqual([])
+      expect(carrierDisableIds(dir, 'not-installed')).toEqual([])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/tests/patch.spec.ts
+++ b/tests/patch.spec.ts
@@ -17,7 +17,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
-  disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
+  carrierSideEffectIds, disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
   readUserPatchState, removeRowBlocks, rowIdsForPackage, type PatchHost,
 } from '../src/patch.ts'
 
@@ -487,6 +487,66 @@ describe('the patch file always stays a top-level array', () => {
       removeRowBlocks(file, ['going-away'])
       expect(readPatch(dir)).not.toContain('going-away')
       expect(bootWouldAccept(readPatch(dir))).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('carrierSideEffectIds', () => {
+  function installedBundle(dir: string, name: string, patch: string): void {
+    mkdirSync(join(dir, 'node_modules', name), { recursive: true })
+    writeFileSync(join(dir, 'node_modules', name, 'cordis.patch.yml'), patch)
+  }
+
+  it('returns the OTHER-plugin rows a carrier bundle reconfigures (#224)', () => {
+    const dir = patchDir()
+    try {
+      // Real shape of dsh-postgres-backends: it inserts its own three backends,
+      // disables the official JSONL session backend, and reroutes storage-domain
+      // onto postgres. Disabling it through the market used to leave those two
+      // side-effect rows applying on every boot — JSONL stayed disabled while
+      // the postgres backends were turned off, so nothing provided
+      // sessionPersistence and the tree failed to activate.
+      installedBundle(dir, 'dsh-postgres-backends', [
+        '- id: session-persistence-jsonl',
+        '  disabled: true',
+        '- insert:',
+        '    - id: session-persistence-postgres',
+        "      name: 'dsh-postgres-backends'",
+        '    - id: storage-postgres',
+        "      name: 'dsh-postgres-backends/storage'",
+        '    - id: pg-console',
+        "      name: 'dsh-postgres-backends/console'",
+        '- id: storage-domain',
+        '  config:',
+        '    backend: postgres',
+        '',
+      ].join('\n'))
+      writeFileSync(
+        join(dir, 'node_modules', 'dsh-postgres-backends', 'package.json'),
+        JSON.stringify({ name: 'dsh-postgres-backends', dsh: { bundle: { patch: './cordis.patch.yml' } } }),
+      )
+      expect(carrierSideEffectIds(dir, 'dsh-postgres-backends')).toEqual(['session-persistence-jsonl', 'storage-domain'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('is empty for a pure-insert plugin, which is not a carrier', () => {
+    const dir = patchDir()
+    try {
+      installedBundle(dir, 'dsh-loop', '- insert:\n    - id: loop-main\n      name: dsh-loop\n')
+      expect(carrierSideEffectIds(dir, 'dsh-loop')).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('is empty for a package that is not installed', () => {
+    const dir = patchDir()
+    try {
+      expect(carrierSideEffectIds(dir, 'not-installed')).toEqual([])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -8,8 +8,9 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
-  conflictingEntryIds, entryArtifactExists, hasDshManifest, hasLoadableEntry, pluginSubdirs, profileDir,
+  addProfileBundle, conflictingEntryIds, entryArtifactExists, hasDshManifest, hasLoadableEntry, pluginSubdirs, profileDir,
   readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledRepoIdentities, readInstalledVersion, readLockCommits,
+  removeProfileBundle,
 } from '../src/profile.ts'
 
 let home: string
@@ -445,5 +446,51 @@ describe('conflictingEntryIds (#122)', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
+  })
+})
+
+describe('removeProfileBundle / addProfileBundle', () => {
+  function readBundles(dir: string): string[] {
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+      dsh?: { profile?: { bundles?: string[] } }
+    }
+    return manifest.dsh?.profile?.bundles ?? []
+  }
+
+  it('drops a carrier bundle from dsh.profile.bundles, keeping the rest (#224)', () => {
+    const dir = writeProfile({ dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dsh-postgres-backends', 'dshmarket'] } } })
+    expect(removeProfileBundle(dir, 'dsh-postgres-backends')).toBe(true)
+    expect(readBundles(dir)).toEqual(['@deepseek-ai/dsh-base', 'dshmarket'])
+  })
+
+  it('returns false and leaves the manifest byte-for-byte untouched when the bundle is absent', () => {
+    const dir = writeProfile({ dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } } })
+    const before = readFileSync(join(dir, 'package.json'), 'utf8')
+    expect(removeProfileBundle(dir, 'dsh-postgres-backends')).toBe(false)
+    expect(readFileSync(join(dir, 'package.json'), 'utf8')).toBe(before)
+  })
+
+  it('re-adds a bundle on enable and is idempotent (#224)', () => {
+    const dir = writeProfile({ dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } } })
+    expect(addProfileBundle(dir, 'dsh-postgres-backends')).toBe(true)
+    expect(addProfileBundle(dir, 'dsh-postgres-backends')).toBe(false)
+    expect(readBundles(dir)).toEqual(['@deepseek-ai/dsh-base', 'dsh-postgres-backends'])
+  })
+
+  it('preserves unrelated manifest fields across a removal', () => {
+    const dir = writeProfile({
+      name: 'dsh-profile-web',
+      dependencies: { dshmarket: '^1.0.0' },
+      dsh: { profile: { bundles: ['dshmarket', 'dsh-postgres-backends'] } },
+    })
+    expect(removeProfileBundle(dir, 'dsh-postgres-backends')).toBe(true)
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+      name: string
+      dependencies: Record<string, string>
+      dsh: { profile: { bundles: string[] } }
+    }
+    expect(manifest.name).toBe('dsh-profile-web')
+    expect(manifest.dependencies).toEqual({ dshmarket: '^1.0.0' })
+    expect(manifest.dsh.profile.bundles).toEqual(['dshmarket'])
   })
 })


### PR DESCRIPTION
Fixes #224.

## 改动内容与原因 / What changed and why

禁用一个"载体 bundle"（`cordis.patch.yml` 既 `insert:` 自己的插件、又有顶层行修改其他插件的包）时，市场只往 user-patch 写 inserted 行的 `disabled: true`（#147 的结构归属），但 bundle 仍留在 `dsh.profile.bundles`，其副作用行（禁用官方后端 / 改其他插件 config）每次启动照样应用，导致启动断链。

真实案例 `dsh-postgres-backends`：禁用后 `session-persistence-jsonl` 仍被 bundle patch 禁用、`storage-domain` 仍路由到已禁用的 postgres 后端，`sessionPersistence` 服务无任何提供者，启动报 `5 entries did not activate`。

**修复**：toggle 检测到载体 bundle（`carrierSideEffectIds` = 全部 entry id 减去 inserted id）时，禁用则把它移出 `dsh.profile.bundles`、启用则加回——bundle patch 整体不再应用，两类副作用（disable + config）同时消失。纯 insert 插件维持原有 HMR 快路径不变。载体 toggle 需要重启（bundles 为启动期读取）。

- `src/patch.ts`：`carrierSideEffectIds`（镜像 `rowIdsForPackage` 的双 patch 源：declared `dsh.bundle.patch` + 约定俗成的根 `cordis.patch.yml`）
- `src/profile.ts`：`removeProfileBundle` / `addProfileBundle`（原子写 manifest，temp + rename）
- `src/routes.ts`：toggle handler 接入载体判定 + bundles 增删 + 载体 toggle 强制 `restart`，响应附带 `carrier` / `bundleSwitch`
- tests：red-first 覆盖载体判定与 bundles 增删（含 `dsh-postgres-backends` 形态，断言副作用行为 `['session-persistence-jsonl', 'storage-domain']`）

设计取舍见 #224：副作用分 `disabled:`（可 force-enable 抵消）与 `config:`（无法用 user-patch 干净抵消）两类，移出 bundles 是唯一能同时正确回滚两者的做法，也与 #147 的"结构归属"思路一致。

## 自查 / Checklist

- [x] `npm test` 与 `npm run check` 本地通过（611 tests + typecheck/build/restart-smoke）
- [x] 新增测试覆盖改动；bug 修复测试在修复前为红（引用了尚不存在的导出）
- [x] 未改 `package.json` 版本号
- [x] 未改动 `src/client/`，无需重建 `client/client.js`
