### PR TITLE
fix: a plugin the user wired up themselves is not a failed install

### DIFF
--- a/src/verify.ts
+++ b/src/verify.ts
@@ -28,6 +28,7 @@ import { readFileSync } from 'node:fs'
 import { Script } from 'node:vm'
 import { join } from 'node:path'
 import { listHotMounts, parseSimplePatch } from './hot.ts'
+import { userPatchPackageReferences } from './patch.ts'
 import { bundlePatchInsertedIds, hasDshManifest, hasLoadableEntry, profileDir, readInstalled } from './profile.ts'
 
 export type ActivationState = 'live' | 'restart' | 'inert' | 'broken' | 'missing' | 'disabled'
@@ -124,6 +125,25 @@ function patchTextOf(profile: string, name: string, explicitDir?: string): strin
  * @param live - names live in the current composition; defaults to the
  * market's hot-mount table (injectable for tests).
  */
+/**
+ * Whether the profile's OWN `cordis.patch.yml` inserts this package by name.
+ *
+ * A third evidence source beside the loader inventory and the package's own
+ * manifest, and the one that was missing (#165): a plugin the user wired up
+ * themselves declares nothing, is not hot-mounted until the next boot, and so
+ * fell through to `broken` — the market told them the install had failed
+ * verification while the plugin was, in fact, working.
+ *
+ * Read with the same parser the uninstall guard uses. Unreadable returns
+ * null, which is treated here as NO evidence rather than as evidence: this
+ * only ever upgrades a verdict away from `broken`, so being unsure has to
+ * leave the stricter answer standing.
+ */
+function patchLoads(activeProfileDir: string, name: string): boolean {
+  const references = userPatchPackageReferences(join(activeProfileDir, 'cordis.patch.yml'), name)
+  return references !== null && references.length > 0
+}
+
 export function verifyActivation(
   profile: string,
   name: string,
@@ -172,10 +192,18 @@ export function verifyActivation(
     // Not live and no dsh surface: for a package the profile lists as a
     // BUNDLE this is a real defect; for a plain dependency it is normal —
     // most dependencies are libraries, not plugins (#135).
+    if (inBundles && !patchLoads(activeProfileDir, name)) {
+      return {
+        state: 'broken',
+        reasons: ['已列入 profile bundle 层但未声明 dsh 元数据,加载会失败 / listed in the profile bundle layer but declares no dsh metadata — loading it fails'],
+        bundle: true,
+        hot: false,
+      }
+    }
     return inBundles
       ? {
-          state: 'broken',
-          reasons: ['已列入 profile bundle 层但未声明 dsh 元数据,加载会失败 / listed in the profile bundle layer but declares no dsh metadata — loading it fails'],
+          state: 'restart',
+          reasons: ['由你自己的 cordis.patch.yml 按名加载,重启后生效 / loaded by name from your own cordis.patch.yml — live after a restart'],
           bundle: true,
           hot: false,
         }
@@ -189,7 +217,7 @@ export function verifyActivation(
   // Carrier bundles (#103) ship no entry of their own — what they mount is
   // the point — so judge by "is anything loadable", not by this package's
   // own artifact.
-  if (!loaderLive && !hasLoadableEntry(activeProfileDir, name)) {
+  if (!loaderLive && !hasLoadableEntry(activeProfileDir, name) && !patchLoads(activeProfileDir, name)) {
     return {
       state: 'broken',
       reasons: [

--- a/tests/verify.spec.ts
+++ b/tests/verify.spec.ts
@@ -56,6 +56,39 @@ describe('verifyActivation (P0-2)', () => {
     expect(verifyActivation('web', 'client-a', new Set(['client-a']))).toMatchObject({ state: 'live', hot: true, bundle: false })
   })
 
+  /** #165: a plugin the user wired into their OWN cordis.patch.yml declares
+   * nothing, is not hot-mounted until the next boot, and so read as `broken`
+   * — the market said the install failed verification while the plugin was
+   * working. The profile's patch is a third evidence source beside the loader
+   * inventory and the package's own manifest. */
+  it('reads a package the user own patch loads as restart, not broken', () => {
+    const dir = profile(['@vincent-guo/dsh-web-search-openai'])
+    pkg('@vincent-guo/dsh-web-search-openai', { main: 'index.js' }, { 'index.js': '' })
+    // Without the patch it is what it looks like: bundled, no dsh metadata.
+    expect(verifyActivation('web', '@vincent-guo/dsh-web-search-openai', new Set()))
+      .toMatchObject({ state: 'broken' })
+
+    writeFileSync(
+      join(dir, 'cordis.patch.yml'),
+      '- insert:\n    - id: mine\n      name: "@vincent-guo/dsh-web-search-openai"\n',
+    )
+    expect(verifyActivation('web', '@vincent-guo/dsh-web-search-openai', new Set()))
+      .toMatchObject({ state: 'restart', bundle: true })
+  })
+
+  it('does not let an unrelated or unreadable patch soften a real defect', () => {
+    const dir = profile(['dsh-broken'])
+    pkg('dsh-broken', { main: 'index.js' }, { 'index.js': '' })
+    // Names a DIFFERENT package: no evidence about this one.
+    writeFileSync(join(dir, 'cordis.patch.yml'), '- insert:\n    - id: other\n      name: somebody-else\n')
+    expect(verifyActivation('web', 'dsh-broken', new Set())).toMatchObject({ state: 'broken' })
+
+    // Unparseable: unsure has to leave the stricter verdict standing, since
+    // this evidence only ever moves a verdict AWAY from broken.
+    writeFileSync(join(dir, 'cordis.patch.yml'), '- insert:\n    - id: broken\n      name: [\n')
+    expect(verifyActivation('web', 'dsh-broken', new Set())).toMatchObject({ state: 'broken' })
+  })
+
   it('disabled when the user switched it off — never "restart to apply"', () => {
     profile(['dsh-loop'])
     pkg('dsh-loop', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'index.js' }, { 'index.js': '', 'cordis.patch.yml': SIMPLE_PATCH })


### PR DESCRIPTION
#165 的另一半（卸载那半已随 1.27.0 发布）。

激活判定原本只有两个证据源——loader 清单、包自己的声明——而用户手工在 profile 的 `cordis.patch.yml` 里接起来的插件两个都没有，于是落进 `broken`。第三个证据源就是 profile 自己的 patch，之前没人读它。

读取用的是 @Jstn-1g 上个版本为卸载守卫写的那个真 YAML 解析（不是我当初担心的逐行扫描）。这个证据**只会把判定从 broken 往回搬**，所以解析不出来时按"无证据"处理——不确定时必须让更严格的结论站住。

954 测试全过。