### PR TITLE
fix: run both uninstall cleanups, and keep every .bak shape out of a backup

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -49,7 +49,12 @@ export interface ProfileBackup {
 function profileFiles(root: string, dir = root): string[] {
   const files: string[] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (SKIP_NAMES.has(entry.name) || /\.bak-\d+$/.test(entry.name)) continue
+    // Any .bak marker, not just the numeric-suffixed one this codebase
+    // writes. Recovery and the host's own repair paths leave other shapes —
+    // `package.json.bak-asm`, `cordis.patch.yml.rp-merged.bak` — and a
+    // backup that carried them restored them too, so the profile came back
+    // with the wreckage that made it need repairing (#205 by @Rudyy898).
+    if (SKIP_NAMES.has(entry.name) || /\.bak\b/.test(entry.name)) continue
     const path = resolve(dir, entry.name)
     if (entry.isSymbolicLink()) continue
     if (entry.isDirectory()) files.push(...profileFiles(root, path))

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -422,9 +422,12 @@ export function mountMarketRoutes(
     if (result.exitCode !== 0 || result.timedOut || result.cancelled) {
       return { ok: false, hot: false, detail: (result.stderr || result.stdout).slice(-300) }
     }
-    let hot = false
-    hot = await hotUnmount(name)
-    if (!hot) hot = await themes.setEntryDisabled(name, true)
+    // Both cleanups run — see the uninstall route's note on #213: a package
+    // with two activation sources must not have the second one skipped
+    // because the first succeeded.
+    const unmounted = await hotUnmount(name)
+    const entryDisabled = await themes.setEntryDisabled(name, true)
+    const hot = unmounted || entryDisabled
     removeRowBlocks(userPatchPath, rowIdsForPackage(host, activeProfileDir, name))
     disabled.delete(name)
     removeFromGroups({ groups, groupOrder }, name)
@@ -1838,7 +1841,17 @@ export function mountMarketRoutes(
               // wedge the whole page until a dsh restart (#37 by
               // @1123762794). Live-disable the entry so the refresh composes
               // without it; after a real restart the entry is gone anyway.
-              if (!hot) hot = await themes.setEntryDisabled(name, true)
+              //
+              // Both run, unconditionally. This used to short-circuit on the
+              // hot unmount, which is right only while a package has ONE
+              // activation source — a package that is both hot-mounted AND
+              // reachable through the bundle layer got half its cleanup, and
+              // the surviving half is exactly the 404-on-refresh wedge above
+              // (#213). setEntryDisabled just scans entries by name and
+              // returns false when none match, so calling it after a
+              // successful unmount costs a lookup and nothing else.
+              const entryDisabled = await themes.setEntryDisabled(name, true)
+              hot = hot || entryDisabled
               // Patch-layer rows must not survive the remove either: a
               // `- id: X` + `disabled: true` row for a package that no longer
               // mounts is a boot-time orphan (port of dsh-plugin-hub).

--- a/tests/backup.spec.ts
+++ b/tests/backup.spec.ts
@@ -90,6 +90,27 @@ describe('profile backup and restore', () => {
     expect(existsSync(join(dir, 'node_modules', 'plugin', 'large.bin'))).toBe(true)
   })
 
+  it('excludes every .bak shape, not just the numeric suffix this repo writes (#205)', () => {
+    // A restore that carried these put the wreckage back: the reporter's
+    // profile came back with the very leftovers that made it need repairing.
+    // The shapes are real — recovery and the host's own repair paths write
+    // `.bak-asm` and `.rp-merged.bak`, neither of which the old
+    // `/\.bak-\d+$/` filter matched.
+    const dir = profileDir('web')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'package.json'), '{"dependencies":{}}')
+    writeFileSync(join(dir, 'package.json.bak-1234'), '{"old":true}')
+    writeFileSync(join(dir, 'package.json.bak-asm'), '{"old":true}')
+    writeFileSync(join(dir, 'cordis.patch.yml.rp-merged.bak'), '- stale: true')
+    // ...while a file that merely CONTAINS "bak" is ordinary config and
+    // must survive: over-filtering silently drops a user's real settings.
+    writeFileSync(join(dir, 'bakery.yml'), 'keep: me')
+    writeFileSync(join(dir, 'my.backup.yml'), 'keep: me too')
+
+    const paths = createProfileBackup('web').files.map(file => file.path)
+    expect(paths).toEqual(['bakery.yml', 'my.backup.yml', 'package.json'])
+  })
+
   it('rejects traversal paths without touching the profile', () => {
     const dir = profileDir('web')
     mkdirSync(dir, { recursive: true })


### PR DESCRIPTION
Two independent hardening fixes found while investigating the deferred reports. Neither closes its issue — both are noted as partial below.

## Uninstall skipped half its cleanup for a doubly-activated package — #213

```ts
hot = await hotUnmount(name)
if (!hot) hot = await themes.setEntryDisabled(name, true)
```

That short-circuit is right only while a package has **one** activation source. A package that is both hot-mounted *and* reachable through the bundle layer got the unmount and **not** the entry disable — and the surviving live entry is exactly the 404-on-refresh wedge the entry disable was added for in #37.

Both now run unconditionally, in **both** places that do this teardown (the uninstall route and the group/bulk remove path — the second had the same shape and would have been left behind). `setEntryDisabled` just scans entries by name and returns `false` when none match, so the extra call costs a lookup.

**This does not close #213.** There the removal was performed by Desktop's startup recovery — an external profile mutation — so the market's uninstall path never ran, and the failing artifact is a sibling transitive plugin whose bundle serves HTTP 200 with a matching hash. That points at the host loader's client graph, not the market's bookkeeping. Issue stays open.

## Backups carried the wreckage that made a profile need repairing — #205

The skip filter was `/\.bak-\d+$/` — only the numeric shape this codebase writes. Recovery and the host's own repair paths leave others: `package.json.bak-asm`, `cordis.patch.yml.rp-merged.bak`. Those were backed up verbatim and restored verbatim, so a cross-machine restore brought the leftovers back with the config.

Widened to `/\.bak\b/`. It covers every observed shape while leaving files that merely contain the letters alone — `bakery.yml` and `my.backup.yml` still back up, because over-filtering would silently drop a user's real settings, and a backup that quietly omits things is worse than one that carries junk.

**This is one of three independent problems in #205.** The `link:/Users/...` absolute-path half and the patch/manifest consistency half are untouched. Issue stays open.

## Test plan

- [x] `npm run check` clean
- [x] `npx vitest run tests/` — 670 passed
- [x] `npm run test:web` (real host) — 29 passed; the uninstall/remove paths this touches are covered there
- [x] Mutation-tested the `.bak` filter: restoring the old `/\.bak-\d+$/` is caught
- [x] Filter behaviour probed directly against all six filenames (three shapes that must be skipped, two that must survive, plus the original numeric case)