### PR TITLE
fix(install): allow caret/tilde semver ranges in plugin target allowlist

### DIFF
--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -498,7 +498,7 @@ export const BOOT_ID = `${String(process.pid)}-${String(Date.now())}`
  * mistaken for shell injection (whitespace and shell metacharacters remain
  * rejected — the win32 bare-dsh fallback is the reason to keep them out).
  */
-const TARGET_RE = /^[A-Za-z0-9@:./_#+~^=-]+$/
+export const TARGET_RE = /^[A-Za-z0-9@:./_#+~^=-]+$/
 
 /** Mutating pnpm commands get the structured reporter appended. */
 const NDJSON_COMMANDS = new Set(['add', 'remove', 'install'])

--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -491,8 +491,14 @@ export const BOOT_ID = `${String(process.pid)}-${String(Date.now())}`
  * Central allowlist for every spawn target, regardless of which route built
  * it (defense in depth on top of per-route validation — the win32 bare-dsh
  * fallback runs through a shell). Suggested in #16 by @anupamme.
+ *
+ * `^`, `~` and `=` are intentionally allowed: restore/install flows turn
+ * manifest specs such as "dsh-better-sidebar": "^0.14.0" into targets like
+ * `dsh-better-sidebar@^0.14.0`, and regex-valid semver ranges must not be
+ * mistaken for shell injection (whitespace and shell metacharacters remain
+ * rejected — the win32 bare-dsh fallback is the reason to keep them out).
  */
-const TARGET_RE = /^[A-Za-z0-9@:./_#+-]+$/
+const TARGET_RE = /^[A-Za-z0-9@:./_#+~^=-]+$/
 
 /** Mutating pnpm commands get the structured reporter appended. */
 const NDJSON_COMMANDS = new Set(['add', 'remove', 'install'])

--- a/tests/dsh-cli.spec.ts
+++ b/tests/dsh-cli.spec.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
-import { cmdCommandLine, nodeExecutable, proxyEnvForPnpm, quoteCmdArg } from '../src/dsh-cli.ts'
+import { cmdCommandLine, nodeExecutable, proxyEnvForPnpm, quoteCmdArg, TARGET_RE } from '../src/dsh-cli.ts'
 
 describe('cmd.exe command line building (DEP0190 shim)', () => {
   it('keeps simple tokens unquoted', () => {
@@ -147,6 +147,37 @@ describe('the proxy translation actually reaches spawned pnpm (#148)', () => {
       else process.env.HTTPS_PROXY = previous
       vi.doUnmock('node:child_process')
       vi.resetModules()
+    }
+  })
+})
+
+describe('TARGET_RE plugin target allowlist', () => {
+  it('accepts semver range prefixes that restore/install flows produce', () => {
+    // Regression: carets/tildes from manifest specs (name@^x.y.z) were rejected
+    // as "unsafe plugin target", breaking every gist restore on the caret.
+    for (const target of [
+      '@linxin666/dsh-tool-describe-image@^0.2.2',
+      'dsh-better-sidebar@^0.14.0',
+      'dsh-dream-skin@~0.3.0',
+      'dsh-free-search@^0.4.7',
+      'dshmarket@^1.14.1',
+      'dsh-market@=1.2.3',
+      'dshmarket@1.14.0',
+      'github:Ychris12138/dsh-usage-stats',
+    ]) {
+      expect(TARGET_RE.test(target)).toBe(true)
+    }
+  })
+
+  it('still rejects targets that could inject through a shell', () => {
+    for (const target of [
+      'dsh; rm -rf /',
+      'dsh-better-sidebar@^0.14.0 --reporter=ndjson',
+      'x|y',
+      '$(pwd)',
+      'dsh-better-sidebar &',
+    ]) {
+      expect(TARGET_RE.test(target)).toBe(false)
     }
   })
 })


### PR DESCRIPTION
## What

`preparePluginArgs()` validates the last pnpm target argument against a central
allowlist before spawning `dsh plugin --profile <p> add <target>`:

```ts
const TARGET_RE = /^[A-Za-z0-9@:./_#+-]+$/
```

Caret (`^`) and tilde (`~`) — the standard npm semver range prefixes that pnpm
writes into `package.json` (pnpm's default `save-prefix` is `^`) — are **not**
in the character class. This patch adds them (plus `=` for exact-pin specs):

```ts
const TARGET_RE = /^[A-Za-z0-9@:./_#+~^=-]+$/
```

## Why

Any install/restore whose target comes from a manifest spec fails. The gist
restore path (the backup/gist channel added in #144) rebuilds each dependency
as `${name}@${spec}`, so a caret range becomes e.g. `dsh-better-sidebar@^0.14.0`
and is rejected with:

```
dsh-better-sidebar: unsafe plugin target rejected: "dsh-better-sidebar@^0.14.0"
```

Reproduced with every freshly-restored plugin (all of them fail on `^`), while
non-caret specs like `github:Ychris12138/dsh-usage-stats` pass — confirming the
caret is the only discriminating character. Tilde ranges (`~1.2.3`) fail the
same way.

## Why it is safe

`^`, `~`, `=` are not shell metacharacters and cannot widen the injection
surface the allowlist guards against — whitespace and real shell
metacharacters (`; | & $ \` \` " ' ( ) < >` …) remain rejected. The allowlist
exists for the win32 bare-dsh fallback that runs through a shell; semver range
operators in the version portion of a package spec are inert there as well.

## Verification

- `TARGET_RE.test('dsh-better-sidebar@^0.14.0')` → now `true` (was `false`).
- All previously-rejected targets from a real gist restore pass the new regex.
- Malicious inputs (`!evil; rm -rf /`, specs with spaces/`;`) are still
  rejected.
- Applied the same one-line change to the compiled `lib/dsh-cli.js` of v1.15.0
  locally: a restore-from-gist that previously failed on every plugin now
  installs them all.

The bug is present in every released version through the latest (1.16.0), so a
patch release would help anyone using the gist restore channel.


---

### Checklist (matching the repo's PULL_REQUEST_TEMPLATE)

- [x] `npm test` — affected spec `tests/dsh-cli.spec.ts`: 12/12 pass; full suite: 630 passed. The only failing file, `tests/updates.spec.ts`, fails on a clean `main` without this change too (registry-snapshot data drift), so it is unrelated to this PR (verified by stashing the change).
- [x] `npm run typecheck` (tsconfig / tsconfig.client / tsconfig.tests) passes.
- [x] Regression tests added: the legitimate-range cases are **RED** on the old regex and **GREEN** with the fix; shell-injection vectors are asserted to remain rejected.
- [x] No version bump in `package.json` (releases are a maintainer action).
- [x] No `src/client/` change, so `client/client.js` is untouched.
