### PR TITLE
docs: add DSH App to Friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ DSHM_REGISTRY_URL=https://your-mirror.example/plugins.json dsh web
 
 [modlens](https://github.com/liustack/modlens) — the first vision plugin for DeepSeek Harness: bolts visual understanding onto text-only models like DeepSeek and GLM. Paste an image, get structured JSON evidence back — OCR, layout, semantics. Available right in this market:
 
+### DSH App
+
+[DSH App](https://github.com/RyensX/dsh-app) - DSH App is a lightweight, stable, and easy-to-use deepseek-harness desktop client, developed based on Tauri2.
+
 ```sh
 dsh plugin --profile web add @liustack/modlens
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -114,6 +114,10 @@ DSHM_REGISTRY_URL=https://your-mirror.example/plugins.json dsh web
 
 [modlens](https://github.com/liustack/modlens)——全网第一个 DeepSeek Harness 视觉插件，为 DeepSeek、GLM 等纯文本模型外挂视觉能力，粘贴图片即得结构化 JSON 证据（OCR、版面、语义）。本市场内即可直接安装：
 
+### DSH App
+
+[DSH App](https://github.com/RyensX/dsh-app)——DSH App 是轻量、稳定、易用的deepseek-harness 桌面客户端， 基于Tauri2开发。
+
 ```sh
 dsh plugin --profile web add @liustack/modlens
 ```


### PR DESCRIPTION
Add [DSH App](https://github.com/RyensX/dsh-app) to the Friends

DSH App 是轻量、稳定、易用的deepseek-harness 桌面客户端， 基于Tauri2开发。/  DSH App is a lightweight, stable, and easy-to-use deepseek-harness desktop client, developed based on Tauri2.

DSH App不会对dsh做任何修改，也不会要求插件做任何适配，对dsh 100%适配。/ The DSH App will not make any modifications to dsh, nor will it require any plugins to adapt; it is 100% compatible with dsh.