### PR TITLE
fix: stop flagging our own optional peer, and carry the proxy as far as git

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-settings": "^0.1.0-rc.7"
+    "@deepseek-ai/dsh-settings": "^0.1.0-rc.7 || ^0.1.1-rc.2"
   },
   "dsh": {
     "bundle": {

--- a/src/check.ts
+++ b/src/check.ts
@@ -112,6 +112,13 @@ export interface PeerMismatch {
   resolved: string | null
   /** False = confirmed incompatible; null = could not be evaluated. */
   satisfied: boolean | null
+  /**
+   * The declaring plugin marked this peer `optional` in
+   * `peerDependenciesMeta`. Carried so the summary can hold the same line
+   * `classifyPeer` already does: an optional peer that does not match is
+   * the plugin saying "I work without this", not a broken install (#275).
+   */
+  optional?: boolean
 }
 
 /**
@@ -820,7 +827,10 @@ export function analyzeProfile(profileDirectory: string, options: CheckOptions =
   const peerMismatches: PeerMismatch[] = []
   const seenDeps = new Set<string>()
   for (const plugin of installedPackageNames(profileDirectory)) {
-    let pkg: { peerDependencies?: Record<string, string> }
+    let pkg: {
+      peerDependencies?: Record<string, string>
+      peerDependenciesMeta?: Record<string, { optional?: unknown }>
+    }
     try {
       pkg = JSON.parse(readFileSync(join(profileDirectory, 'node_modules', plugin, 'package.json'), 'utf8')) as typeof pkg
     } catch {
@@ -844,9 +854,11 @@ export function analyzeProfile(profileDirectory: string, options: CheckOptions =
       // plugin-to-plugin peer mismatches break runtime registration just as
       // hard (issue #98 optimization round).
       const satisfied = resolved !== null ? satisfiesRange(resolved, spec) : null
+      const optional = pkg.peerDependenciesMeta?.[name]?.optional === true
       peerMismatches.push({
         plugin, name, range: spec, resolved,
         satisfied: satisfied === null ? null : satisfied,
+        ...(optional ? { optional: true } : {}),
       })
     }
   }
@@ -880,7 +892,13 @@ export function analyzeProfile(profileDirectory: string, options: CheckOptions =
     // the peer is supplied by the host, an optional accelerator, or simply
     // absent) stay in the peerMismatches list for the UI but are not noise
     // in the summary (issue #98 optimization round).
-    if (mismatch.satisfied === false) {
+    // ...and an OPTIONAL peer is not a confirmed incompatibility either.
+    // classifyPeer already downgrades those to non-risk (compatibility.ts),
+    // and the summary disagreeing with it meant a plugin that declares "I
+    // work without this" still produced a scary warning line — including
+    // for the market's own optional peer, on every profile that installs us
+    // (#275 by @tjxjxjx).
+    if (mismatch.satisfied === false && mismatch.optional !== true) {
       warnings.push(`${mismatch.plugin} peer range ${mismatch.name}@${mismatch.range} does not match resolved ${String(mismatch.resolved)}`)
     }
   }

--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -96,14 +96,37 @@ export function proxyEnvForPnpm(env: NodeJS.ProcessEnv = process.env): NodeJS.Pr
     return null
   }
   const out: NodeJS.ProcessEnv = {}
-  // Same precedence as undici's EnvHttpProxyAgent (lowercase over uppercase,
-  // https falling back to http), so pnpm goes where the catalog fetch went.
-  const https = pick('https_proxy', 'HTTPS_PROXY') ?? pick('http_proxy', 'HTTP_PROXY')
-  const http = pick('http_proxy', 'HTTP_PROXY') ?? https
-  if (https !== null && !has('npm_config_https_proxy')) out.npm_config_https_proxy = https
-  if (http !== null && !has('npm_config_proxy')) out.npm_config_proxy = http
-  const noProxy = pick('no_proxy', 'NO_PROXY')
-  if (noProxy !== null && !has('npm_config_noproxy')) out.npm_config_noproxy = noProxy
+  // Three consumers, three vocabularies, one proxy. The market's own fetch
+  // reads the standard vars (and, since #263, npm config too); pnpm reads
+  // ONLY npm config; and `git` — which pnpm shells out to for every
+  // git-hosted plugin — reads only the standard vars and never npm config.
+  // Translating one direction left the third out: registry installs went
+  // through the proxy while git installs went direct and failed with
+  // "Failed to connect to github.com:443" (#274 by @rucsocial).
+  //
+  // Same precedence as undici's EnvHttpProxyAgent (lowercase over
+  // uppercase, https falling back to http).
+  const stdHttps = pick('https_proxy', 'HTTPS_PROXY') ?? pick('http_proxy', 'HTTP_PROXY')
+  const stdHttp = pick('http_proxy', 'HTTP_PROXY') ?? stdHttps
+  if (stdHttps !== null && !has('npm_config_https_proxy')) out.npm_config_https_proxy = stdHttps
+  if (stdHttp !== null && !has('npm_config_proxy')) out.npm_config_proxy = stdHttp
+  const stdNoProxy = pick('no_proxy', 'NO_PROXY')
+  if (stdNoProxy !== null && !has('npm_config_noproxy')) out.npm_config_noproxy = stdNoProxy
+
+  // The other direction, and ONLY when the standard vocabulary is empty.
+  // A proxy known solely to npm config is the case that stranded git; if
+  // the caller has said anything in the standard vars, that is their
+  // statement about what git should do and copying npm's answer over it
+  // would invent a setting they did not make — notably an HTTP_PROXY for
+  // someone who deliberately proxied https only.
+  if (stdHttps === null && stdHttp === null) {
+    const npmHttps = pick('npm_config_https_proxy') ?? pick('npm_config_proxy')
+    const npmHttp = pick('npm_config_proxy') ?? npmHttps
+    if (npmHttps !== null) out.HTTPS_PROXY = npmHttps
+    if (npmHttp !== null) out.HTTP_PROXY = npmHttp
+    const npmNoProxy = pick('npm_config_noproxy')
+    if (npmNoProxy !== null && stdNoProxy === null) out.NO_PROXY = npmNoProxy
+  }
   return out
 }
 

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -376,6 +376,31 @@ describe('peer range mismatch', () => {
     expect(mismatch?.satisfied).toBe(false)
     expect(report.summary.warnings.some(w => w.includes('does not match'))).toBe(true)
   })
+
+  it('does not WARN about an optional peer that does not match (#275)', () => {
+    // `peerDependenciesMeta.optional` is the plugin saying "I work without
+    // this". classifyPeer already treats those as non-risk; the summary
+    // disagreeing meant a scary warning line for a plugin that is fine —
+    // including the market's own optional peer, on every profile that
+    // installs it.
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writePackage(dir, 'plugin-opt', {
+      name: 'plugin-opt',
+      version: '1.0.0',
+      peerDependencies: { '@deepseek-ai/dsh-llm': '^0.1.0' },
+      peerDependenciesMeta: { '@deepseek-ai/dsh-llm': { optional: true } },
+    })
+    writePackage(dir, '@deepseek-ai/dsh-llm', { name: '@deepseek-ai/dsh-llm', version: '0.2.0' })
+
+    const report = analyzeProfile(dir)
+    const mismatch = report.peerMismatches.find(m => m.plugin === 'plugin-opt')
+    // Still REPORTED — the diagnostics page shows it, and classifyPeer
+    // decides what it means. Only the summary warning is suppressed.
+    expect(mismatch?.satisfied).toBe(false)
+    expect(mismatch?.optional).toBe(true)
+    expect(report.summary.warnings.some(w => w.includes('plugin-opt'))).toBe(false)
+  })
 })
 
 describe('pnpm-lock.yaml multi-version core packages', () => {

--- a/tests/dsh-cli.spec.ts
+++ b/tests/dsh-cli.spec.ts
@@ -63,15 +63,20 @@ describe('nodeExecutable (Android linker64 execPath)', () => {
   })
 })
 
-describe('proxy env translated for pnpm (#148/#161/#188/#232)', () => {
-  // The market's own catalog fetches go through undici's EnvHttpProxyAgent,
-  // which reads HTTPS_PROXY/http_proxy. pnpm reads NONE of those — it reads
-  // npm config — so on a proxied network the catalog loaded and every
-  // install then hung. These assert the translation, and its precedence.
-  it('translates https_proxy/http_proxy into the npm_config_* names pnpm reads', () => {
+describe('proxy env translated for the pnpm subprocess (#148/#161/#188/#232/#274)', () => {
+  // Three consumers, three vocabularies. The market's own fetch reads the
+  // standard vars; pnpm reads ONLY npm config; `git` — which pnpm shells
+  // out to for every git-hosted plugin — reads only the standard vars.
+  it('fills the npm_config_* names pnpm reads AND the standard names git reads', () => {
     expect(proxyEnvForPnpm({ HTTPS_PROXY: 'http://proxy:8080' })).toEqual({
       npm_config_https_proxy: 'http://proxy:8080',
       npm_config_proxy: 'http://proxy:8080',
+    })
+    // A proxy known ONLY to npm config is the case that stranded git:
+    // registry installs went through it, git installs went direct (#274).
+    expect(proxyEnvForPnpm({ npm_config_proxy: 'http://p:1' })).toEqual({
+      HTTPS_PROXY: 'http://p:1',
+      HTTP_PROXY: 'http://p:1',
     })
   })
 
@@ -91,22 +96,30 @@ describe('proxy env translated for pnpm (#148/#161/#188/#232)', () => {
     })
   })
 
-  it('forwards NO_PROXY, so a host excluding its own registry mirror keeps excluding it', () => {
+  it('forwards NO_PROXY both ways, so an excluded mirror stays excluded for git too', () => {
     expect(proxyEnvForPnpm({ HTTPS_PROXY: 'http://p:1', NO_PROXY: 'registry.local,10.0.0.0/8' }))
       .toEqual({
         npm_config_https_proxy: 'http://p:1',
         npm_config_proxy: 'http://p:1',
         npm_config_noproxy: 'registry.local,10.0.0.0/8',
       })
+    expect(proxyEnvForPnpm({ npm_config_proxy: 'http://p:1', npm_config_noproxy: 'registry.local' }))
+      .toEqual({ HTTPS_PROXY: 'http://p:1', HTTP_PROXY: 'http://p:1', NO_PROXY: 'registry.local' })
   })
 
-  it('never overrides an npm_config_* the caller already set, case-insensitively (Windows env keys)', () => {
+  it('never overrides a value the caller already set, case-insensitively (Windows env keys)', () => {
     // The more specific statement of intent wins — including when Windows
     // hands the key back in a different case than we would have written.
     expect(proxyEnvForPnpm({ HTTPS_PROXY: 'http://env:1', npm_config_https_proxy: 'http://explicit:2' }))
       .toEqual({ npm_config_proxy: 'http://env:1' })
     expect(proxyEnvForPnpm({ HTTPS_PROXY: 'http://env:1', NPM_CONFIG_HTTPS_PROXY: 'http://explicit:2' }))
       .toEqual({ npm_config_proxy: 'http://env:1' })
+    // ...and the reverse direction never fires at all when the standard
+    // vocabulary says anything: copying npm's answer over it would invent a
+    // setting the caller did not make (an HTTP_PROXY for someone who
+    // deliberately proxied https only).
+    expect(proxyEnvForPnpm({ npm_config_proxy: 'http://npm:1', HTTPS_PROXY: 'http://std:2' }))
+      .toEqual({ npm_config_https_proxy: 'http://std:2' })
   })
 
   it('adds nothing when no proxy is configured, or when the value is blank', () => {


### PR DESCRIPTION
Closes #275. Closes the third of #274's three problems (the other two were already addressed in 1.17.1 — see the issue comment).

## Our own diagnostic warned about our own package — #275

The market declares `@deepseek-ai/dsh-settings: ^0.1.0-rc.7`, and DSH now ships `0.1.1-rc.2`. npm's prerelease rule — which this codebase implements itself in `satisfiesRange` — admits a prerelease only when a comparator pins the same `major.minor.patch`, so `0.1.1-rc.2` genuinely falls outside it. **The reporter's semver analysis is correct and our own checker agrees with them.**

The range widens to `^0.1.0-rc.7 || ^0.1.1-rc.2`, verified against our own `satisfiesRange` to still admit `0.1.0-rc.7` and `0.1.0-rc.9`. **Only the advertised peer range moves** — the devDependency stays pinned, so local builds resolve one concrete version and the lockfile is untouched.

The second half is why it was loud at all: the summary warned on *any* unsatisfied peer without consulting `peerDependenciesMeta.optional`, while `classifyPeer` has always downgraded optional peers to non-risk. **The two now agree.** An optional peer is the plugin saying "I work without this" — it's still reported for the diagnostics page, it just no longer produces a warning line. That also silences the same false alarm for every other plugin with optional peers (which #267 noticed independently).

## The proxy now reaches git — #274 problem 3

Three consumers, three vocabularies:

| consumer | reads |
|---|---|
| the market's own fetch | standard vars, **and** npm config since #263 |
| pnpm | **only** npm config |
| `git` (pnpm shells out to it for every git-hosted plugin) | **only** standard vars |

Translating one direction left the third out, so a proxy known only to npm config sent registry installs through it while git went direct and failed with `Failed to connect to github.com:443`.

**The reverse fill is deliberately narrow: it fires only when the standard vocabulary is empty.** A first attempt filled it whenever a value could be derived, which handed an `HTTP_PROXY` to someone who had deliberately proxied https only — inventing a setting they never made. Caught by the existing tests asserting exact object equality.

## Test plan

- [x] `npm run check` clean
- [x] `npx vitest run tests/` — 707 passed
- [x] `npm run test:web` (real host) — 29 passed
- [x] Proposed peer range verified against our own `satisfiesRange` for four versions before writing it
- [x] New test: an optional peer that doesn't match is still *reported* but no longer *warned* about
- [x] Proxy tests rewritten for the three-way contract, including the "npm config only" case and the "don't invent settings" case
- [x] Mutation-tested both: restoring the unconditional summary warning, and letting the reverse proxy fill fire unconditionally, are each caught