### PR TITLE
fix: respect host-provided profile bundles

### DIFF
--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -40,7 +40,7 @@ import { clearSettled, drop, enqueue, patch as patchRecord, recordForUrl } from 
 import type { OperationRecord } from './operations.ts'
 import { Diagnostics } from './Diagnostics.tsx'
 import {
-  avatarColor, entryForDep, githubProxyInUse, githubUrl, groupSwitchState, humanOutput, isInstalled, looksTerminal, matchInstalledName, orderedCategories,
+  avatarColor, entryForDep, githubProxyInUse, githubUrl, groupSwitchState, humanOutput, installedForCatalog, isInstalled, looksTerminal, matchInstalledName, orderedCategories,
   formatCount, pageItems, pluginName, pluginScreenshotCandidates, pluginScreenshots, rankThemeScreenshots, readSession, safeScreenshots, setGithubProxy, themePlugins as themePluginsOf, themeSwatch, TIME_RANGE_DAYS, visiblePlugins,
 } from './market-data.ts'
 import type {
@@ -1293,6 +1293,11 @@ export function MarketSection(props: MarketSectionProps) {
       .catch(() => {})
   }, [])
 
+  /** Active Bundles count as installed in Discover without becoming package-manager targets. */
+  const catalogInstalled = useMemo(
+    () => installedForCatalog(installed, installedBundles),
+    [installed, installedBundles],
+  )
   /** Lookup set for the persisted disable list (#60). */
   const disabledSet = useMemo(() => new Set(disabledNames), [disabledNames])
   /** Effective switch state: market disable list ∪ user-patch-layer disables. */
@@ -2439,7 +2444,7 @@ export function MarketSection(props: MarketSectionProps) {
   const pluginCard = (p: RegistryPlugin) => {
     const desc = (p.description && (p.description[lang] || p.description.en)) || ''
     const done = doneUrls.includes(p.url) || hotUrls.includes(p.url)
-    const already = isInstalled(p, installed, repoIdentities, data?.plugins, repoHints)
+    const already = isInstalled(p, catalogInstalled, repoIdentities, data?.plugins, repoHints)
     const busy = busyUrl === p.url
     const replacement = replacementOf(p)
     // The card reflects its own latest operation. Without this a rejected
@@ -3706,7 +3711,7 @@ export function MarketSection(props: MarketSectionProps) {
                                   return (
                                     <>
                                       <Button variant="outline" size="sm" onClick={() => { setCat('all'); setQ(entry.replacement!); setTab('discover') }}>{t('viewReplacement')}</Button>
-                                      {!isInstalled(replacement, installed, repoIdentities, data?.plugins, repoHints) && (
+                                      {!isInstalled(replacement, catalogInstalled, repoIdentities, data?.plugins, repoHints) && (
                                         <Button variant="outline" size="sm" onClick={() => setConfirming(replacement)}>{t('installReplacement')}</Button>
                                       )}
                                     </>

--- a/src/client/SettingsCard.tsx
+++ b/src/client/SettingsCard.tsx
@@ -1,8 +1,10 @@
 /**
  * The market's card on the plugin configuration page (dsh >= 0.1.0-rc.7).
  *
- * It manages the market ITSELF — version, update, remove. That is the whole
- * scope on purpose: this page is where a user goes to deal with a plugin,
+ * It manages the market ITSELF — version, update, remove — when the current
+ * profile owns the dependency. A host-provided market keeps only its version
+ * display and download-region controls. This page is where a user goes to deal
+ * with a plugin,
  * and "which version am I on / update it / get rid of it" is the part of
  * that anybody can act on without knowing how DSH is put together.
  *
@@ -70,6 +72,8 @@ interface SelfStatus {
   regions: Region[]
   /** The region came from the network check, not from the user. */
   regionAuto: boolean
+  /** Whether the profile package manager owns this market installation. */
+  selfManaged: boolean
 }
 
 /** The subset of `/dsh-market/status` this card reads. */
@@ -82,6 +86,7 @@ interface StatusBody {
   regions?: string[]
   regionAuto?: boolean
   githubProxy?: string | null
+  selfManaged?: boolean
 }
 
 /** What `/dsh-market/updates` says about the market's own row. */
@@ -141,6 +146,7 @@ function readStatus(body: StatusBody): SelfStatus {
     // the row tells the truth about that host rather than hiding.
     regions: regions.length > 0 ? regions : REGIONS,
     regionAuto: body.regionAuto === true,
+    selfManaged: body.selfManaged !== false,
   }
 }
 
@@ -205,7 +211,7 @@ export function SettingsCard({ t, onRemoved }: SettingsCardProps): ReactElement 
         if (live) {
           setStatus({
             version: null, restart: false, channel: 'stable', channels: ['stable', 'beta'],
-            region: 'global', regions: REGIONS, regionAuto: false,
+            region: 'global', regions: REGIONS, regionAuto: false, selfManaged: true,
           })
         }
       }
@@ -350,7 +356,7 @@ export function SettingsCard({ t, onRemoved }: SettingsCardProps): ReactElement 
   const body = phase === 'removed'
     ? row(t('setSelfRemoved'), t('setSelfRemovedHint'), null)
     : h(Fragment, null,
-        row(
+        status?.selfManaged === true ? row(
           // An older offer is not an update, and calling it one would have
           // the user click "更新" to go backwards. It IS what picking an
           // earlier channel asked for, so it is offered — under its own name.
@@ -374,8 +380,8 @@ export function SettingsCard({ t, onRemoved }: SettingsCardProps): ReactElement 
               : update?.channelSwitch != null
                 ? h(Button, { variant: 'outline', size: 'sm', disabled: busy, onClick: () => onUpdate() }, t('setChannelSwitch'))
                 : null,
-        ),
-        row(t('setChannel'), t(CHANNEL_HINT[status?.channel ?? 'stable']),
+        ) : null,
+        status?.selfManaged === true ? row(t('setChannel'), t(CHANNEL_HINT[status.channel]),
           h('div', { className: css.setSeg },
             // Drawn from what the SERVER says is available, so the control
             // can never offer a channel the route would refuse.
@@ -391,7 +397,7 @@ export function SettingsCard({ t, onRemoved }: SettingsCardProps): ReactElement 
               title: id === 'dev' ? t('setChannelDevHint') : undefined,
               onClick: () => { onChannel(id) },
             }, t(CHANNEL_LABEL[id]))),
-          )),
+          )) : null,
         // Above the channel row and below the update row: this is about
         // getting plugins at all, which is the market's whole job, while the
         // channel is about which build of the market itself arrives.
@@ -414,7 +420,7 @@ export function SettingsCard({ t, onRemoved }: SettingsCardProps): ReactElement 
               onClick: () => { onRegion(id) },
             }, t(REGION_LABEL[id]))),
           )),
-        row(t('setSelfRemove'), t('setSelfRemoveHint'),
+        status?.selfManaged === true ? row(t('setSelfRemove'), t('setSelfRemoveHint'),
           phase === 'confirming' || busy
             ? null
             : h(Button, {
@@ -423,8 +429,8 @@ export function SettingsCard({ t, onRemoved }: SettingsCardProps): ReactElement 
                 className: css.setDanger,
                 disabled: busy,
                 onClick: () => { setPhase('confirming') },
-              }, t('setSelfRemove'))),
-        phase === 'confirming' || busy
+              }, t('setSelfRemove'))) : null,
+        status?.selfManaged === true && (phase === 'confirming' || busy)
           ? h('div', { className: css.setConfirm },
               h('div', { className: css.setHint }, t('setSelfConfirm')),
               h('label', { className: css.setCheck },

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -2,7 +2,7 @@
 
 export const zh = {
   nav: '插件市场',
-  setCardDesc: '查看版本、更新或移除插件市场。',
+  setCardDesc: '查看插件市场版本与设置。',
   setSelfUpToDate: '已是最新版本',
   setSelfUpdateReady: '有新版本',
   setSelfUpdateHint: '更新会下载新版本，重启后生效。',
@@ -454,7 +454,7 @@ export type MarketKey = keyof typeof zh
 
 export const en: Record<MarketKey, string> = {
   nav: 'Plugin Market',
-  setCardDesc: 'See the version, update, or remove the plugin market.',
+  setCardDesc: 'View the plugin market version and settings.',
   setSelfUpToDate: 'Up to date',
   setSelfUpdateReady: 'New version available:',
   setSelfUpdateHint: 'Updating downloads the new version; it takes effect after a restart.',

--- a/src/client/market-data.ts
+++ b/src/client/market-data.ts
@@ -47,6 +47,20 @@ export interface Registry {
 /** Profile dependency map: package name → install spec. */
 export type InstalledMap = Record<string, string>
 
+/**
+ * Add active profile Bundles as presence-only catalog entries.
+ *
+ * The returned map is for catalog matching only. Update and uninstall flows
+ * must keep using the dependency-only map because a Bundle supplied by the
+ * dsh installation is not owned by the profile package manager.
+ */
+export function installedForCatalog(installed: InstalledMap, bundles: readonly string[]): InstalledMap {
+  return Object.fromEntries([
+    ...bundles.map(name => [name, '*'] as const),
+    ...Object.entries(installed),
+  ])
+}
+
 /** Strong repo identities discovered for local link:/file: dependencies (#141). */
 export type InstalledRepoIdentities = Record<string, string[]>
 
@@ -71,6 +85,8 @@ export interface UpdateStatus {
 export interface MarketStatus {
   /** The market's own version — rendered in the heading so screenshots carry it. */
   version?: string
+  /** Whether the profile package manager owns the market dependency. */
+  selfManaged?: boolean
   /**
    * Prefix to put in front of github.com URLs the BROWSER loads, or null to
    * address them directly. Resolved by the server from the download region.

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1414,6 +1414,7 @@ export function mountMarketRoutes(
           return
         }
         await dropStaleHotMounts()
+        const installed = readInstalled(config.profile, activeProfileDir)
         sendJson(response, 200, {
           active: progress.active,
           target: progress.target,
@@ -1455,7 +1456,8 @@ export function mountMarketRoutes(
           // Named so the UI can say WHY the button is gone. A blank
           // "no restart button" is the state #229 reported as broken.
           supervisor: detectedSupervisor(),
-          installed: readInstalled(config.profile, activeProfileDir),
+          selfManaged: installed.dshmarket !== undefined || installed['dsh-market'] !== undefined,
+          installed,
         })
       },
     }),

--- a/tests/client/settings-card.client.spec.tsx
+++ b/tests/client/settings-card.client.spec.tsx
@@ -22,7 +22,7 @@ const t = (key: string): string => (en as Record<string, string>)[key] ?? key
 let calls: Array<{ path: string; body: unknown }> = []
 
 function stubFetch(options: {
-  version?: string; restart?: boolean; latest?: string | null; removeOk?: boolean; error?: string
+  version?: string; restart?: boolean; latest?: string | null; removeOk?: boolean; error?: string; selfManaged?: boolean
   channel?: string; channelSwitch?: string; channelError?: string
   region?: string; regionAuto?: boolean; regionError?: string; githubProxy?: string | null
 } = {}): void {
@@ -42,6 +42,7 @@ function stubFetch(options: {
         regions: ['global', 'china'],
         regionAuto: options.regionAuto === true,
         githubProxy: options.githubProxy ?? null,
+        selfManaged: options.selfManaged !== false,
       })
     }
     if (path.includes('/dsh-market/updates')) {
@@ -91,6 +92,17 @@ describe('SettingsCard', () => {
   it('shows the running version once opened', async () => {
     await open()
     await waitFor(() => { expect(screen.getByText(/v1\.12\.2/)).toBeTruthy() })
+  })
+
+  it('keeps host-provided installations out of profile package controls', async () => {
+    stubFetch({ selfManaged: false, latest: '1.13.0' })
+    render(<SettingsCard t={t} />)
+    fireEvent.click(screen.getByRole('button', { expanded: false }))
+    await waitFor(() => { expect(screen.getByText(t('setRegion'), { selector: 'div' })).toBeTruthy() })
+    expect(screen.queryByText(t('setSelfUpToDate'))).toBeNull()
+    expect(screen.queryByText(t('setChannel'), { selector: 'div' })).toBeNull()
+    expect(screen.queryByRole('button', { name: t('setSelfUpdate') })).toBeNull()
+    expect(screen.queryByRole('button', { name: t('setSelfRemove') })).toBeNull()
   })
 
   it('offers an update only when one exists', async () => {

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -501,8 +501,12 @@ describe('host-provided profile and package-operation seams', () => {
     const exportedManifest = exported.json.files.find((file: { path: string }) => file.path === 'package.json')
     expect(exportedManifest.json.dependencies).toEqual({ 'desktop-only': '1.0.0' })
     const status = await bed.dispatch('GET', '/dsh-market/status')
-    expect(status.json).toMatchObject({ pnpm: true, restart: false, installed: { 'desktop-only': '1.0.0' } })
-    expect(probe).toHaveBeenCalledOnce()
+    expect(status.json).toMatchObject({
+      pnpm: true, restart: false, selfManaged: false, installed: { 'desktop-only': '1.0.0' },
+    })
+    writeFileSync(join(explicitDir, 'package.json'), '{"dependencies":{"desktop-only":"1.0.0","dshmarket":"1.26.0"}}')
+    expect((await bed.dispatch('GET', '/dsh-market/status')).json.selfManaged).toBe(true)
+    expect(probe).toHaveBeenCalledTimes(2)
     expect((await bed.dispatch('POST', '/dsh-market/setup-pnpm', {})).json.ok).toBe(true)
     expect(provision).toHaveBeenCalledOnce()
     expect((await bed.dispatch('POST', '/dsh-market/cancel', {})).status).toBe(200)

--- a/tests/market-data.spec.ts
+++ b/tests/market-data.spec.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it } from 'vitest'
 import {
-  entryForDep, extractReadmeImageCandidates, extractReadmeImages, formatCount, groupSwitchState, isInstalled, isMarketItself, looksTerminal, matchInstalledName, orderedCategories, pageItems, previewDimensionScore, rankThemeScreenshots, safeScreenshots, themePlugins, visiblePlugins, humanOutput} from '../src/client/market-data.ts'
+  entryForDep, extractReadmeImageCandidates, extractReadmeImages, formatCount, groupSwitchState, installedForCatalog, isInstalled, isMarketItself, looksTerminal, matchInstalledName, orderedCategories, pageItems, previewDimensionScore, rankThemeScreenshots, safeScreenshots, themePlugins, visiblePlugins, humanOutput} from '../src/client/market-data.ts'
 import type { RegistryPlugin, ScreenshotCandidate } from '../src/client/market-data.ts'
 
 function plugin(partial: Partial<RegistryPlugin>): RegistryPlugin {
@@ -31,6 +31,19 @@ describe('looksTerminal', () => {
   it('still warns for plugins that positively target a terminal surface', () => {
     expect(looksTerminal(plugin({ name: 'dsh-tui' }), 'en')).toBe(true)
     expect(looksTerminal(plugin({ description: { zh: '为 DSH 提供命令行界面。' } }), 'zh')).toBe(true)
+  })
+})
+
+describe('installedForCatalog', () => {
+  it('adds Bundle presence without replacing dependency specs', () => {
+    expect(installedForCatalog(
+      { managed: '^2.0.0', shared: 'workspace:*' },
+      ['host-provided', 'shared'],
+    )).toEqual({
+      'host-provided': '*',
+      shared: 'workspace:*',
+      managed: '^2.0.0',
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- treat active profile Bundles as installed only when matching Discover catalog cards
- keep update, uninstall, backup, and group operations on profile-owned dependencies
- report whether the profile owns the market dependency and hide self-update, channel, and removal controls when a host provides it

## Problem

A dsh distribution can provide Bundles from its application dependency closure while the profile manifest keeps `dependencies` empty. Those Bundles are active through `dsh.profile.bundles`, but Discover currently offers them for installation. Adding them directly to the dependency-owned installed map avoids that button but incorrectly enables update and uninstall, creating a profile-local shadow of the host-provided version.

The installed endpoint already returns both the dependency map and active Bundle names. This change keeps their ownership distinct and combines them only for catalog matching.

## Verification

- `pnpm exec vitest run tests/market-data.spec.ts tests/client/settings-card.client.spec.tsx tests/flows.spec.ts` (177 tests passed)
- `pnpm run typecheck`

Coverage includes dependency-spec precedence, host-provided catalog presence, status ownership for both profile-managed and host-provided installations, and hidden self-management controls.
