### PR TITLE
fix: install prebuilt registry tarballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ its own dsh: it may be older than the one `npm` would give you (#139).
 
 ## Speed
 
-Installs prefer npm tarballs over full-repo GitHub downloads whenever a plugin publishes to npm (registry-verified against the repo to prevent name squatting). Registry installs are typically seconds; GitHub-only plugins depend on your connection to GitHub.
+Installs prefer repo-verified npm packages, then author-supplied prebuilt GitHub Release tarballs, before falling back to full-repo GitHub source downloads. Prebuilt installs are typically seconds and do not need local build scripts; source-only plugins depend on your connection to GitHub.
 
 ## Security
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -51,7 +51,7 @@ dsh plugin --profile web add dshmarket
 
 ## 速度
 
-只要插件发布了 npm 包（registry 会校验其 repository 指回同一仓库,防冒名）,安装即走 npm tarball 而非整仓 GitHub 下载——通常秒级;仅 GitHub 分发的插件取决于你到 GitHub 的网络。
+安装依次优先使用经仓库验证的 npm 包、作者提供的 GitHub Release 预构建 tarball，最后才回退到整仓 GitHub 源码下载。预构建安装通常只需数秒且无需执行本地构建脚本；仅提供源码的插件仍取决于你到 GitHub 的网络。
 
 ## 安全
 

--- a/src/client/market-data.ts
+++ b/src/client/market-data.ts
@@ -15,6 +15,7 @@ export interface RegistryPlugin {
   owner: string
   url: string
   npm?: string
+  tarball?: string | null
   category: string
   description?: LocalizedText
   stars?: number

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -13,6 +13,7 @@ export interface RegistryPlugin {
   category: string
   description: Record<string, string>
   npm?: string | null
+  tarball?: string | null
   stars?: number | null
   /**
    * npm downloads in the last 30 days, when the entry has a published

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -13,6 +13,23 @@ function validSubpath(subpath: string): boolean {
 /** Registry tarball names must be plain npm package names, nothing fancier. */
 const NPM_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
 
+const TARBALL_HOSTS = new Set(['github.com', 'objects.githubusercontent.com', 'release-assets.githubusercontent.com'])
+
+/** A curated, prebuilt GitHub Release archive accepted as a pnpm target. */
+function releaseTarballTarget(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const target = value.trim()
+  let url: URL
+  try {
+    url = new URL(target)
+  } catch {
+    return null
+  }
+  if (url.protocol !== 'https:' || !TARBALL_HOSTS.has(url.hostname)) return null
+  if (url.hostname === 'github.com' && !url.pathname.includes('/releases/')) return null
+  return url.pathname.endsWith('.tgz') || url.pathname.endsWith('.tar.gz') ? target : null
+}
+
 /**
  * Parse a registry source url: a github repo, optionally with a
  * `/tree/<branch>/<subpath>` suffix (how the curated list links monorepo
@@ -112,16 +129,17 @@ export function gitAllowBuildsKey(name: string, spec: string): string | null {
 }
 
 /**
- * The pnpm install target for a registry entry. Registry tarballs beat
- * full-repo GitHub downloads: smaller, prebuilt, and CDN/mirror served. The
- * npm name comes from our curated registry, which only maps repo-verified
- * packages (name-squatting protection).
+ * The pnpm install target for a registry entry. Repo-verified npm packages
+ * win, followed by author-supplied prebuilt GitHub Release tarballs; both avoid
+ * full-repo downloads and local build scripts.
  * @returns the target spec, or null when the source url is unsupported.
  */
-export function installTargetFor(entry: { url: string; npm?: unknown }): string | null {
+export function installTargetFor(entry: { url: string; npm?: unknown; tarball?: unknown }): string | null {
   const source = parseSourceUrl(entry.url)
   if (source === null) return null
   if (typeof entry.npm === 'string' && NPM_NAME_RE.test(entry.npm)) return entry.npm
+  const tarball = releaseTarballTarget(entry.tarball)
+  if (tarball !== null) return tarball
   return source.subpath !== null
     ? `github:${source.repo}#path:/${source.subpath}`
     : `github:${source.repo}`

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -13,10 +13,24 @@ function validSubpath(subpath: string): boolean {
 /** Registry tarball names must be plain npm package names, nothing fancier. */
 const NPM_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
 
-const TARBALL_HOSTS = new Set(['github.com', 'objects.githubusercontent.com', 'release-assets.githubusercontent.com'])
-
-/** A curated, prebuilt GitHub Release archive accepted as a pnpm target. */
-function releaseTarballTarget(value: unknown): string | null {
+/**
+ * A curated, prebuilt GitHub Release archive accepted as a pnpm target —
+ * but only one belonging to `repo`, the entry's own `owner/name`.
+ *
+ * The binding is the whole point. `npm` gets the same treatment one branch
+ * up (repo-verified, "name-squatting protection"); without it here, an entry
+ * could name a trusted repo and install an archive from somewhere else:
+ *
+ *     url:     https://github.com/good/plugin
+ *     tarball: https://github.com/evil/repo/releases/download/v1/p.tgz
+ *
+ * That is also why the release CDNs (`objects.githubusercontent.com`,
+ * `release-assets.githubusercontent.com`) are not accepted: their paths
+ * carry no owner or repo, so there is nothing to bind the archive to and no
+ * way to tell whose release it is. All 70 entries carrying `tarball` today
+ * use github.com and match their own repo, so nothing real is turned away.
+ */
+function releaseTarballTarget(value: unknown, repo: string): string | null {
   if (typeof value !== 'string') return null
   const target = value.trim()
   let url: URL
@@ -25,9 +39,13 @@ function releaseTarballTarget(value: unknown): string | null {
   } catch {
     return null
   }
-  if (url.protocol !== 'https:' || !TARBALL_HOSTS.has(url.hostname)) return null
-  if (url.hostname === 'github.com' && !url.pathname.includes('/releases/')) return null
-  return url.pathname.endsWith('.tgz') || url.pathname.endsWith('.tar.gz') ? target : null
+  if (url.protocol !== 'https:' || url.hostname !== 'github.com') return null
+  if (!url.pathname.endsWith('.tgz') && !url.pathname.endsWith('.tar.gz')) return null
+  // /{owner}/{repo}/releases/... — the two leading segments must be the
+  // entry's own. GitHub treats them case-insensitively, so we do too.
+  const segments = url.pathname.split('/').filter(segment => segment !== '')
+  if (segments.length < 4 || segments[2] !== 'releases') return null
+  return `${segments[0]}/${segments[1]}`.toLowerCase() === repo.toLowerCase() ? target : null
 }
 
 /**
@@ -138,7 +156,7 @@ export function installTargetFor(entry: { url: string; npm?: unknown; tarball?: 
   const source = parseSourceUrl(entry.url)
   if (source === null) return null
   if (typeof entry.npm === 'string' && NPM_NAME_RE.test(entry.npm)) return entry.npm
-  const tarball = releaseTarballTarget(entry.tarball)
+  const tarball = releaseTarballTarget(entry.tarball, source.repo)
   if (tarball !== null) return tarball
   return source.subpath !== null
     ? `github:${source.repo}#path:/${source.subpath}`

--- a/tests/sources.spec.ts
+++ b/tests/sources.spec.ts
@@ -71,11 +71,9 @@ describe('installTargetFor', () => {
     expect(installTargetFor({ url: 'https://github.com/o/r', npm: 'dsh-loop', tarball })).toBe('dsh-loop')
     expect(installTargetFor({ url: 'https://github.com/o/r', npm: '@scope/pkg' })).toBe('@scope/pkg')
     expect(installTargetFor({ url: 'https://github.com/o/r', tarball })).toBe(tarball)
-    expect(installTargetFor({
-      url: 'https://github.com/o/r',
-      npm: 'evil;rm -rf',
-      tarball: 'https://release-assets.githubusercontent.com/github-production-release-asset/file.tar.gz',
-    })).toBe('https://release-assets.githubusercontent.com/github-production-release-asset/file.tar.gz')
+    // A malformed npm name is not a way past the tarball rules: it fails the
+    // name check, and the archive still has to be this repo's own.
+    expect(installTargetFor({ url: 'https://github.com/o/r', npm: 'evil;rm -rf', tarball })).toBe(tarball)
     expect(installTargetFor({ url: 'https://github.com/o/r/tree/main/packages/x' }))
       .toBe('github:o/r#path:/packages/x')
     expect(installTargetFor({ url: 'https://github.com/o/r' })).toBe('github:o/r')
@@ -92,6 +90,31 @@ describe('installTargetFor', () => {
     ]) {
       expect(installTargetFor({ url: 'https://github.com/o/r', tarball: rejected })).toBe('github:o/r')
     }
+  })
+
+  /** The npm branch is repo-verified against name squatting; the tarball
+   * branch has to be too, or a trusted-looking entry installs a stranger's
+   * archive. Each of these is a real archive at a real GitHub Release — the
+   * only thing wrong with it is whose. */
+  it('refuses a release archive that is not the entry repo own', () => {
+    for (const foreign of [
+      'https://github.com/evil/repo/releases/download/v1/p.tgz',
+      'https://github.com/o/other/releases/download/v1/p.tgz',
+      'https://github.com/evil/r/releases/download/v1/p.tgz',
+      // No owner or repo anywhere in the path, so nothing to bind to.
+      'https://objects.githubusercontent.com/whatever/x.tgz',
+      'https://release-assets.githubusercontent.com/github-production-release-asset/file.tar.gz',
+    ]) {
+      expect(installTargetFor({ url: 'https://github.com/o/r', tarball: foreign })).toBe('github:o/r')
+    }
+  })
+
+  it('accepts the entry own release archive whatever the case, as GitHub does', () => {
+    const mixed = 'https://github.com/O/R/releases/download/v1/p.tgz'
+    expect(installTargetFor({ url: 'https://github.com/o/r', tarball: mixed })).toBe(mixed)
+    // A monorepo entry still binds on the repo, not the subpath.
+    const own = 'https://github.com/o/r/releases/latest/download/x.tgz'
+    expect(installTargetFor({ url: 'https://github.com/o/r/tree/main/packages/x', tarball: own })).toBe(own)
   })
 })
 

--- a/tests/sources.spec.ts
+++ b/tests/sources.spec.ts
@@ -65,15 +65,33 @@ describe('local GitHub source identity (#141)', () => {
 })
 
 describe('installTargetFor', () => {
-  it('prefers curated npm, targets subpaths via #path:, falls back to github, refuses the rest', () => {
-    expect(installTargetFor({ url: 'https://github.com/o/r', npm: 'dsh-loop' })).toBe('dsh-loop')
+  const tarball = 'https://github.com/o/r/releases/download/v1.2.3/dsh-loop-1.2.3.tgz'
+
+  it('prefers curated npm, then a prebuilt release tarball, before github source', () => {
+    expect(installTargetFor({ url: 'https://github.com/o/r', npm: 'dsh-loop', tarball })).toBe('dsh-loop')
     expect(installTargetFor({ url: 'https://github.com/o/r', npm: '@scope/pkg' })).toBe('@scope/pkg')
-    // A malformed npm name never reaches pnpm — fall back to the repo.
-    expect(installTargetFor({ url: 'https://github.com/o/r', npm: 'evil;rm -rf' })).toBe('github:o/r')
+    expect(installTargetFor({ url: 'https://github.com/o/r', tarball })).toBe(tarball)
+    expect(installTargetFor({
+      url: 'https://github.com/o/r',
+      npm: 'evil;rm -rf',
+      tarball: 'https://release-assets.githubusercontent.com/github-production-release-asset/file.tar.gz',
+    })).toBe('https://release-assets.githubusercontent.com/github-production-release-asset/file.tar.gz')
     expect(installTargetFor({ url: 'https://github.com/o/r/tree/main/packages/x' }))
       .toBe('github:o/r#path:/packages/x')
     expect(installTargetFor({ url: 'https://github.com/o/r' })).toBe('github:o/r')
-    expect(installTargetFor({ url: 'https://gitlab.com/o/r' })).toBeNull()
+    expect(installTargetFor({ url: 'https://gitlab.com/o/r', tarball })).toBeNull()
+  })
+
+  it('refuses non-release, foreign, insecure, and malformed tarball targets', () => {
+    for (const rejected of [
+      'https://github.com/o/r/archive/main.tar.gz',
+      'https://example.com/dsh-loop.tgz',
+      'http://github.com/o/r/releases/download/v1/dsh-loop.tgz',
+      'https://github.com/o/r/releases/download/v1/dsh-loop.zip',
+      '--config.ignore-scripts=false',
+    ]) {
+      expect(installTargetFor({ url: 'https://github.com/o/r', tarball: rejected })).toBe('github:o/r')
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

- honor the curated `tarball` field after a repo-verified npm package and before GitHub source fallback
- accept only HTTPS GitHub Release hosts with `.tgz` or `.tar.gz` archives
- document the prebuilt install path and cover its priority and rejection cases

## Why

`awesome-dsh-plugin` already exposes author-supplied prebuilt Release tarballs. dsh-market ignored that field, so GitHub-only packages such as `dsh-inline-comments` fell back to a source checkout and required pnpm build approval even when a ready-to-install archive existed.

## Checks

- `npm ci` (includes production build)
- `npm run typecheck`
- `npm test -- tests/sources.spec.ts`