### PR TITLE
fix: reach the catalog through a proxy that lives only in npm config

### DIFF
--- a/src/net.ts
+++ b/src/net.ts
@@ -25,11 +25,16 @@ import { EnvHttpProxyAgent, fetch as undiciFetch } from 'undici'
 /**
  * The proxy this process would use for the catalog, if any.
  *
- * This mirrors `EnvHttpProxyAgent`'s own resolution deliberately, rather
- * than picking the order that reads best, because the same answer does two
- * jobs: it decides whether to route through undici at all, and it is what
- * the failure message CLAIMS was tried. A helper that named a proxy undici
- * would not have used would put a false statement in every bug report.
+ * The standard variables mirror `EnvHttpProxyAgent`'s own resolution
+ * deliberately, rather than picking the order that reads best, because the
+ * same answer does two jobs: it decides whether to route through undici at
+ * all, and it is what the failure message CLAIMS was tried. A helper that
+ * named a proxy undici would not have used would put a false statement in
+ * every bug report. `npm_config_*` is an additional source on top of that:
+ * npm holds its proxy in its own config namespace (a machine set up with
+ * `npm config set proxy` has the proxy in `npm_config_proxy` and nowhere
+ * else), and undici does not read it — so it is resolved here and handed to
+ * the agent explicitly in `marketFetch`.
  *
  * Three details are undici's, not ours (env-http-proxy-agent.js):
  *   - lowercase wins over uppercase (`https_proxy ?? HTTPS_PROXY`)
@@ -41,10 +46,27 @@ import { EnvHttpProxyAgent, fetch as undiciFetch } from 'undici'
  * whitespace-only value to `new URL()` and throw out of the constructor.
  */
 export function configuredProxy(): string | null {
+  const { http, https } = proxyFromEnv()
+  return https ?? http
+}
+
+/**
+ * Proxy URLs resolved from the process environment, standard variables
+ * first and npm's own config (`npm_config_https_proxy` / `npm_config_proxy`)
+ * as the fallback. npm's config is the second source, not a preference: a
+ * standard variable always wins over npm's, and npm's https proxy falls
+ * back to npm's http proxy the same way undici's does.
+ */
+function proxyFromEnv(): { http: string | null; https: string | null } {
   const pick = (raw: string | undefined): string | null =>
     raw === undefined || raw.trim() === '' ? null : raw.trim()
-  const https = pick(process.env.https_proxy ?? process.env.HTTPS_PROXY)
-  return https ?? pick(process.env.http_proxy ?? process.env.HTTP_PROXY)
+  const https =
+    pick(process.env.https_proxy ?? process.env.HTTPS_PROXY) ??
+    pick(process.env.npm_config_https_proxy)
+  const http =
+    pick(process.env.http_proxy ?? process.env.HTTP_PROXY) ??
+    pick(process.env.npm_config_proxy)
+  return { http, https }
 }
 
 /**
@@ -65,7 +87,15 @@ export async function marketFetch(
   url: string,
   init?: { signal?: AbortSignal; headers?: Record<string, string> },
 ): Promise<Response> {
-  if (configuredProxy() === null) return await fetch(url, init)
-  agent ??= new EnvHttpProxyAgent()
+  const { http, https } = proxyFromEnv()
+  if (http === null && https === null) return await fetch(url, init)
+  // Pass the resolved proxies explicitly. EnvHttpProxyAgent itself reads
+  // only http(s)_proxy out of the environment, so a proxy that lives in
+  // npm_config_* must be handed over directly — otherwise the agent would
+  // silently go direct while configuredProxy() claims a proxy was used.
+  agent ??= new EnvHttpProxyAgent({
+    httpProxy: http ?? undefined,
+    httpsProxy: https ?? undefined,
+  })
   return await undiciFetch(url, { ...init, dispatcher: agent }) as unknown as Response
 }

--- a/tests/registry.spec.ts
+++ b/tests/registry.spec.ts
@@ -14,7 +14,27 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { describeFetchFailure, forgetCatalog, loadRegistry } from '../src/registry.ts'
-import { configuredProxy } from '../src/net.ts'
+import { configuredProxy, marketFetch } from '../src/net.ts'
+
+/**
+ * undici stands in for the real outbound path. `marketFetch` routes through
+ * EnvHttpProxyAgent only when a proxy is configured, and the assertion that
+ * matters is exactly which proxy URLs the agent was built with —
+ * npm_config_* is invisible to EnvHttpProxyAgent, so the explicit handoff
+ * is what makes the npm fallback real instead of a name the failure message
+ * claims was tried.
+ */
+const undici = vi.hoisted(() => ({
+  fetch: vi.fn(async () => new Response('ok', { status: 200 })),
+  EnvHttpProxyAgent: vi.fn(function (this: unknown, opts?: unknown) {
+    return { opts }
+  }),
+}))
+
+vi.mock('undici', () => ({
+  fetch: undici.fetch,
+  EnvHttpProxyAgent: undici.EnvHttpProxyAgent,
+}))
 
 const CATALOG = {
   updated: '2026-08-18',
@@ -26,8 +46,8 @@ const CATALOG = {
   }],
 }
 
-/** Every proxy variable, so one test's environment cannot leak into another. */
-const PROXY_VARS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy'] as const
+/** Every proxy variable — standard and npm's own config — so one test's environment cannot leak into another. */
+const PROXY_VARS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'npm_config_https_proxy', 'npm_config_proxy', 'npm_config_noproxy'] as const
 let savedProxy: Record<string, string | undefined> = {}
 
 beforeEach(() => {
@@ -292,5 +312,66 @@ describe('configuredProxy', () => {
   it('trims a stray newline, which a shell heredoc leaves behind', () => {
     process.env.HTTPS_PROXY = 'http://127.0.0.1:7897\n'
     expect(configuredProxy()).toBe('http://127.0.0.1:7897')
+  })
+
+  it('uses npm_config_https_proxy when the standard variables are not set', () => {
+    // The machine that reported this: its proxy was configured with
+    // `npm config set proxy` (common on Windows), so it exists as
+    // npm_config_* and nowhere else. Every npm-based tool works; the
+    // catalog fetch still tried the direct route and timed out.
+    process.env.npm_config_https_proxy = 'http://npm:1'
+    expect(configuredProxy()).toBe('http://npm:1')
+  })
+
+  it('falls back to npm_config_proxy for the https catalog, as undici does', () => {
+    // npm's https-proxy falls back to its plain proxy value; report the
+    // proxy that is actually in use rather than "no proxy" while one is
+    // plainly configured.
+    process.env.npm_config_proxy = 'http://npm:2'
+    expect(configuredProxy()).toBe('http://npm:2')
+  })
+
+  it('prefers a standard proxy over npm config', () => {
+    // npm_config_* is a fallback source, never an override: a process
+    // whose environment carries http_proxy has decided, and the market
+    // must not second-guess it with the machine's npm config.
+    process.env.HTTPS_PROXY = 'http://std:1'
+    process.env.npm_config_https_proxy = 'http://npm:1'
+    expect(configuredProxy()).toBe('http://std:1')
+  })
+
+  it('treats empty npm proxy values as unset, like the standard ones', () => {
+    process.env.npm_config_https_proxy = ''
+    process.env.npm_config_proxy = ''
+    expect(configuredProxy()).toBeNull()
+  })
+})
+
+describe('marketFetch', () => {
+  beforeEach(() => {
+    undici.fetch.mockClear()
+    undici.EnvHttpProxyAgent.mockClear()
+  })
+
+  it('hands npm-config proxies to the agent explicitly — EnvHttpProxyAgent cannot see them', async () => {
+    // The trap this guards: configuredProxy() alone would make the failure
+    // message claim a proxy was tried while `new EnvHttpProxyAgent()` with
+    // no arguments still reads only http(s)_proxy and goes direct.
+    process.env.npm_config_https_proxy = 'http://npm:1'
+    await marketFetch('https://catalog.example/plugins.json')
+    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledWith({
+      httpProxy: undefined,
+      httpsProxy: 'http://npm:1',
+    })
+    expect(undici.fetch).toHaveBeenCalledWith(
+      'https://catalog.example/plugins.json',
+      expect.objectContaining({ dispatcher: expect.any(Object) }),
+    )
+  })
+
+  it('stays on the global fetch when there is no proxy anywhere', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })))
+    await marketFetch('https://catalog.example/plugins.json')
+    expect(undici.fetch).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## The catalog failed on a machine whose proxy lives only in npm config

**Symptom**: the market shows `fetch failed (21s, 2 attempts)` although every npm-based tool on the machine works. The proxy was configured with `npm config set proxy` (common on Windows): it lives in `npm_config_proxy` / `npm_config_https_proxy` (and `.npmrc`), but not in `HTTP_PROXY` / `HTTPS_PROXY`. The catalog fetch therefore took the direct route and timed out at the same GitHub Pages IPs that prompted #187.

**Cause**: `configuredProxy()` resolved only the standard `http(s)_proxy` variables, so on such a machine it returned `null` and `marketFetch` fell back to Node's global `fetch` — exactly the direct path `EnvHttpProxyAgent` was introduced to avoid.

**Fix** (`src/net.ts`):
- `proxyFromEnv()` resolves the standard variables first, then falls back to `npm_config_https_proxy` / `npm_config_proxy` (same precedence as undici: lowercase wins, https falls back to http, blank is unset; a standard variable always beats npm's config).
- `marketFetch` builds `EnvHttpProxyAgent` with the resolved proxies passed explicitly (`httpProxy` / `httpsProxy`). `EnvHttpProxyAgent` reads only `http(s)_proxy` out of the environment, so without the explicit handoff the npm fallback would be a false claim in the failure message while the agent still went direct.

**Tests** (`tests/registry.spec.ts`), red before green:
- `configuredProxy` npm-fallback cases (https, http fallback, standard precedence, empty-is-unset). The per-test env cleanup now covers `npm_config_*` too, so the suite stays deterministic when the developer's own `.npmrc` carries a proxy.
- `marketFetch` (undici mocked) pins that npm-sourced proxies reach the agent explicitly, and that the global-fetch path is kept when no proxy is configured anywhere.

With the source fix stashed the new tests fail — the npm fallback returns `null` and the handoff test reproduces the direct `ENOTFOUND`.

Verified end-to-end on the reporting machine: `GET /dsh-market/registry` went from 502 `fetch failed (21s, 2 attempts)` to 200 (full catalog) with the equivalent local change.

Known non-goal: `npm_config_noproxy` is deliberately not consulted — `no_proxy` behavior stays exactly as `EnvHttpProxyAgent` defines it.

Local checks: `tsc -p tsconfig.tests.json --noEmit` / `tsc -p tsconfig.json --noEmit` clean; `tests/registry.spec.ts` 30/30. The full unit suite shows 15 failures in `dsh-cli`/`flows`/`updates` specs that are identical on a clean checkout (live npm/GitHub version assertions, unrelated to this change).