### PR TITLE
fix: guard uninstall against user patch references

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -204,17 +204,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
-/** Parse one entry-list patch file with the dsh dialect; null when unreadable. */
-export function parsePatchFile(path: string): unknown[] | null {
-  let text: string
-  try {
-    text = readFileSync(path, 'utf8')
-  } catch {
-    return null
-  }
+/** Parse entry-list source with the DSH dialect; null when it is not a list. */
+export function parsePatchText(text: string): unknown[] | null {
   try {
     const value = load(text, { schema: entrySchema })
     return Array.isArray(value) ? value : null
+  } catch {
+    return null
+  }
+}
+
+/** Parse one entry-list patch file with the DSH dialect; null when unreadable. */
+export function parsePatchFile(path: string): unknown[] | null {
+  try {
+    return parsePatchText(readFileSync(path, 'utf8'))
   } catch {
     return null
   }

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -29,7 +29,7 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { logEvent } from './log.ts'
-import { parsePatchFile } from './check.ts'
+import { parsePatchFile, parsePatchText } from './check.ts'
 import { bundlePatchInsertedIds, parsePatchRows } from './profile.ts'
 
 /** The slice of the loader tree this module needs. */
@@ -172,6 +172,76 @@ export function readUserPatchState(patchPath: string): PatchState {
     else if (/^ {2}disabled: false\s*$/u.test(next)) forced.push(disableRow[1])
   }
   return { disables, forced, inserts }
+}
+
+/**
+ * User-authored insert rows that still load `packageName` (or one of its
+ * exported subpaths). This evidence deliberately stays separate from the
+ * package's own bundle declaration: uninstall may clean market-owned rows,
+ * but it must never rewrite an insert the user owns.
+ *
+ * A missing patch is the ordinary empty-profile shape. `null` means the
+ * existing file could not be read as DSH's patch dialect; callers must treat
+ * that as indeterminate and refuse the destructive step.
+ */
+export function userPatchPackageReferences(patchPath: string, packageName: string): string[] | null {
+  let source: string
+  try {
+    source = readFileSync(patchPath, 'utf8')
+  } catch (error) {
+    const code = error !== null && typeof error === 'object' && 'code' in error
+      ? (error as { code?: unknown }).code
+      : undefined
+    if (code === 'ENOENT') return []
+    return null
+  }
+
+  // Use the same schema as profile composition, including !!js scalars. A
+  // line scanner cannot distinguish flow-style entries or nested loader
+  // groups from arbitrary config keys in a hand-written user patch.
+  const rows = parsePatchText(source)
+  if (rows === null) return null
+  const insertedNames = new Set<string>()
+  const visiting = new Set<unknown[]>()
+  const visited = new Set<unknown[]>()
+  const collect = (entries: unknown[]): boolean => {
+    if (visited.has(entries)) return true
+    if (visiting.has(entries)) return false
+    visiting.add(entries)
+    for (const entry of entries) {
+      if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+        visiting.delete(entries)
+        return false
+      }
+      const row = entry as Record<string, unknown>
+      if ('name' in row && typeof row.name !== 'string') {
+        visiting.delete(entries)
+        return false
+      }
+      if (typeof row.name === 'string') insertedNames.add(row.name)
+      // Only group rows treat an array-valued config as child loader rows.
+      // Other plugins may use arrays of `{ name: ... }` as ordinary options,
+      // and those must not become false package references.
+      if (row.group === true && Array.isArray(row.config)) {
+        if (!collect(row.config)) {
+          visiting.delete(entries)
+          return false
+        }
+      }
+    }
+    visiting.delete(entries)
+    visited.add(entries)
+    return true
+  }
+  for (const patch of rows) {
+    if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) return null
+    const patchRow = patch as Record<string, unknown>
+    if (!('insert' in patchRow)) continue
+    if (!Array.isArray(patchRow.insert) || !collect(patchRow.insert)) return null
+  }
+  return [...insertedNames].filter(
+    reference => reference === packageName || reference.startsWith(`${packageName}/`),
+  )
 }
 
 /** The include entry's id prefix (loader entry ids look like `include:X`). */

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -44,7 +44,7 @@ import { detectedSupervisor, restartAllowed, scheduleRestart, servingPort, trust
 import { activationAfterReplace, brokenClientBundles, checkClientBundle, hasHostHalf, newlyBrokenBundles, verifyActivation } from './verify.ts'
 import {
   carrierDisableIds, disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
-  readUserPatchState, removeRowBlocks, rowIdsForPackage,
+  readUserPatchState, removeRowBlocks, rowIdsForPackage, userPatchPackageReferences,
 } from './patch.ts'
 import {
   createProfileBackup, downloadWebdav, MAX_BACKUP_BYTES, mergeRestoreManifest, restoreProfileBackup, secretFileCount, unportableDeps, uploadWebdav,
@@ -2312,6 +2312,25 @@ export function mountMarketRoutes(
             }
             if (readInstalled(config.profile, activeProfileDir)[name] === undefined) {
               sendJson(response, 400, { error: 'plugin is not installed' })
+              return
+            }
+            const userPatchReferences = userPatchPackageReferences(userPatchPath, name)
+            if (userPatchReferences === null) {
+              logEvent('warn', 'uninstall-blocked', `${name}: user cordis.patch.yml could not be inspected safely`)
+              sendJson(response, 409, {
+                error: `无法安全卸载 ${name}：当前 profile 的 cordis.patch.yml 无法读取为有效的补丁列表，因此无法排除它仍在引用该包。请先检查补丁文件再重试。 / Cannot safely uninstall ${name}: this profile's cordis.patch.yml could not be read as a valid patch list, so the market cannot rule out a remaining package reference. Check the patch file and retry.`,
+                userPatchInspectionFailed: true,
+              })
+              return
+            }
+            if (userPatchReferences.length > 0) {
+              const listed = userPatchReferences.join(', ')
+              logEvent('warn', 'uninstall-blocked', `${name}: user cordis.patch.yml still inserts ${listed}`)
+              sendJson(response, 409, {
+                error: `无法卸载 ${name}：当前 profile 的 cordis.patch.yml 仍通过 insert 引用 ${listed}。请先移除这些用户补丁引用再重试；市场不会自动改写用户补丁。 / Cannot uninstall ${name}: this profile's cordis.patch.yml still inserts ${listed}. Remove those user-owned patch references first and retry; the market will not rewrite the user patch automatically.`,
+                userPatchReferenced: true,
+                patchReferences: userPatchReferences,
+              })
               return
             }
             const busyAgents = runningAgentsForGuard()

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -1595,6 +1595,67 @@ describe('uninstall flow', () => {
     expect((await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'ghost' })).status).toBe(400)
   })
 
+  it('refuses to remove a package still inserted by the user patch (#165)', async () => {
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+    const patch = join(fake.profileDir, 'cordis.patch.yml')
+    const patchText = [
+      '- insert:',
+      '    - id: user-loop',
+      "      name: 'dsh-loop/runtime'",
+      '',
+    ].join('\n')
+    writeFileSync(patch, patchText)
+    const callsBefore = fake.calls.length
+
+    const r = await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(409)
+    expect(r.json).toMatchObject({
+      userPatchReferenced: true,
+      patchReferences: ['dsh-loop/runtime'],
+    })
+    expect(String(r.json.error)).toContain('cordis.patch.yml')
+    expect(installedSpec('dsh-loop')).toBeDefined()
+    expect(readFileSync(patch, 'utf8')).toBe(patchText)
+    expect(fake.calls.slice(callsBefore).some(call => call[0] === 'remove')).toBe(false)
+  })
+
+  it('does not confuse a neighbouring package name for a user-patch reference (#165)', async () => {
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+    writeFileSync(join(fake.profileDir, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: neighbour',
+      '      name: dsh-loop-extra',
+      '',
+    ].join('\n'))
+
+    const r = await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(200)
+    expect(r.json.ok).toBe(true)
+    expect(installedSpec('dsh-loop')).toBeUndefined()
+  })
+
+  it('refuses to uninstall when the user patch cannot be inspected safely (#165)', async () => {
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+    const patch = join(fake.profileDir, 'cordis.patch.yml')
+    const patchText = '- insert:\n    - id: broken\n      name: [\n'
+    writeFileSync(patch, patchText)
+    const callsBefore = fake.calls.length
+
+    const r = await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(409)
+    expect(r.json.userPatchInspectionFailed).toBe(true)
+    expect(String(r.json.error)).toContain('cordis.patch.yml')
+    expect(installedSpec('dsh-loop')).toBeDefined()
+    expect(readFileSync(patch, 'utf8')).toBe(patchText)
+    expect(fake.calls.slice(callsBefore).some(call => call[0] === 'remove')).toBe(false)
+  })
+
   it('uninstall succeeds even when the lockfile holds a too-young release (#39)', async () => {
     fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
     await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })

--- a/tests/patch.spec.ts
+++ b/tests/patch.spec.ts
@@ -18,7 +18,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   carrierDisableIds, disableRow, enableRow, findUserPatchPath, isProtectedModule, packagePatchFlags,
-  readUserPatchState, removeRowBlocks, rowIdsForPackage, type PatchHost,
+  readUserPatchState, removeRowBlocks, rowIdsForPackage, userPatchPackageReferences, type PatchHost,
 } from '../src/patch.ts'
 
 function patchDir(): string {
@@ -59,6 +59,138 @@ describe('readUserPatchState', () => {
     const dir = patchDir()
     try {
       expect(readUserPatchState(join(dir, 'cordis.patch.yml'))).toEqual({ disables: [], forced: [], inserts: [] })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('userPatchPackageReferences', () => {
+  it('finds exact package and exported-subpath inserts without prefix collisions', () => {
+    const dir = patchDir()
+    try {
+      const patch = join(dir, 'cordis.patch.yml')
+      writeFileSync(patch, [
+        '- insert:',
+        '    - id: exact',
+        '      name: dsh-loop',
+        '    - id: subpath',
+        "      name: 'dsh-loop/runtime'",
+        '    - id: scoped',
+        '      name: "@scope/plugin/client"',
+        '    - id: neighbour',
+        '      name: dsh-loop-extra',
+        '',
+      ].join('\n'))
+
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toEqual(['dsh-loop', 'dsh-loop/runtime'])
+      expect(userPatchPackageReferences(patch, '@scope/plugin')).toEqual(['@scope/plugin/client'])
+      expect(userPatchPackageReferences(patch, 'missing')).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores nested config names and rows after the insert block', () => {
+    const dir = patchDir()
+    try {
+      const patch = join(dir, 'cordis.patch.yml')
+      writeFileSync(patch, [
+        '- insert:',
+        '  - id: workbench',
+        '    name: real-plugin',
+        '    config:',
+        '      name: nested-config-value',
+        '  - id: array-options',
+        '    name: options-plugin',
+        '    config:',
+        '      - name: nested-array-value',
+        '- config:',
+        '    name: later-top-level-value',
+        '',
+      ].join('\n'))
+
+      expect(userPatchPackageReferences(patch, 'real-plugin')).toEqual(['real-plugin'])
+      expect(userPatchPackageReferences(patch, 'nested-config-value')).toEqual([])
+      expect(userPatchPackageReferences(patch, 'nested-array-value')).toEqual([])
+      expect(userPatchPackageReferences(patch, 'later-top-level-value')).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('recognizes flow-style inserts and loader entries nested in a group', () => {
+    const dir = patchDir()
+    try {
+      const patch = join(dir, 'cordis.patch.yml')
+      writeFileSync(patch, '[{ insert: [{ id: flow, name: dsh-loop/runtime }] }]\n')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toEqual(['dsh-loop/runtime'])
+
+      writeFileSync(patch, [
+        '- insert:',
+        '    - id: group',
+        '      name: cordis:group',
+        '      group: true',
+        '      config:',
+        '        - id: child',
+        '          name: dsh-loop/child',
+        '',
+      ].join('\n'))
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toEqual(['dsh-loop/child'])
+
+      writeFileSync(patch, '- insert:\n    - id: empty-group\n      name: cordis:group\n      group: true\n')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports an existing malformed patch as indeterminate', () => {
+    const dir = patchDir()
+    try {
+      const patch = join(dir, 'cordis.patch.yml')
+      writeFileSync(patch, '- insert:\n    - id: broken\n      name: [\n')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toBeNull()
+      writeFileSync(patch, '- insert: { id: wrong-shape, name: dsh-loop }\n')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toBeNull()
+      writeFileSync(patch, '- dsh-loop\n')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toBeNull()
+      writeFileSync(patch, '')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toBeNull()
+      writeFileSync(patch, '# no valid top-level list yet\n')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toBeNull()
+      writeFileSync(patch, [
+        '- insert: &entries',
+        '    - id: cyclic-group',
+        '      name: cordis:group',
+        '      group: true',
+        '      config: *entries',
+        '',
+      ].join('\n'))
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toBeNull()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('treats a missing patch and the template [] placeholder as no references', () => {
+    const dir = patchDir()
+    try {
+      const patch = join(dir, 'cordis.patch.yml')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toEqual([])
+      writeFileSync(patch, '# no user entries yet\n[]\n')
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a non-file patch path as unreadable', () => {
+    const dir = patchDir()
+    try {
+      const patch = join(dir, 'cordis.patch.yml')
+      mkdirSync(patch)
+      expect(userPatchPackageReferences(patch, 'dsh-loop')).toBeNull()
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary

- inspect the profile's user cordis.patch.yml with the same YAML dialect DSH uses to compose it
- refuse uninstall when an insert entry still names the exact package or one of its exported subpaths, including nested loader groups
- fail safely when the existing patch is unreadable, malformed, structurally indeterminate, or cyclic
- leave the user-authored patch byte-for-byte untouched and avoid neighbouring package-name false positives

## Why

This addresses the uninstall-safety half of #165. The uninstall route currently reaches package removal without checking whether the profile's user patch still loads that package. Removing it can therefore leave an unresolved loader entry and break the next DSH boot.

The broader post-install activation classification remains separate, as agreed in the issue discussion.

## Verification

- focused patch, flow, and parser suites: 168/168 passed
- full suite: 917 passed, 1 skipped across 47 files
- type checking: all three TypeScript projects passed
- production build and restart smoke: passed
- git diff --check