### PR TITLE
fix: stop reporting a workspace peer as a definite mismatch

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -461,6 +461,25 @@ export function satisfiesRange(version: string, range: string): boolean | null {
   if (v === null) return null
   const versionHasPre = v.pre.length > 0
 
+  // Mirror pnpm's peer-dependency publish transform. Unlike ordinary
+  // dependency specs, a workspace token may sit inside a larger peer range.
+  // Operator-only (or bare) tokens receive the linked sibling's version;
+  // explicit versions only lose the protocol prefix. Unsupported alias/path
+  // forms become an unknown range below rather than a definite mismatch.
+  const workspaceSemver = /workspace:([\^~*]|>=|>|<=|<)?((\d+|[xX*])(\.(\d+|[xX*])){0,2})?/
+  let normalizedRange = range
+  if (range.includes('workspace:')) {
+    const match = workspaceSemver.exec(range)
+    if (match === null) {
+      normalizedRange = range.replace('workspace:', '')
+    } else if (match[2] !== undefined) {
+      normalizedRange = range.replace('workspace:', '')
+    } else {
+      const operator = match[1] === '*' ? '' : (match[1] ?? '')
+      normalizedRange = range.replace(workspaceSemver, `${operator}${semverStr(v)}`)
+    }
+  }
+
   const single = (part: string): boolean | null => {
     const p = part.trim()
     if (p === '' || p === '*' || p === 'x' || p === 'X') return true
@@ -508,7 +527,13 @@ export function satisfiesRange(version: string, range: string): boolean | null {
     if (p === '' || p === '*' || p === 'x' || p === 'X') return { op: '', target: '' }
     const m = /^(\^|~|>=|<=|>|<)?(.*)$/.exec(p)
     if (m === null) return null
-    return { op: m[1] ?? '', target: (m[2] ?? '').trim() }
+    const target = (m[2] ?? '').trim()
+    // Enforce this function's documented unknown-range contract before the
+    // prerelease admission gate. Otherwise an unknown protocol such as
+    // `workspace:^` or `catalog:default` is misreported as a definite false
+    // whenever the resolved version happens to carry a prerelease tag.
+    if (parseSemver(target) === null) return null
+    return { op: m[1] ?? '', target }
   }
 
   /** Evaluate ONE comparator set (a `||` alternative) as a conjunction. */
@@ -533,12 +558,13 @@ export function satisfiesRange(version: string, range: string): boolean | null {
     return results.every(r => r === true)
   }
 
-  if (range.includes('||')) {
-    const outcomes = range.split('||').map(part => evaluateSet(part))
+  if (normalizedRange.includes('||')) {
+    const outcomes = normalizedRange.split('||').map(part => evaluateSet(part))
     if (outcomes.some(out => out === true)) return true
-    return outcomes.every(out => out === null) ? null : false
+    if (outcomes.some(out => out === null)) return null
+    return false
   }
-  return evaluateSet(range)
+  return evaluateSet(normalizedRange)
 }
 
 // --- composition (mirrors dsh-app-boot applyEntryPatches) ---

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -401,6 +401,33 @@ describe('peer range mismatch', () => {
     expect(mismatch?.optional).toBe(true)
     expect(report.summary.warnings.some(w => w.includes('plugin-opt'))).toBe(false)
   })
+
+  it('accepts a rolling workspace peer resolved to its prerelease sibling (#317)', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writePackage(dir, 'workspace-plugin', {
+      name: 'workspace-plugin',
+      version: '0.1.1-rc.2',
+      peerDependencies: { '@deepseek-ai/dsh-invariants': 'workspace:^' },
+    })
+    writePackage(dir, '@deepseek-ai/dsh-invariants', {
+      name: '@deepseek-ai/dsh-invariants',
+      version: '0.1.1-rc.2',
+    })
+
+    const report = analyzeProfile(dir)
+    const peer = report.peerMismatches.find(
+      mismatch => mismatch.plugin === 'workspace-plugin'
+        && mismatch.name === '@deepseek-ai/dsh-invariants',
+    )
+
+    expect(peer).toMatchObject({
+      range: 'workspace:^',
+      resolved: '0.1.1-rc.2',
+      satisfied: true,
+    })
+    expect(report.summary.warnings.some(w => w.includes('workspace-plugin'))).toBe(false)
+  })
 })
 
 describe('pnpm-lock.yaml multi-version core packages', () => {
@@ -502,7 +529,26 @@ describe('satisfiesRange', () => {
     expect(satisfiesRange('2.1.0', '>=1.2.0 <2.0.0')).toBe(false)
     expect(satisfiesRange('2.0.0', '^1.0.0 || ^2.0.0')).toBe(true)
     expect(satisfiesRange('0.5.0', '^1.0.0 || ^2.0.0')).toBe(false)
-    expect(satisfiesRange('1.2.3', 'workspace:*')).toBeNull()
+    expect(satisfiesRange('1.2.3', 'catalog:default')).toBeNull()
+    expect(satisfiesRange('1.2.3-rc.1', 'catalog:default')).toBeNull()
+    expect(satisfiesRange('1.2.3', 'catalog:default || ^3.0.0')).toBeNull()
+    expect(satisfiesRange('3.1.0', 'catalog:default || ^3.0.0')).toBe(true)
+  })
+
+  it('materializes pnpm workspace protocol ranges against the resolved sibling (#317)', () => {
+    expect(satisfiesRange('0.1.1-rc.2', 'workspace:')).toBe(true)
+    expect(satisfiesRange('0.1.1-rc.2', 'workspace:*')).toBe(true)
+    expect(satisfiesRange('0.1.1-rc.2', 'workspace:^')).toBe(true)
+    expect(satisfiesRange('0.1.1-rc.2', 'workspace:~')).toBe(true)
+    expect(satisfiesRange('0.1.1-rc.2', 'workspace:^0.1.1-rc.1')).toBe(true)
+    expect(satisfiesRange('0.1.1-rc.2', 'workspace:^0.1.2-rc.1')).toBe(false)
+    expect(satisfiesRange('4.5.6', 'workspace:>= || ^3.9.0')).toBe(true)
+    expect(satisfiesRange('1.2.3', '^3.0.0 || workspace:>=')).toBe(true)
+    expect(satisfiesRange('1.2.3', 'workspace:>')).toBe(false)
+    expect(satisfiesRange('1.2.3', 'workspace:<')).toBe(false)
+    expect(satisfiesRange('1.2.3', 'workspace:<=')).toBe(true)
+    expect(satisfiesRange('1.2.3', 'workspace:1.2.x || ^3.0.0')).toBeNull()
+    expect(satisfiesRange('0.1.1-rc.2', 'workspace:../sibling')).toBeNull()
   })
 })
 


### PR DESCRIPTION
承 #319（@Jstn-1g），修 #317（@HomuraTokido）。取净 diff 重放到当前 main，逻辑未改。

直接探过函数确认不是"见 workspace: 就放行"：`workspace:^1.2.3` 对 2.0.0 仍判 false，`^0.1.0` 对 `0.2.0-rc.1` 仍判 false，`catalog:`/`npm:` 别名回到 null（unknown）而不是 false。

912 测试全过。