### PR TITLE
feat: say when a user patch loads a package that is not there

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -18,16 +18,18 @@
  *     version (tool calls die, minimal preset fails to mount)?
  *  4. Are there multiple versions of one core package in the lockfile, and
  *     do plugin peerDependencies ranges match the resolved core version?
+ *  5. Do effective user/home patch entries reference npm package roots that
+ *     are installed in the profile-visible node_modules ancestry?
  *
  * The composition step mirrors @deepseek-ai/dsh-app-boot's applyEntryPatches
  * (same js-yaml dialect incl. `!!js` scalars), so the rows reported here are
  * what actually mounts at boot.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
-import { createRequire } from 'node:module'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { createRequire, isBuiltin } from 'node:module'
 import { homedir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { JSON_SCHEMA, Type, load } from 'js-yaml'
 import { INBOX_BUNDLES, readBundleRules, suggestOrder, validateOrder } from './order.ts'
 
@@ -223,6 +225,52 @@ export function parsePatchFile(path: string): unknown[] | null {
   }
 }
 
+/** Whether `name` goes through the Loader's bare-module resolver. */
+function isBareLoaderSpecifier(name: string): boolean {
+  return !name.startsWith('.')
+    && !name.startsWith('#')
+    && !isAbsolute(name)
+    && !/^[a-z][a-z\d+.-]*:/i.test(name)
+}
+
+/** Npm package root owning one bare Loader specifier. */
+function packageRoot(specifier: string): string | null {
+  const parts = specifier.split('/')
+  const segments = specifier.startsWith('@') ? parts.slice(0, 2) : parts.slice(0, 1)
+  if (segments.length !== (specifier.startsWith('@') ? 2 : 1)) return null
+  if (segments.some(segment => segment === '' || segment === '.' || segment === '..'
+    || segment.includes('%') || segment.includes('\\'))) return null
+  if (specifier.startsWith('@') && (segments[0]?.length ?? 0) <= 1) return null
+  return segments.join('/')
+}
+
+/**
+ * Package-root presence from the Loader-visible profile ancestry only.
+ * An explicit walk avoids CommonJS global lookup directories that
+ * `createRequire(...).resolve.paths()` appends but Node ESM does not search.
+ */
+function profilePackageInstalled(profileDirectory: string, name: string): boolean {
+  try {
+    const profile = JSON.parse(readFileSync(join(profileDirectory, 'package.json'), 'utf8')) as unknown
+    if (isRecord(profile) && profile.name === name
+      && profile.exports !== undefined && profile.exports !== null) return true
+  } catch { /* not a self-referencing profile package */ }
+  let directory = resolve(profileDirectory)
+  while (true) {
+    const packageDirectory = join(directory, 'node_modules', name)
+    // Node stops at the nearest matching package directory. A partial install
+    // there shadows any healthy parent copy and must not be accepted.
+    try {
+      if (statSync(packageDirectory).isDirectory()) {
+        return existsSync(join(packageDirectory, 'package.json'))
+      }
+    } catch { /* keep walking */ }
+    const parent = dirname(directory)
+    if (parent === directory) return false
+    directory = parent
+  }
+}
+
 /** Every id in one patch row's insert list, recursively (group configs included). */
 function collectInsertIds(rows: unknown[]): string[] {
   const ids: string[] = []
@@ -318,14 +366,14 @@ function readNodeModulesVersion(base: string, name: string): string | null {
 }
 
 /**
- * Resolve one bundle package's directory the way the dsh boot does
+ * Resolve one package's directory the way the dsh boot does
  * (dsh-app-boot's resolveBundleDir): probe Node's own node_modules search
  * paths from the installation anchor first, then the profile directory.
  * Node resolution walks upward, so this also finds pnpm's workspace-root
  * hoisting (`<profiles>/node_modules/…` when the profile lives under
- * `<profiles>/<name>`) and matches exactly what the Loader would import.
+ * `<profiles>/<name>`) and mirrors the Loader's package search roots.
  */
-function resolveBundleDir(anchorPackageJson: string, name: string): string | null {
+function resolvePackageDir(anchorPackageJson: string, name: string): string | null {
   let paths: string[] = []
   try {
     paths = createRequire(anchorPackageJson).resolve.paths(name) ?? []
@@ -575,18 +623,78 @@ export function satisfiesRange(version: string, range: string): boolean | null {
 interface EntryNode {
   id: string
   name?: string
-  layer: string
+  layer?: string
   group?: boolean
   config?: unknown
+  disabled?: unknown
 }
 
 /** Flatten a tree of entries (group configs included) into row records. */
 function flattenEntries(nodes: EntryNode[]): LoaderRow[] {
   const rows: LoaderRow[] = []
-  const walk = (list: EntryNode[]): void => {
+  const walk = (list: EntryNode[], inheritedLayer?: string): void => {
     for (const node of list) {
-      rows.push({ id: node.id, layer: node.layer, kind: 'insert', name: node.name })
-      if (node.group === true && Array.isArray(node.config)) walk(node.config as EntryNode[])
+      // Nested group configs come straight from the parsed patch and do not
+      // carry the synthetic layer metadata attached to their parent insert.
+      const layer = typeof node.layer === 'string' ? node.layer : inheritedLayer
+      if (layer === undefined) continue
+      rows.push({ id: node.id, layer, kind: 'insert', name: node.name })
+      if (node.group === true && Array.isArray(node.config)) {
+        walk(node.config as EntryNode[], layer)
+      }
+    }
+  }
+  walk(nodes)
+  return rows
+}
+
+type DisabledState = 'active' | 'disabled' | 'conditional'
+
+interface ResolvableLoaderRow extends LoaderRow {
+  activation: 'required' | 'conditional'
+}
+
+/** Literal values use Loader Boolean semantics; `!!js` stays indeterminate. */
+function disabledState(value: unknown): DisabledState {
+  if (isRecord(value) && typeof value.__jsExpr === 'string') return 'conditional'
+  return Boolean(value) ? 'disabled' : 'active'
+}
+
+function combineDisabled(parent: DisabledState, own: DisabledState): DisabledState {
+  if (parent === 'disabled' || own === 'disabled') return 'disabled'
+  if (parent === 'conditional' || own === 'conditional') return 'conditional'
+  return 'active'
+}
+
+/**
+ * Rows whose specifiers the Loader can attempt to import. Group rows are
+ * always imported even when disabled (their disabled state gates children),
+ * while expression-gated non-group rows are retained as conditional.
+ */
+function resolvableEntries(nodes: EntryNode[]): ResolvableLoaderRow[] {
+  const rows: ResolvableLoaderRow[] = []
+  const walk = (
+    list: EntryNode[],
+    inheritedLayer?: string,
+    parentDisabled: DisabledState = 'active',
+  ): void => {
+    for (const node of list) {
+      const layer = typeof node.layer === 'string' ? node.layer : inheritedLayer
+      if (layer === undefined) continue
+      const descendantsDisabled = combineDisabled(parentDisabled, disabledState(node.disabled))
+      const activation = node.group === true ? 'required' : descendantsDisabled
+      if (activation !== 'disabled') {
+        rows.push({
+          id: node.id,
+          layer,
+          kind: 'insert',
+          name: node.name,
+          activation: activation === 'conditional' ? 'conditional' : 'required',
+        })
+      }
+      if (node.group === true && Array.isArray(node.config)) {
+        walk(node.config as EntryNode[], layer, descendantsDisabled)
+      }
     }
   }
   walk(nodes)
@@ -602,6 +710,7 @@ export interface LayerInput {
 
 interface Composed {
   rows: LoaderRow[]
+  resolvableRows: ResolvableLoaderRow[]
   duplicates: DuplicateId[]
   overrides: OverrideRow[]
   orphans: OrphanRow[]
@@ -653,6 +762,7 @@ export function composeLayers(layers: LayerInput[]): Composed {
             layer: layer.label,
             group: entry.group === true,
             config: Array.isArray(entry.config) ? entry.config : undefined,
+            disabled: entry.disabled,
           }
         }).filter((n): n is EntryNode => n !== null)
         if (hasId) {
@@ -704,6 +814,7 @@ export function composeLayers(layers: LayerInput[]): Composed {
     }
   }
   const rows = flattenEntries(tree)
+  const resolvableRows = resolvableEntries(tree)
   const byId = new Map<string, string[]>()
   for (const row of rows) {
     const layers = byId.get(row.id) ?? []
@@ -718,7 +829,7 @@ export function composeLayers(layers: LayerInput[]): Composed {
     duplicates.push({ id, layers: byId.get(id) ?? [], count })
   }
   duplicates.sort((a, b) => a.id.localeCompare(b.id))
-  return { rows, duplicates, overrides, orphans }
+  return { rows, resolvableRows, duplicates, overrides, orphans }
 }
 
 /** Distinct versions of `@deepseek-ai/{dsh,cordis}*` packages in the lockfile. */
@@ -774,7 +885,7 @@ export function buildBundleLayers(
     let directory: string | null = null
     for (const anchor of anchors) {
       if (anchor === null) continue
-      directory = resolveBundleDir(anchor, name)
+      directory = resolvePackageDir(anchor, name)
       if (directory !== null) break
     }
     const layer: BundleLayer = {
@@ -939,6 +1050,48 @@ export function analyzeProfile(profileDirectory: string, options: CheckOptions =
   }
   for (const layer of layers) {
     if (layer.parseError !== null && layer.kind !== 'bundle') errors.push(`${layer.label}: ${layer.parseError}`)
+  }
+  // User and home patches can insert packages independently of a bundle.
+  // Only check rows that survived composition: an insert targeting a missing
+  // group is skipped by the boot and therefore cannot cause module loading to
+  // fail. Normalize package subpaths to their npm root and check the profile's
+  // node_modules ancestry; exact exports/subpath validation and relative,
+  // absolute, URL, builtin, package-import (#), or cordis: specifiers are
+  // outside this check.
+  const userLayerLabels = new Set(
+    layers
+      .filter(layer => layer.kind === 'user' || layer.kind === 'home')
+      .map(layer => layer.label),
+  )
+  const candidates = new Map<string, { row: ResolvableLoaderRow, packageName: string }>()
+  for (const row of composed.resolvableRows) {
+    if (row.kind !== 'insert' || !userLayerLabels.has(row.layer)) continue
+    if (row.name === undefined || row.name === '') {
+      const message = `${row.layer}: loader entry ${JSON.stringify(row.id)} has no module name`
+      if (row.activation === 'required') errors.push(`${message} — the profile will fail to boot`)
+      else warnings.push(`${message} — boot will fail if its disabled expression enables the entry`)
+      continue
+    }
+    if (!isBareLoaderSpecifier(row.name)) continue
+    if (isBuiltin(row.name)) continue
+    const packageName = packageRoot(row.name)
+    if (packageName === null) {
+      const message = `${row.layer}: loader specifier ${JSON.stringify(row.name)} is not a valid bare package name`
+      if (row.activation === 'required') errors.push(`${message} — the profile will fail to boot`)
+      else warnings.push(`${message} — boot will fail if its disabled expression enables the entry`)
+      continue
+    }
+    const key = `${row.layer}\u0000${packageName}`
+    const previous = candidates.get(key)
+    if (previous === undefined || previous.row.activation === 'conditional' && row.activation === 'required') {
+      candidates.set(key, { row, packageName })
+    }
+  }
+  for (const { row, packageName } of candidates.values()) {
+    if (profilePackageInstalled(profileDirectory, packageName)) continue
+    const message = `${row.layer}: loader package ${packageName} is not installed in the profile`
+    if (row.activation === 'required') errors.push(`${message} — the profile will fail to boot`)
+    else warnings.push(`${message} — boot will fail if its disabled expression enables the entry`)
   }
   for (const dup of composed.duplicates) {
     errors.push(`duplicate loader entry id ${JSON.stringify(dup.id)} (${dup.count} rows: ${dup.layers.join(', ')})`)

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -47,6 +47,18 @@ function writePackage(base: string, name: string, manifest: unknown): string {
   return dir
 }
 
+/** Write a minimal package that Node's ESM resolver can actually import. */
+function writeLoadablePackage(base: string, name: string): string {
+  const dir = writePackage(base, name, {
+    name,
+    version: '1.0.0',
+    type: 'module',
+    exports: './index.js',
+  })
+  writeFileSync(join(dir, 'index.js'), 'export default {}\n')
+  return dir
+}
+
 /** Write a dsh bundle package (dsh.bundle.patch entry-list) at base/node_modules/<name>. */
 function writeBundle(base: string, name: string, version: string, patch: unknown[]): string {
   const dir = writePackage(base, name, {
@@ -145,6 +157,414 @@ describe('workspace-root hoisted bundles (#98 review B1)', () => {
     expect(bundle?.directory).toBe(root)
     expect(report.rows.map(r => r.id)).toEqual(['a-entry'])
     expect(report.summary.ok).toBe(true)
+  })
+})
+
+describe('user patch package resolution (#205)', () => {
+  const resolutionErrors = (errors: string[]): string[] =>
+    errors.filter(line => line.includes('loader package') || line.includes('loader specifier') || line.includes('has no module name'))
+
+  it('flags a missing package inserted by the profile patch as a boot failure', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      { insert: [{ id: 'rp-plugin', name: '@dsh-rp/missing' }] },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(report.rows).toContainEqual({
+      id: 'rp-plugin',
+      layer: 'user-patch',
+      kind: 'insert',
+      name: '@dsh-rp/missing',
+    })
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader package @dsh-rp/missing is not installed in the profile — the profile will fail to boot',
+    ])
+    expect(report.summary.ok).toBe(false)
+  })
+
+  it('normalizes a scoped package subpath to its installed npm package root', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: { '@scope/plugin': '^1.0.0' } })
+    const plugin = writePackage(dir, '@scope/plugin', {
+      name: '@scope/plugin',
+      version: '1.0.0',
+      type: 'module',
+      exports: { './runtime': './runtime.js' },
+    })
+    writeFileSync(join(plugin, 'runtime.js'), 'throw new Error("must not execute during check")\n')
+    writePackage(dir, 'legacy-package', { name: 'legacy-package', version: '1.0.0' })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      {
+        insert: [
+          { id: 'runtime', name: '@scope/plugin/runtime' },
+          { id: 'double-slash', name: 'legacy-package//index.js' },
+          { id: 'dot-segment', name: 'legacy-package/./index.js' },
+          { id: 'parent-segment', name: 'legacy-package/../legacy-package/index.js' },
+        ],
+      },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
+    expect(report.summary.ok).toBe(true)
+  })
+
+  it('accepts a profile package self-reference without a node_modules copy', () => {
+    const dir = pdir()
+    writeProfile(dir, {
+      name: 'self-profile',
+      exports: { '.': './index.js' },
+      dependencies: {},
+    })
+    writeFileSync(join(dir, 'index.js'), 'export default {}\n')
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([{
+      insert: [{ id: 'self', name: 'self-profile' }],
+    }]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(existsSync(join(dir, 'node_modules', 'self-profile'))).toBe(false)
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
+  })
+
+  it('does not treat exports:null as a resolvable profile self-reference', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'self-profile', exports: null, dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([{
+      insert: [{ id: 'self', name: 'self-profile' }],
+    }]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader package self-profile is not installed in the profile — the profile will fail to boot',
+    ])
+  })
+
+  it('accepts Node-resolvable legacy and Unicode package roots', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writePackage(dir, '_private', { name: '_private', version: '1.0.0' })
+    writePackage(dir, '@_scope/_pkg', { name: '@_scope/_pkg', version: '1.0.0' })
+    writePackage(dir, '插件', { name: '插件', version: '1.0.0' })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([{
+      insert: [
+        { id: 'private', name: '_private/runtime' },
+        { id: 'scoped-private', name: '@_scope/_pkg/runtime' },
+        { id: 'unicode', name: '插件/runtime' },
+      ],
+    }]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
+    expect(report.summary.ok).toBe(true)
+  })
+
+  it('uses the profile workspace-root fallback that is visible to the Loader', () => {
+    const profiles = join(tmp, 'profiles')
+    const dir = join(profiles, 'web')
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeLoadablePackage(profiles, 'workspace-plugin')
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      { insert: [{ id: 'workspace', name: 'workspace-plugin' }] },
+    ]))
+
+    expect(existsSync(join(dir, 'node_modules', 'workspace-plugin'))).toBe(false)
+    expect(existsSync(join(tmp, 'node_modules', 'workspace-plugin'))).toBe(false)
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
+    expect(report.summary.ok).toBe(true)
+  })
+
+  it('does not accept an install-only package that the profile Loader cannot see', () => {
+    const dir = pdir()
+    const dshInstall = join(tmp, 'dsh-install')
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeProfile(dshInstall, { name: '@deepseek-ai/dsh' })
+    writeLoadablePackage(dshInstall, '@issue205/host-only-plugin')
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      { insert: [{ id: 'host-only', name: '@issue205/host-only-plugin' }] },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: dshInstall, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader package @issue205/host-only-plugin is not installed in the profile — the profile will fail to boot',
+    ])
+  })
+
+  it('does not skip a broken nearer package directory for a healthy parent copy', () => {
+    const profiles = join(tmp, 'profiles')
+    const dir = join(profiles, 'web')
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeLoadablePackage(profiles, 'shadowed-plugin')
+    writeLoadablePackage(profiles, 'file-shadow-plugin')
+    mkdirSync(join(dir, 'node_modules', 'shadowed-plugin'), { recursive: true })
+    writeFileSync(join(dir, 'node_modules', 'file-shadow-plugin'), 'not a package directory')
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([{
+      insert: [
+        { id: 'shadowed', name: 'shadowed-plugin' },
+        { id: 'file-shadow', name: 'file-shadow-plugin' },
+      ],
+    }]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader package shadowed-plugin is not installed in the profile — the profile will fail to boot',
+    ])
+  })
+
+  it('does not check an insert skipped because its target group is missing', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      {
+        id: 'missing-group',
+        insert: [{ id: 'skipped', name: 'missing-but-never-loaded' }],
+      },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(report.rows.some(row => row.id === 'skipped')).toBe(false)
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
+    expect(report.summary.warnings).toContain(
+      'user-patch: missing-group — insert target not found',
+    )
+    expect(report.summary.ok).toBe(true)
+  })
+
+  it('checks a user package inserted into a group supplied by a bundle', () => {
+    const dir = pdir()
+    writeProfile(dir, {
+      name: 'web-profile',
+      dependencies: { 'base-bundle': '^1.0.0' },
+      dsh: { profile: { bundles: ['base-bundle'] } },
+    })
+    writeBundle(dir, 'base-bundle', '1.0.0', [
+      { insert: [{ id: 'bundle-group', name: 'cordis:group', group: true, config: [] }] },
+    ])
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      {
+        id: 'bundle-group',
+        insert: [{ id: 'user-child', name: 'missing-targeted-plugin' }],
+      },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(report.rows.find(row => row.id === 'user-child')?.layer).toBe('user-patch')
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader package missing-targeted-plugin is not installed in the profile — the profile will fail to boot',
+    ])
+  })
+
+  it('checks nested group children with the layer inherited from their patch', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      {
+        insert: [{
+          id: 'tools',
+          name: 'cordis:group',
+          group: true,
+          config: [{ id: 'nested-missing', name: 'nested-plugin' }],
+        }],
+      },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(report.rows.find(row => row.id === 'nested-missing')?.layer).toBe('user-patch')
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader package nested-plugin is not installed in the profile — the profile will fail to boot',
+    ])
+  })
+
+  it('checks the home patch and deduplicates repeated references within one layer', () => {
+    const dir = pdir()
+    const home = join(tmp, 'home')
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    mkdirSync(home, { recursive: true })
+    writeFileSync(join(home, 'cordis.patch.yml'), dump([
+      {
+        insert: [
+          { id: 'one', name: 'missing-home/runtime' },
+          { id: 'two', name: 'missing-home/worker' },
+        ],
+      },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: home })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'home-patch: loader package missing-home is not installed in the profile — the profile will fail to boot',
+    ])
+  })
+
+  it('ignores non-group rows disabled directly, by a parent, by a later layer, or by a truthy literal', () => {
+    const dir = pdir()
+    const home = join(tmp, 'home')
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    mkdirSync(home, { recursive: true })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      {
+        insert: [
+          { id: 'direct-off', name: 'missing-direct', disabled: true },
+          { id: 'truthy-off', name: 'missing-truthy', disabled: 'false' },
+          {
+            id: 'group-off',
+            name: 'cordis:group',
+            group: true,
+            disabled: true,
+            config: [{ id: 'child-off', name: 'missing-child' }],
+          },
+          { id: 'later-off', name: 'missing-later' },
+        ],
+      },
+    ]))
+    writeFileSync(join(home, 'cordis.patch.yml'), dump([
+      { id: 'later-off', disabled: true },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: home })
+
+    expect(report.rows.map(row => row.id)).toEqual([
+      'direct-off', 'truthy-off', 'group-off', 'child-off', 'later-off',
+    ])
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
+    expect(report.summary.ok).toBe(true)
+  })
+
+  it('still resolves custom group modules while their disabled state suppresses descendants', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      {
+        insert: [{
+          id: 'outer-off',
+          name: 'cordis:group',
+          group: true,
+          disabled: true,
+          config: [{
+            id: 'custom-group',
+            name: 'missing-custom-group',
+            group: true,
+            config: [{ id: 'suppressed-child', name: 'missing-child' }],
+          }],
+        }],
+      },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader package missing-custom-group is not installed in the profile — the profile will fail to boot',
+    ])
+    expect(report.summary.errors.some(line => line.includes('missing-child'))).toBe(false)
+  })
+
+  it('reports expression-gated missing modules as conditional warnings, never definite failures', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), [
+      '- insert:',
+      '  - id: maybe-plugin',
+      '    name: missing-conditional',
+      '    disabled: !!js process.platform === "win32"',
+      '',
+    ].join('\n'))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
+    expect(report.summary.warnings).toContain(
+      'user-patch: loader package missing-conditional is not installed in the profile — boot will fail if its disabled expression enables the entry',
+    )
+    expect(report.summary.ok).toBe(true)
+  })
+
+  it('reports enabled rows with a missing or empty module name', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      { insert: [{ id: 'missing-name' }, { id: 'empty-name', name: '' }] },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader entry "missing-name" has no module name — the profile will fail to boot',
+      'user-patch: loader entry "empty-name" has no module name — the profile will fail to boot',
+    ])
+  })
+
+  it('reports malformed bare specifiers instead of silently skipping them', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      {
+        insert: [
+          { id: 'scope-only', name: '@scope' },
+          { id: 'encoded', name: 'foo%bar' },
+        ],
+      },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([
+      'user-patch: loader specifier "@scope" is not a valid bare package name — the profile will fail to boot',
+      'user-patch: loader specifier "foo%bar" is not a valid bare package name — the profile will fail to boot',
+    ])
+  })
+
+  it('ignores builtins, relative or absolute modules, URLs, and names inside ordinary config', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), dump([
+      {
+        insert: [
+          { id: 'builtin', name: 'cordis:group' },
+          { id: 'node-builtin', name: 'node:path' },
+          { id: 'bare-builtin', name: 'fs/promises' },
+          { id: 'package-import', name: '#profile-plugin' },
+          { id: 'relative', name: './local-plugin.js' },
+          { id: 'absolute', name: join(dir, 'local-plugin.js') },
+          { id: 'url', name: 'file:///portable/plugin.js' },
+          {
+            id: 'configured',
+            name: 'cordis:group',
+            config: [{ name: 'ordinary-option-name' }],
+          },
+        ],
+      },
+    ]))
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
+    expect(report.summary.ok).toBe(true)
+  })
+
+  it('reports a malformed patch once without inventing a missing package', () => {
+    const dir = pdir()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    writeFileSync(join(dir, 'cordis.patch.yml'), '- insert: [unterminated')
+
+    const report = analyzeProfile(dir, { dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+    expect(report.summary.errors).toEqual([
+      'user-patch: patch file is not a valid entry list',
+    ])
+    expect(resolutionErrors(report.summary.errors)).toEqual([])
   })
 })
 


### PR DESCRIPTION
承 #318（@Jstn-1g），取净 diff 重放到当前 main，逻辑未改。

方向上认可两点：只查包根存在性而不解析 exports/子路径（宁可漏报不误报）；表达式门控的行只报 warning 不报 error。刚修完 #317 的假警告，这个分寸很重要。

941 测试全过。