### PR TITLE
fix: restore in-flight update progress when the config page reopens

### DIFF
--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -351,6 +351,8 @@ export function MarketSection(props: MarketSectionProps) {
   const [busyUrl, setBusyUrl] = useState<string | null>(null)
   /** Consecutive idle polls with a pending install that never landed (#32). */
   const idleStrikes = useRef(0)
+  /** Same idle-strike bookkeeping for an update whose response was lost. */
+  const updateIdleStrikes = useRef(0)
   const [doneUrls, setDoneUrls] = useState<string[]>([])
   const [installError, setInstallError] = useState<string | null>(null)
   interface CompatibilityNotice {
@@ -672,6 +674,12 @@ export function MarketSection(props: MarketSectionProps) {
   useEffect(() => {
     const pending = readSession('dshm-pending')
     if (pending !== null && typeof pending.url === 'string') setBusyUrl(pending.url)
+    // Same recovery for an update in flight: closing the config page unmounts
+    // this section and drops `updatingName` with it, so the running row's
+    // progress vanished on reopen. The marker restores the row and the poll
+    // below converges it from the host's ground truth.
+    const updating = readSession('dshm-updating')
+    if (updating !== null && typeof updating.name === 'string' && updating.name !== '') setUpdatingName(updating.name)
   }, [])
 
   useEffect(() => {
@@ -741,6 +749,23 @@ export function MarketSection(props: MarketSectionProps) {
                 setBusyUrl(null)
                 setInstallError(t('installFail') + ' — ' + t('exportLog'))
               }
+            }
+            // An update whose response was lost — the page was closed mid-run
+            // and reopened via the dshm-updating marker — converges the same
+            // way. Once the host reports the operation fully settled (pnpm
+            // exited AND the mutation lock released), hand the running row
+            // back to the refreshed listing instead of showing "updating"
+            // forever. Two idle polls guard the brief window before the host
+            // has actually started the command.
+            if (updatingName !== null && status.busy !== true) {
+              if (++updateIdleStrikes.current >= 2) {
+                updateIdleStrikes.current = 0
+                sessionStorage.removeItem('dshm-updating')
+                setUpdatingName(null)
+                refreshInstalled()
+              }
+            } else {
+              updateIdleStrikes.current = 0
             }
           }
         })
@@ -988,6 +1013,12 @@ export function MarketSection(props: MarketSectionProps) {
     setActivationWarnings([])
     setStaleName(null)
     setUpdatingName(name)
+    updateIdleStrikes.current = 0
+    // Mirror the install flow's dshm-pending marker: closing the config page
+    // unmounts this section and drops `updatingName`, so the running row's
+    // progress was lost on reopen. The marker survives the unmount and lets a
+    // reopen restore the row while the status poll converges the outcome.
+    sessionStorage.setItem('dshm-updating', JSON.stringify({ name }))
     return fetch('/dsh-market/update', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -995,6 +1026,11 @@ export function MarketSection(props: MarketSectionProps) {
     })
       .then(res => res.json().then(body => ({ status: res.status, body })))
       .then(({ status, body }) => {
+        // A response means the host settled the request (even a 4xx/5xx), so
+        // the running row can hand back now. Only a lost response keeps the
+        // marker + row for the poll to converge.
+        sessionStorage.removeItem('dshm-updating')
+        setUpdatingName(null)
         if (body.cancelled === true) {
           refreshInstalled()
           if (body.partial === true) setInstallError(t('partialNote'))
@@ -1030,8 +1066,12 @@ export function MarketSection(props: MarketSectionProps) {
           setInstallError(t('updateFail') + ': ' + name + ' — ' + detail.trim().slice(-600))
         }
       })
-      .catch(error => setInstallError(t('updateFail') + ': ' + String(error)))
-      .finally(() => setUpdatingName(null))
+      .catch(() => {
+        // A lost response does not mean the update stopped (the route holds
+        // its reply until pnpm finishes, #100): keep the marker AND the
+        // running row, and let the status poll converge the outcome instead
+        // of declaring a false failure — mirroring the install flow's catch.
+      })
   }, [refreshInstalled, t])
 
   const doUseSkin = useCallback((name: string) => {

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -483,6 +483,50 @@ describe('stuck pending recovery (#32)', () => {
   })
 })
 
+describe('lost update progress (config page reopened)', () => {
+  it('restores the running update row from the marker and converges it once the host settles', async () => {
+    vi.useFakeTimers()
+    try {
+      // A previous page load started an update, then the config page closed
+      // before the response arrived. The marker survives the unmount, so a
+      // reopen restores the running row instead of losing its progress.
+      sessionStorage.setItem('dshm-updating', JSON.stringify({ name: 'dsh-loop' }))
+      let settled = false
+      vi.stubGlobal('fetch', vi.fn((url: string) => {
+        const path = String(url).split('?')[0]
+        const payload =
+          path === '/dsh-market/registry' ? { source: 'live', registry: REGISTRY }
+          : path === '/dsh-market/installed' ? { profile: 'web', installed: { 'dsh-loop': '^1.0.0' }, live: [], disabled: [], groups: {}, groupOrder: [] }
+          : path === '/dsh-market/status' ? {
+              active: !settled, busy: !settled, pnpm: true, boot: 'boot-1', restart: true,
+              installed: { 'dsh-loop': '^1.0.0' },
+              phase: settled ? null : 'downloading', currentPackage: settled ? null : 'is-odd@3.0.1', done: settled ? 0 : 3,
+            }
+          : path === '/dsh-market/updates' ? { updates: {} }
+          : null
+        if (payload === null) return Promise.reject(new Error(`unstubbed fetch: ${String(url)}`))
+        return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }))
+      }))
+      render(<MarketSection {...props()} />)
+      fireEvent.click(screen.getByRole('button', { name: new RegExp(re(en.tabInstalled)) }))
+      // The restored marker re-renders the running row and its live progress.
+      await vi.waitFor(() => { screen.getByRole('button', { name: en.updating }) })
+      await vi.advanceTimersByTimeAsync(2100)
+      await vi.waitFor(() => { screen.getByText(/Downloading · is-odd@3\.0\.1 · 3 packages processed/) })
+      // The host finishes the update; two idle polls hand the row back.
+      settled = true
+      await vi.advanceTimersByTimeAsync(2100)
+      await vi.advanceTimersByTimeAsync(2100)
+      await vi.waitFor(() => {
+        expect(sessionStorage.getItem('dshm-updating')).toBeNull()
+        expect(screen.queryByRole('button', { name: en.updating })).toBeNull()
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
 describe('P1-6 structured progress', () => {
   it('shows the pnpm phase + package + count, and a disabled cancel button while cancelling', async () => {
     vi.useFakeTimers()


### PR DESCRIPTION
## What & why

Closing the Settings → Plugin Market page while a plugin update is running **loses the update progress**. Reopening the page shows no running row — even though the update is still executing server-side — because the running row is driven by `updatingName`, a React state in `MarketSection.tsx` that dies with the component on unmount.

The install flow already survives this via a `dshm-pending` sessionStorage marker + the `/dsh-market/status` poll recovery; the update flow had no equivalent.

## Fix

Mirror the install flow for updates:

1. `doUpdate` writes a `dshm-updating` sessionStorage marker before firing the request.
2. The marker is cleared once the HTTP response arrives (any 2xx/4xx/5xx).
3. A **lost** response (`.catch`) keeps the marker and the running row instead of declaring a false failure — same reasoning as the install flow's #100 recovery.
4. On mount, `updatingName` is restored from the marker.
5. The status poll's idle branch hands the restored row back (clears marker + `updatingName`, refreshes the installed listing) once the host reports the operation settled — pnpm exited AND the mutation lock released — guarded by the same two-idle-poll grace as the install #32 recovery.

## Changes

- `src/client/MarketSection.tsx`
- `tests/client/market-section.client.spec.tsx`

## Test plan

- Added regression test: `lost update progress (config page reopened)` — restores the running row + live progress from the marker, then converges once the host settles.
- `tests/client` + `market-data.spec.ts`: **124 tests pass**.
- `tsc -p tsconfig.client.json --noEmit`: clean.