### PR TITLE
fix: pass --no-open to dsh web boot in e2e, bump CI to rc.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,13 @@ jobs:
         with:
           version: 10
       - run: npm install
-      - run: npm install -g @deepseek-ai/dsh@0.1.0-rc.7
+      # rc.8+: earlier CLIs unconditionally launched a system browser on
+      # `dsh web` boot, which on the Windows runner left orphaned msedge
+      # processes and the status endpoint never answering — read as a
+      # flaky "dsh boot timeout" (and, on longer specs, an hours-long stuck
+      # job) with nothing wrong in this repo's own code. rc.8 added
+      # `--no-open`, which tests/web/scaffold.ts now passes.
+      - run: npm install -g @deepseek-ai/dsh@0.1.0-rc.8
       # --with-deps installs system libraries and is Linux-only.
       - run: npx playwright install --with-deps chromium
         if: runner.os == 'Linux'

--- a/tests/web/scaffold.ts
+++ b/tests/web/scaffold.ts
@@ -115,9 +115,14 @@ export async function launchMarketScaffold(options: ScaffoldOptions = {}): Promi
   const port = 3200 + Math.floor(Math.random() * 500)
   const baseUrl = `http://127.0.0.1:${String(port)}`
 
-  /** Spawn dsh and wait until the market answers, or explain why it never did. */
+  /** Spawn dsh and wait until the market answers, or explain why it never did.
+   * `--no-open` (dsh >= 0.1.0-rc.8) is required here: without it, boot tries
+   * to launch a system browser, which on a headless CI runner (confirmed on
+   * Windows) left orphaned browser processes and the status endpoint never
+   * answering — surfacing as a "dsh boot timeout" with nothing actually
+   * wrong in this repo. */
   const boot = async (): Promise<ChildProcess> => {
-    const process_ = spawn(`${command} --profile web --port ${String(port)}`, {
+    const process_ = spawn(`${command} --profile web --port ${String(port)} --no-open`, {
       shell: true,
       cwd: DSH_CWD,
       env,


### PR DESCRIPTION
## Summary
- Traced the intermittent Windows `web-e2e` "dsh boot timeout" failures (and at least two PRs — #126, #155 — hitting a job stuck for 6+ hours) to older `dsh` CLIs unconditionally launching a system browser on `dsh web` boot. A headless CI runner never satisfies that, and orphaned `msedge` processes were left behind at job cleanup.
- `dsh` `0.1.0-rc.8` added a `--no-open` flag for exactly this. This PR wires it into `tests/web/scaffold.ts`'s boot command and bumps CI's pinned CLI version from `0.1.0-rc.7` to `0.1.0-rc.8` to match.

## Test plan
- [x] `npm run test:web` locally against `dsh 0.1.0-rc.8`: 6 files / 29 tests, all green, no lingering browser processes.
- [x] `npm run check` clean.