### PR TITLE
fix: support dotted, Unicode, and spaced profile names

### DIFF
--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -15,7 +15,7 @@ import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { logEvent } from './log.ts'
 import { createProgressTracker, type ProgressPhase } from './ndjson.ts'
 import { pluginArgsFor } from './pnpm-compat.ts'
-import { profileDir } from './profile.ts'
+import { isDshProfileName, profileDir } from './profile.ts'
 import { activeRegion, DEFAULT_NPM_REGISTRY, routesFor, type Region } from './regions.ts'
 
 // 15 min default (slow networks + git installs), overridable for CI/tests.
@@ -186,6 +186,18 @@ export function quoteCmdArg(arg: string): string {
  */
 export function cmdCommandLine(argv: readonly string[]): string {
   return argv.map(quoteCmdArg).join(' ')
+}
+
+/**
+ * Whether a profile name can cross the rare Windows `dsh.cmd` fallback.
+ *
+ * cmd.exe expands percent-delimited environment variables even inside a
+ * quoted argument. Keep that fallback to names made only of letters, marks,
+ * numbers, spaces, dots, underscores, and hyphens. The normal direct-Node
+ * launcher remains argv-safe and accepts every DSH-valid profile name.
+ */
+export function isCmdSafeProfileName(profile: string): boolean {
+  return isDshProfileName(profile) && /^[\p{L}\p{M}\p{N}._ -]+$/u.test(profile)
 }
 
 /** cmd.exe resolved once; the Windows shim path only. */
@@ -611,6 +623,11 @@ function makeProgressFeeder(tracker: ReturnType<typeof createProgressTracker>): 
 /** Run one `dsh plugin --profile <p> …` command with timeout and progress tracking. */
 export function runDshPlugin(profile: string, pluginArgs: string[]): Promise<InstallResult> {
   const { file, args, cwd, viaShell } = dshArgv()
+  if (viaShell && !isCmdSafeProfileName(profile)) {
+    const error = `dsh-market: profile name ${JSON.stringify(profile)} cannot cross the Windows cmd.exe fallback safely; relaunch DSH through its Node entry point, or use a profile name containing only letters, numbers, spaces, dots, underscores, and hyphens`
+    logEvent('error', 'install', error)
+    return Promise.resolve({ exitCode: 1, timedOut: false, stdout: '', stderr: error, cancelled: false })
+  }
   const prepared = preparePluginArgs(profileDir(profile), pluginArgs)
   if ('error' in prepared) {
     logEvent('error', 'install', prepared.error)

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -10,12 +10,31 @@ import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { githubRemoteIdentities, githubRepoIdentities } from './sources.ts'
 
 /**
+ * Whether a profile name follows DSH's own directory-name contract.
+ *
+ * Keep this aligned with `@deepseek-ai/dsh-app-boot`'s
+ * `resolveProfileDir`: dots, spaces, and Unicode are ordinary name
+ * characters; only empty, traversal-shaped, launcher-owned, or
+ * separator-bearing names are refused.
+ */
+export function isDshProfileName(profile: string): boolean {
+  return profile !== ''
+    && profile !== '.'
+    && profile !== '..'
+    && profile !== 'node_modules'
+    && !profile.includes('/')
+    && !profile.includes('\\')
+    && !profile.includes('\0')
+}
+
+/**
  * Resolve a profile name to its directory under DSH_HOME (default ~/.dsh).
  * An explicit directory is used by hosts, such as DSH Desktop, that own the
  * active profile location rather than deriving it from process environment.
  */
 export function profileDir(profile: string, explicitDir?: string): string {
   if (explicitDir !== undefined) return explicitDir
+  if (!isDshProfileName(profile)) throw new Error(`dsh-market: invalid profile name ${JSON.stringify(profile)}`)
   const home = process.env.DSH_HOME ?? join(homedir(), '.dsh')
   return join(home, 'profiles', profile)
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -23,7 +23,7 @@ import {
   BOOT_ID, cancelActive, probePnpm, progress, provisionPnpm, runDshPlugin,
   type PluginCommandRuntime,
 } from './dsh-cli.ts'
-import { addProfileBundle, hasLoadableEntry, INBOX_BUNDLES, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readManifestDeps, readProfileBundles, removeProfileBundle, restoreManifestDeps, setAllowBuilds } from './profile.ts'
+import { addProfileBundle, hasLoadableEntry, INBOX_BUNDLES, isDshProfileName, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readManifestDeps, readProfileBundles, removeProfileBundle, restoreManifestDeps, setAllowBuilds } from './profile.ts'
 import { assessProfile, introducedDuplicateNames, introducedRisks, type CompatibilityRisk } from './compatibility.ts'
 import { runningAgentIds, type AgentsLookup } from './agents.ts'
 import { analyzeProfile, type DuplicateName } from './check.ts'
@@ -83,8 +83,6 @@ export interface MarketConfig {
   /** Which mirrors every outbound request uses; undefined until decided. */
   region?: Region
 }
-
-const PROFILE_RE = /^[A-Za-z0-9_-]+$/
 
 /**
  * The market's own version, read once from its installed package.json.
@@ -151,17 +149,17 @@ export function mountMarketRoutes(
   commandRuntime?: PluginCommandRuntime,
   agentsLookup?: AgentsLookup,
 ): () => void {
-  // Ordinary DSH profile names cross the CLI boundary and keep the legacy
-  // allowlist. A host-authoritative explicit directory (DSH Desktop) may
-  // legitimately pair with a Unicode or spaced display/profile name.
-  if (config.profileDirectory === undefined && !PROFILE_RE.test(config.profile)) {
+  // An ordinary profile must resolve under DSH_HOME by the same rules as the
+  // DSH CLI. A host-authoritative explicit directory (DSH Desktop) does not
+  // derive a path from this display/profile name.
+  if (config.profileDirectory === undefined && !isDshProfileName(config.profile)) {
     // Loud on the way out. This throw happens inside a cordis effect, which
     // swallows it: the routes silently never mount and EVERY /dsh-market/*
     // request answers 404 with nothing anywhere saying why — the market
     // simply looks broken (#260 by @realguan). The log line is the only
     // thing that turns that into something diagnosable, so it is written
     // before the throw rather than left to a handler that never runs.
-    const message = `dsh-market: profile name ${JSON.stringify(config.profile)} contains characters outside [A-Za-z0-9_-], so the market's routes were not mounted and every /dsh-market/* request will answer 404. Rename the profile, or pass an explicit profile directory.`
+    const message = `dsh-market: invalid profile name ${JSON.stringify(config.profile)}; the market's routes were not mounted and every /dsh-market/* request will answer 404. Use the same non-empty, non-traversal profile name accepted by DSH, or pass an explicit profile directory.`
     host.logger?.warn(`[dsh-market] ${message}`)
     logEvent('error', 'mount', message)
     throw new Error(message)

--- a/tests/dsh-cli.spec.ts
+++ b/tests/dsh-cli.spec.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
-import { cmdCommandLine, nodeExecutable, proxyEnvForPnpm, quoteCmdArg, TARGET_RE } from '../src/dsh-cli.ts'
+import { cmdCommandLine, isCmdSafeProfileName, nodeExecutable, proxyEnvForPnpm, quoteCmdArg, TARGET_RE } from '../src/dsh-cli.ts'
 import { routesFor } from '../src/regions.ts'
 
 describe('cmd.exe command line building (DEP0190 shim)', () => {
@@ -25,6 +25,17 @@ describe('cmd.exe command line building (DEP0190 shim)', () => {
     expect(cmdCommandLine(['dsh', 'plugin', '--profile', 'web', 'add', '@scope/pkg'])).toBe(
       'dsh plugin --profile web add @scope/pkg',
     )
+  })
+
+  it('admits common DSH profile names without admitting cmd expansion syntax', () => {
+    for (const profile of ['web', '011-rc.2', '测试001', '工作 profile', 'Профиль-2']) {
+      expect(isCmdSafeProfileName(profile)).toBe(true)
+    }
+    for (const profile of [
+      '%USERPROFILE%', 'name!VAR!', 'a&b', 'a|b', 'a^b', 'a<b', 'a>b', 'a(b)', 'say"hi"', 'line\nbreak',
+    ]) {
+      expect(isCmdSafeProfileName(profile)).toBe(false)
+    }
   })
 })
 

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -419,6 +419,21 @@ function installedSpec(name: string): string | undefined {
 }
 
 describe('host-provided profile and package-operation seams', () => {
+  it('mounts ordinary routes for a dotted, Unicode, spaced DSH profile name (#260)', async () => {
+    bed.dispose()
+    const profile = '测试 profile.011-rc.2'
+    const ordinaryDir = profileDir(profile)
+    mkdirSync(ordinaryDir, { recursive: true })
+    writeFileSync(join(ordinaryDir, 'package.json'), '{"dependencies":{}}')
+    writeFileSync(join(ordinaryDir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+    fake.profileDir = ordinaryDir
+    bed = createTestbed({ profile })
+
+    const installed = await bed.dispatch('GET', '/dsh-market/installed')
+    expect(installed.status).toBe(200)
+    expect(installed.json).toMatchObject({ profile, installed: {} })
+  })
+
   it('uses the explicit profile directory and injected status/setup/cancel operations', async () => {
     bed.dispose()
     const explicitDir = join(home, 'desktop-owned-profile')

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -8,7 +8,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
-  addProfileBundle, conflictingEntryIds, entryArtifactExists, hasDshManifest, hasLoadableEntry, pluginSubdirs, profileDir,
+  addProfileBundle, conflictingEntryIds, entryArtifactExists, hasDshManifest, hasLoadableEntry, isDshProfileName, pluginSubdirs, profileDir,
   readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledRepoIdentities, readInstalledVersion, readLockCommits,
   removeProfileBundle,
 } from '../src/profile.ts'
@@ -29,6 +29,27 @@ function writeProfile(manifest: unknown): string {
   writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest))
   return dir
 }
+
+describe('profile names (#260)', () => {
+  it('matches the DSH profile directory contract instead of an ASCII-only subset', () => {
+    for (const name of ['web', '011-rc.2', '测试001', '工作 profile', 'Профиль-2']) {
+      expect(isDshProfileName(name)).toBe(true)
+      expect(profileDir(name)).toBe(join(home, 'profiles', name))
+    }
+  })
+
+  it('still rejects every traversal-shaped or launcher-owned name DSH rejects', () => {
+    for (const name of ['', '.', '..', 'node_modules', 'a/b', 'a\\b', 'a\0b']) {
+      expect(isDshProfileName(name)).toBe(false)
+      expect(() => profileDir(name)).toThrow('invalid profile name')
+    }
+  })
+
+  it('keeps a host-authoritative Desktop directory independent of its display name', () => {
+    const explicit = join(home, 'desktop-owned')
+    expect(profileDir('../display-only', explicit)).toBe(explicit)
+  })
+})
 
 describe('readInstalled', () => {
   it('filters exactly the in-box bundles — scoped COMMUNITY plugins stay (#28)', () => {


### PR DESCRIPTION
Closes #260.

## What changed

- Align ordinary profile path validation with DSH's `resolveProfileDir` contract instead of the legacy ASCII-only allowlist.
- Mount market routes for legitimate names such as `011-rc.2`, `测试001`, and `工作 profile`.
- Keep the Desktop `profileDirectory` contract unchanged: its host-authoritative directory remains independent of the display name.
- Preserve the Windows command boundary at the actual launcher: the rare bare `dsh.cmd` fallback permits only letters, marks, numbers, spaces, dots, underscores, and hyphens; the normal direct-Node launcher remains argv-safe and accepts every DSH-valid name.

## Why the launcher-specific guard

The profile path itself does not need an ASCII subset. Standard DSH launches are re-invoked through the detected Node entry point with `shell: false`, so dotted, Unicode, and spaced names remain ordinary argv data.

The fallback is different: `cmd.exe` expands `%VAR%` even inside double quotes. This change therefore fails closed only when that shell boundary is actually in use, before any plugin operation is prepared or spawned. Names containing `%`, `!`, quotes, newlines, or cmd metacharacters are rejected there with an actionable error.

## Tests

- `npm run check` — typecheck, build, and restart smoke passed
- `npm test` — 44 files passed; 764 tests passed, 1 skipped
- New coverage for DSH-compatible and traversal-shaped names, the cmd fallback allowlist, Desktop's explicit-directory seam, and a real route dispatch using a dotted/Unicode/spaced profile
- Optional real-host web E2E: unavailable on this machine because no `dsh` CLI was reachable (the suite's documented skip condition)