### PR TITLE
fix: preserve git subpaths during updates

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -109,6 +109,30 @@ export function marketVersion(): string {
 const SELF_NAMES = new Set(['dshmarket', 'dsh-market'])
 
 /**
+ * Rebuild a GitHub target for an update: revision selectors are deliberately
+ * dropped so pnpm resolves the repository again, while one valid `path:`
+ * selector is kept because it identifies the package inside a monorepo.
+ * pnpm permits both in one fragment (`#main&path:/packages/plugin`).
+ */
+function githubUpdateTarget(spec: string): string {
+  const fragmentAt = spec.indexOf('#')
+  if (fragmentAt === -1) return spec
+  const repo = spec.slice(0, fragmentAt)
+  let subpath: string | null = null
+  for (const selector of spec.slice(fragmentAt + 1).split('&')) {
+    if (!selector.startsWith('path:/')) continue
+    const candidate = selector.slice('path:/'.length)
+    const valid = /^[A-Za-z0-9_./-]+$/.test(candidate)
+      && !candidate.split('/').some(segment => segment === '' || segment === '.' || segment === '..')
+    // Multiple path selectors are ambiguous; an invalid selector is never
+    // forwarded to the package manager from a hand-edited profile.
+    if (subpath !== null || !valid) return repo
+    subpath = candidate
+  }
+  return subpath === null ? repo : `${repo}#path:/${subpath}`
+}
+
+/**
  * Whether an installed package declares a client part (`dsh.client`). Its UI
  * is injected into the page, so toggling it needs a browser refresh to show
  * the change — the install flow prompts the same way via the hot banner.
@@ -1320,7 +1344,7 @@ export function mountMarketRoutes(
             // The market follows its channel; everything else is `latest`.
             const selfChannel = SELF_NAMES.has(name) ? activeChannel() : null
             const tag = selfChannel === null ? 'latest' : DIST_TAG[selfChannel]
-            const target = isGit ? spec.replace(/#.*$/, '') : `${name}@${tag}`
+            const target = isGit ? githubUpdateTarget(spec) : `${name}@${tag}`
             // Never let `@latest` walk a profile BACKWARDS (#64 by @ZeroOrigin64):
             // a package whose latest dist-tag was left on an older release turns
             // this update into a downgrade that also rewrites an exact pin to

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -852,6 +852,36 @@ describe('update flow — no npm publishing required', () => {
     expect(r.json.activation['dsh-loop']).toMatchObject({ state: 'restart', hot: false })
   })
 
+  it('keeps a github subpath while dropping revision selectors during update (#281)', async () => {
+    const target = 'github:m/mono#path:/packages/plug-a'
+    fake.repos[target] = {
+      name: 'plug-a', manifest: { dsh: {}, main: 'index.js' }, artifacts: ['index.js'],
+    }
+    const installed = await bed.dispatch('POST', '/dsh-market/install', {
+      url: 'https://github.com/m/mono/tree/main/packages/plug-a',
+    })
+    expect(installed.status).toBe(200)
+    expect(installedSpec('plug-a')).toBe(target)
+
+    const direct = await bed.dispatch('POST', '/dsh-market/update', { name: 'plug-a' })
+    expect(direct.status).toBe(200)
+    expect(fake.calls.at(-1)).toContain(target)
+    expect(installedSpec('plug-a')).toBe(target)
+
+    // A ref and path may share pnpm's fragment. Updating still discards the
+    // ref (so HEAD is re-resolved) but must not discard the package subpath.
+    const manifestPath = join(profileDir('web'), 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    manifest.dependencies['plug-a'] = 'github:m/mono#release-1&path:/packages/plug-a'
+    writeFileSync(manifestPath, JSON.stringify(manifest))
+
+    const refreshed = await bed.dispatch('POST', '/dsh-market/update', { name: 'plug-a' })
+    expect(refreshed.status).toBe(200)
+    expect(fake.calls.at(-1)).toContain(target)
+    expect(fake.calls.at(-1)).not.toContain('release-1')
+    expect(installedSpec('plug-a')).toBe(target)
+  })
+
   it('refuses an update while any agent is running, before pnpm is touched', async () => {
     advanceNpmLatest('1.2.0')
     const callsBefore = fake.calls.length


### PR DESCRIPTION
## Summary

- preserve a validated `#path:/subdir` selector when updating GitHub-hosted plugins
- continue dropping branch, tag, commit, and semver selectors so the update re-resolves the repository
- cover both plain subpath and combined ref-plus-subpath specs through the real install/update flow

## Why

The update route previously stripped the complete Git fragment. For monorepo plugins, that changed a dependency such as `github:owner/repo#path:/packages/plugin` into `github:owner/repo`, installing the collection root instead of the selected plugin.

The replacement keeps the package-identifying path selector while removing revision selectors. It also refuses malformed or ambiguous paths rather than forwarding them to pnpm.

Thanks to @aqbjqtd for the precise report and reproduction.

## Verification

- focused flow suite: 95/95 passed
- full suite: 760 passed, 1 skipped across 44 files
- TypeScript checks: all three projects passed
- `git diff --check`

Fixes #281