### PR TITLE
fix: roll back the bundle row too, not just the dependency

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -7,6 +7,7 @@
 import { existsSync, readdirSync, readFileSync, realpathSync, renameSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { isDeepStrictEqual } from 'node:util'
 import { githubRemoteIdentities, githubRepoIdentities } from './sources.ts'
 
 /**
@@ -84,38 +85,125 @@ export function readManifestDeps(profile: string, explicitDir?: string): Record<
   }
 }
 
+/** Exact rollback state owned by one profile package operation. */
+export interface ProfileManifestSnapshot {
+  dependencies: Record<string, string>
+  profileBundles: { present: false } | { present: true; value: unknown }
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+/** Read dependencies and the exact `dsh.profile.bundles` field before a package operation. */
+export function readProfileManifestSnapshot(profile: string, explicitDir?: string): ProfileManifestSnapshot {
+  try {
+    const manifest = JSON.parse(readFileSync(join(profileDir(profile, explicitDir), 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+      dsh?: { profile?: unknown }
+    }
+    const profileManifest = objectRecord(manifest.dsh?.profile)
+    const present = profileManifest !== undefined && Object.hasOwn(profileManifest, 'bundles')
+    return {
+      dependencies: { ...manifest.dependencies },
+      profileBundles: present
+        ? { present: true, value: structuredClone(profileManifest.bundles) }
+        : { present: false },
+    }
+  } catch {
+    return { dependencies: {}, profileBundles: { present: false } }
+  }
+}
+
+/** String package names carried by one valid bundle-list value. */
+function bundleNames(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((name): name is string => typeof name === 'string') : []
+}
+
 /**
- * Restore the profile manifest's dependency map to a pre-operation snapshot,
- * leaving every other manifest field untouched. pnpm writes package.json
- * BEFORE it finishes installing (#65, #69: a 404/blocked-build failure lands
- * after the write), so a failed add leaves ghost dependencies that break
- * every later pnpm run — and pnpm itself can no longer remove them (the same
- * failure re-fires on any mutation). Direct manifest surgery is the only
- * reliable rollback; the lockfile is left as-is (pnpm reconciles it from the
- * manifest on the next run).
+ * Restore the profile manifest fields a package operation may mutate:
+ * `dependencies` and `dsh.profile.bundles`. pnpm and `dsh plugin add` can
+ * write both before a later fetch or build-script failure (#65, #69, #339),
+ * leaving either an unresolvable dependency or a bundle the next boot cannot
+ * activate. Every unrelated manifest field remains untouched. The lockfile is
+ * left as-is; pnpm reconciles it from the manifest on the next run.
+ *
+ * The write is atomic because rollback runs after another operation already
+ * failed; a partial repair must not turn a valid profile into invalid JSON.
  * @returns names whose entries were dropped or reverted, empty when nothing changed.
  */
-export function restoreManifestDeps(profile: string, snapshot: Record<string, string>, explicitDir?: string): string[] {
+export function restoreProfileManifest(
+  profile: string,
+  snapshot: ProfileManifestSnapshot,
+  explicitDir?: string,
+): string[] {
   const file = join(profileDir(profile, explicitDir), 'package.json')
-  let manifest: { dependencies?: Record<string, string> }
+  let manifest: {
+    dependencies?: Record<string, string>
+    dsh?: unknown
+  }
   try {
-    manifest = JSON.parse(readFileSync(file, 'utf8')) as { dependencies?: Record<string, string> }
+    manifest = JSON.parse(readFileSync(file, 'utf8')) as typeof manifest
   } catch {
     return []
   }
   const current = manifest.dependencies ?? {}
   const touched = new Set<string>()
-  for (const name of Object.keys(current)) if (current[name] !== snapshot[name]) touched.add(name)
-  for (const name of Object.keys(snapshot)) if (current[name] !== snapshot[name]) touched.add(name)
+  for (const name of Object.keys(current)) {
+    if (current[name] !== snapshot.dependencies[name]) touched.add(name)
+  }
+  for (const name of Object.keys(snapshot.dependencies)) {
+    if (current[name] !== snapshot.dependencies[name]) touched.add(name)
+  }
+
+  const currentDsh = objectRecord(manifest.dsh)
+  const currentProfile = objectRecord(currentDsh?.profile)
+  const currentBundles = currentProfile !== undefined && Object.hasOwn(currentProfile, 'bundles')
+    ? { present: true as const, value: currentProfile.bundles }
+    : { present: false as const }
+  const bundlesChanged = currentBundles.present !== snapshot.profileBundles.present
+    || (currentBundles.present && snapshot.profileBundles.present
+      && !isDeepStrictEqual(currentBundles.value, snapshot.profileBundles.value))
+  if (bundlesChanged) {
+    const currentNames = new Set(currentBundles.present ? bundleNames(currentBundles.value) : [])
+    const snapshotNames = new Set(snapshot.profileBundles.present ? bundleNames(snapshot.profileBundles.value) : [])
+    let namedBundleChange = false
+    for (const name of currentNames) {
+      if (!snapshotNames.has(name)) {
+        touched.add(name)
+        namedBundleChange = true
+      }
+    }
+    for (const name of snapshotNames) {
+      if (!currentNames.has(name)) {
+        touched.add(name)
+        namedBundleChange = true
+      }
+    }
+    // Presence, order, duplicates, or a malformed non-array value can differ
+    // without changing the set of package names. Still report that rollback.
+    if (!namedBundleChange) touched.add('dsh.profile.bundles')
+  }
   if (touched.size === 0) return []
-  manifest.dependencies = { ...snapshot }
-  writeFileSync(file, `${JSON.stringify(manifest, null, 2)}\n`)
+  manifest.dependencies = { ...snapshot.dependencies }
+  if (snapshot.profileBundles.present) {
+    const dsh = currentDsh ?? {}
+    const profileManifest = currentProfile ?? {}
+    manifest.dsh = dsh
+    dsh.profile = profileManifest
+    profileManifest.bundles = structuredClone(snapshot.profileBundles.value)
+  } else if (currentProfile !== undefined) {
+    delete currentProfile.bundles
+  }
+  writeManifestAtomic(file, manifest)
   return [...touched]
 }
 
 /**
  * Remove a package from BOTH manifest lists — dependencies and
- * dsh.profile.bundles. The uninstall counterpart of restoreManifestDeps:
+ * dsh.profile.bundles. The uninstall counterpart of restoreProfileManifest:
  * pnpm can fail a remove after deleting node_modules but before saving
  * package.json (the #65 write-order's mirror image — a file locked mid-
  * unlink aborts the run), leaving the manifest pointing at a package that
@@ -123,10 +211,8 @@ export function restoreManifestDeps(profile: string, snapshot: Record<string, st
  * dependency. When disk truth says the package is gone, this finishes the
  * removal the CLI could not. Every other manifest field is untouched.
  *
- * Written atomically, unlike restoreManifestDeps above. This one runs only
- * after something already went wrong mid-uninstall, so it is the worst place
- * in the codebase to leave a half-written package.json: the profile would go
- * from "one ghost dependency" to "will not parse".
+ * Written atomically because it runs only after something already went wrong
+ * mid-uninstall, so it is the worst place to leave a half-written manifest.
  * @returns true when either list still mentioned the package.
  */
 export function dropFromManifest(profile: string, name: string, explicitDir?: string): boolean {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -23,7 +23,7 @@ import {
   BOOT_ID, cancelActive, probePnpm, progress, provisionPnpm, runDshPlugin,
   type PluginCommandRuntime,
 } from './dsh-cli.ts'
-import { addProfileBundle, dropFromManifest, hasLoadableEntry, INBOX_BUNDLES, isDshProfileName, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readManifestDeps, readProfileBundles, removeProfileBundle, restoreManifestDeps, setAllowBuilds } from './profile.ts'
+import { addProfileBundle, dropFromManifest, hasLoadableEntry, INBOX_BUNDLES, isDshProfileName, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readProfileBundles, readProfileManifestSnapshot, removeProfileBundle, restoreProfileManifest, setAllowBuilds, type ProfileManifestSnapshot } from './profile.ts'
 import { assessProfile, classifyPeer, introducedDuplicateNames, introducedRisks, type CompatibilityRisk } from './compatibility.ts'
 import { runningAgentIds, type AgentsLookup } from './agents.ts'
 import { analyzeProfile, type DuplicateName } from './check.ts'
@@ -462,8 +462,8 @@ export function mountMarketRoutes(
    * next start still fails. Re-run pnpm install against the restored
    * manifest to rematerialize the previous build's files.
    */
-  async function rollbackUpdateBuild(name: string, manifestBefore: Record<string, string>): Promise<{ ok: boolean; detail: string | null }> {
-    const rolledBack = restoreManifestDeps(config.profile, manifestBefore, activeProfileDir)
+  async function rollbackUpdateBuild(name: string, manifestBefore: ProfileManifestSnapshot): Promise<{ ok: boolean; detail: string | null }> {
+    const rolledBack = restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
     if (rolledBack.length === 0) return { ok: true, detail: null }
     // CI=true (the market always runs pnpm that way) turns frozen-lockfile
     // on, and the restored manifest pin now disagrees with the lockfile the
@@ -483,7 +483,7 @@ export function mountMarketRoutes(
     id: string
     kind: 'update' | 'install'
     names: string[]
-    manifestBefore?: Record<string, string>
+    manifestBefore?: ProfileManifestSnapshot
     /** github: updates must re-add the pre-update commit, not just reinstall. */
     gitTarget?: string
     beforeCommit?: string | null
@@ -501,14 +501,14 @@ export function mountMarketRoutes(
   /** Restore a github: update by re-adding the commit captured before the update. */
   async function rollbackGitBuild(
     name: string,
-    manifestBefore: Record<string, string>,
+    manifestBefore: ProfileManifestSnapshot,
     target: string,
     beforeCommit: string | null,
   ): Promise<{ ok: boolean; detail: string | null }> {
     if (beforeCommit === null) {
       return { ok: false, detail: 'the previous commit is unknown; nothing to roll back to' }
     }
-    restoreManifestDeps(config.profile, manifestBefore, activeProfileDir)
+    restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
     const add = await runPlugin(config.profile, ['add', RELEASE_AGE_OVERRIDE, `${target}#${beforeCommit}`])
     if (add.exitCode !== 0 || add.timedOut || add.cancelled) {
       return { ok: false, detail: failureDetail(add) }
@@ -516,7 +516,7 @@ export function mountMarketRoutes(
     // pnpm wrote a commit-pinned spec; the profile's durable spec must stay
     // the original `github:owner/repo` form. The lockfile keeps the restored
     // commit resolution for the next boot.
-    restoreManifestDeps(config.profile, manifestBefore, activeProfileDir)
+    restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
     logEvent('info', 'update-rollback', `${name}: restored github build at ${beforeCommit}`)
     return { ok: true, detail: null }
   }
@@ -1722,9 +1722,9 @@ export function mountMarketRoutes(
             // force: the user chose to install a fresh release without the
             // default one-day safety wait; scoped to this single command.
             const addArgs = force ? ['add', RELEASE_AGE_OVERRIDE, target] : ['add', target]
-            // RAW manifest snapshot for failure rollback (#65) — pnpm writes
-            // package.json before it finishes, so a hard-failed add leaves
-            // ghost/bumped entries that break every later pnpm run.
+            // Exact manifest snapshot for failure rollback (#65, #339) — the
+            // host can write dependencies AND dsh.profile.bundles before a
+            // hard-failed add, leaving residue that breaks the next boot.
             pendingRollbacks.clear()
             const compatibilityBefore = assessProfile(config.profile, activeProfileDir)
             // pnpm re-extracts the whole tree on any operation, so a plugin
@@ -1733,11 +1733,11 @@ export function mountMarketRoutes(
             // broke is attributable to it, so the profile is swept before as
             // well as after.
             const bundlesBefore = brokenClientBundles(config.profile, activeProfileDir)
-            const manifestBefore = readManifestDeps(config.profile, activeProfileDir)
+            const manifestBefore = readProfileManifestSnapshot(config.profile, activeProfileDir)
             const result = await runPlugin(config.profile, addArgs)
             const cancelled = result.cancelled
             if ((result.exitCode !== 0 || result.timedOut) && !cancelled) {
-              const rolledBack = restoreManifestDeps(config.profile, manifestBefore, activeProfileDir)
+              const rolledBack = restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
               if (rolledBack.length > 0) logEvent('warn', 'update', `${name}: rolled back manifest residue of the failed run: ${rolledBack.join(', ')}`)
             }
             let ok = result.exitCode === 0 && !result.timedOut && !cancelled
@@ -2681,16 +2681,17 @@ export function mountMarketRoutes(
             // broke is attributable to it, so the profile is swept before as
             // well as after.
             const bundlesBefore = brokenClientBundles(config.profile, activeProfileDir)
-            // RAW manifest snapshot for failure rollback (#65): pnpm writes
-            // package.json before the build-script check / registry fetches
-            // run, so a hard-failed add leaves ghost dependencies that break
-            // every later pnpm run — of anything. Cancelled runs keep their
-            // partial state on purpose (the user sees the diff and decides).
-            const manifestBefore = readManifestDeps(config.profile, activeProfileDir)
+            // Exact manifest snapshot for failure rollback (#65, #339): the
+            // host writes dependencies and dsh.profile.bundles before the
+            // build-script check / registry fetches run. Either residue can
+            // break every later operation or the next boot. Cancelled runs
+            // keep their partial state on purpose (the user sees the diff
+            // and decides).
+            const manifestBefore = readProfileManifestSnapshot(config.profile, activeProfileDir)
             const result = await runPlugin(config.profile, ['add', target])
             const cancelled = result.cancelled
             if ((result.exitCode !== 0 || result.timedOut) && !cancelled) {
-              const rolledBack = restoreManifestDeps(config.profile, manifestBefore, activeProfileDir)
+              const rolledBack = restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
               if (rolledBack.length > 0) logEvent('warn', 'install', `${target}: rolled back manifest residue of the failed run: ${rolledBack.join(', ')}`)
             }
             let ok = result.exitCode === 0 && !result.timedOut && !cancelled

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -67,6 +67,8 @@ const fake = vi.hoisted(() => ({
    * is written before registry fetches and the build-script check run.
    */
   failAfterWriteStderrOnce: '',
+  /** Simulate dsh adding a profile bundle before that same add later fails (#339). */
+  profileBundleOnNextAdd: null as string | null,
   /** Make restore's bulk install fail so its per-plugin fallback is exercised. */
   failInstallOnce: false,
   captureBundlesOnNextAdd: false,
@@ -91,7 +93,10 @@ vi.mock('../src/dsh-cli.ts', () => {
       writeFileSync(join(root, rel), artifactContents[rel] ?? '')
     }
   }
-  function readManifest(): { dependencies?: Record<string, string> } {
+  function readManifest(): {
+    dependencies?: Record<string, string>
+    dsh?: { profile?: { bundles?: string[] } }
+  } {
     return JSON.parse(readFileSync(join(fake.profileDir, 'package.json'), 'utf8'))
   }
   function writeLockCommit(repo: string, commit: string): void {
@@ -105,6 +110,14 @@ vi.mock('../src/dsh-cli.ts', () => {
   function writeDep(name: string, spec: string): void {
     const manifest = readManifest()
     manifest.dependencies = { ...manifest.dependencies, [name]: spec }
+    writeFileSync(join(fake.profileDir, 'package.json'), JSON.stringify(manifest))
+  }
+  function appendProfileBundle(name: string): void {
+    const manifest = readManifest()
+    manifest.dsh ??= {}
+    manifest.dsh.profile ??= {}
+    const bundles = manifest.dsh.profile.bundles ?? []
+    if (!bundles.includes(name)) manifest.dsh.profile.bundles = [...bundles, name]
     writeFileSync(join(fake.profileDir, 'package.json'), JSON.stringify(manifest))
   }
   function removeDep(name: string): void {
@@ -198,6 +211,19 @@ vi.mock('../src/dsh-cli.ts', () => {
       writePkg(repo.name, def?.manifest ?? repo.manifest, def?.artifacts ?? repo.artifacts)
       const nextCommit = commit ?? repo.lockCommit
       if (nextCommit !== undefined) writeLockCommit(repoKey.replace(/^github:/, ''), nextCommit)
+      // `dsh plugin add` writes the bundle row on this path too — that is
+      // where #339 came from, a github-sourced install whose build was
+      // blocked. Consuming the flag only in the npm branch below let the
+      // regression test pass without ever creating the orphan it asserts on.
+      if (fake.profileBundleOnNextAdd !== null) {
+        appendProfileBundle(fake.profileBundleOnNextAdd)
+        fake.profileBundleOnNextAdd = null
+      }
+      if (fake.failAfterWriteStderrOnce !== '') {
+        const stderr = fake.failAfterWriteStderrOnce
+        fake.failAfterWriteStderrOnce = ''
+        return { exitCode: 1, timedOut: false, stdout: '', stderr, cancelled: false }
+      }
       for (const child of repo.junkChildren ?? []) {
         mkdirSync(join(fake.profileDir, 'node_modules', repo.name, child), { recursive: true })
         writeFileSync(join(fake.profileDir, 'node_modules', repo.name, child, 'package.json'), '{"dsh":{}}')
@@ -224,6 +250,10 @@ vi.mock('../src/dsh-cli.ts', () => {
     const version = pkg.latest
     writeDep(name, `^${version}`)
     writePkg(name, { version, ...(pkg.versions[version].manifest as object) }, pkg.versions[version].artifacts, pkg.versions[version].artifactContents)
+    if (fake.profileBundleOnNextAdd !== null) {
+      appendProfileBundle(fake.profileBundleOnNextAdd)
+      fake.profileBundleOnNextAdd = null
+    }
     if (fake.failAfterWriteStderrOnce !== '') {
       const stderr = fake.failAfterWriteStderrOnce
       fake.failAfterWriteStderrOnce = ''
@@ -438,6 +468,7 @@ beforeEach(() => {
   fake.buildScriptOutputOnce = ''
   fake.failNextAddStderrOnce = ''
   fake.failAfterWriteStderrOnce = ''
+  fake.profileBundleOnNextAdd = null
   fake.failInstallOnce = false
   fake.captureBundlesOnNextAdd = false
   fake.bundlesBeforeFallbackAdd = null
@@ -845,13 +876,18 @@ describe('install flow', () => {
     const ghostPath = join(profileDir('web'), 'package.json')
     const ghosted = JSON.parse(readFileSync(ghostPath, 'utf8'))
     ghosted.dependencies = { ...ghosted.dependencies, '@deepseek-ai/dsh-client-ui-theme-toggle': '^1.0.0' }
+    ghosted.dsh = { profile: { bundles: ['@deepseek-ai/dsh-base'] } }
     writeFileSync(ghostPath, JSON.stringify(ghosted))
+    fake.profileBundleOnNextAdd = 'dsh-loop'
     fake.failAfterWriteStderrOnce = '[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/@deepseek-ai%2Fdsh-client-ui-theme-toggle: Not Found - 404'
     const r = await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
     expect(r.status).toBe(502)
     // The failed run's manifest write is rolled back — no ghost entry left
     // to break every later pnpm operation.
     expect(installedSpec('dsh-loop')).toBeUndefined()
+    expect(installedSpec('@deepseek-ai/dsh-client-ui-theme-toggle')).toBe('^1.0.0')
+    const rolledBackManifest = JSON.parse(readFileSync(ghostPath, 'utf8'))
+    expect(rolledBackManifest.dsh.profile.bundles).toEqual(['@deepseek-ai/dsh-base'])
     // The classification names the unresolvable package, decoded.
     expect(String(r.json.stderr)).toContain('@deepseek-ai/dsh-client-ui-theme-toggle')
     expect(String(r.json.stderr)).toContain('幽灵依赖')

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -303,30 +303,71 @@ describe('manifest rollback (#65)', () => {
     expect(readManifestDeps('web')).toEqual({ 'dsh-loop': '^1.0.0', '@deepseek-ai/dsh-base': 'latest' })
   })
 
-  it('restoreManifestDeps drops ghost entries and reverts bumped specs, preserving other fields', async () => {
-    const { readManifestDeps, restoreManifestDeps } = await import('../src/profile.ts')
+  it('restoreProfileManifest drops ghost entries from both manifest lists and preserves other fields', async () => {
+    const { readProfileManifestSnapshot, restoreProfileManifest } = await import('../src/profile.ts')
     const dir = writeProfile({
       name: 'web-profile',
-      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dsh-loop'], mode: 'manual' } },
       dependencies: { 'dsh-loop': '^1.0.0', '@deepseek-ai/dsh-base': 'latest' },
     })
-    const snapshot = readManifestDeps('web')
-    // Simulate pnpm's partial write of a failed run: a ghost dep appears
-    // and an existing pin is bumped.
+    const snapshot = readProfileManifestSnapshot('web')
+    // Simulate the host's partial write of a failed run: a ghost dep and
+    // bundle appear, and an existing pin is bumped. An unrelated field also
+    // changes after the snapshot and must not be rolled back.
     writeFileSync(join(dir, 'package.json'), JSON.stringify({
       name: 'web-profile',
-      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dsh-loop', 'ghost-pkg'], mode: 'manual', future: true } },
       dependencies: { 'dsh-loop': '^1.2.0', '@deepseek-ai/dsh-base': 'latest', 'ghost-pkg': '0.1.0-rc.6' },
     }))
-    const rolledBack = restoreManifestDeps('web', snapshot)
+    const rolledBack = restoreProfileManifest('web', snapshot)
     expect(rolledBack.sort()).toEqual(['dsh-loop', 'ghost-pkg'])
     const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
     expect(manifest.dependencies).toEqual({ 'dsh-loop': '^1.0.0', '@deepseek-ai/dsh-base': 'latest' })
-    // The in-box bundle survived, and non-dependency fields are untouched.
-    expect(manifest.dsh).toEqual({ profile: { bundles: ['@deepseek-ai/dsh-base'] } })
+    expect(manifest.dsh).toEqual({
+      profile: {
+        bundles: ['@deepseek-ai/dsh-base', 'dsh-loop'],
+        mode: 'manual',
+        future: true,
+      },
+    })
     expect(manifest.name).toBe('web-profile')
     // A second restore is a no-op.
-    expect(restoreManifestDeps('web', snapshot)).toEqual([])
+    expect(restoreProfileManifest('web', snapshot)).toEqual([])
+  })
+
+  it('restoreProfileManifest removes a newly-created bundle field without deleting its parent objects', async () => {
+    const { readProfileManifestSnapshot, restoreProfileManifest } = await import('../src/profile.ts')
+    const dir = writeProfile({ name: 'web-profile', dsh: { profile: { mode: 'manual' } }, dependencies: {} })
+    const snapshot = readProfileManifestSnapshot('web')
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dsh: { profile: { mode: 'manual', bundles: ['ghost-pkg'] } },
+      dependencies: {},
+    }))
+
+    expect(restoreProfileManifest('web', snapshot)).toEqual(['ghost-pkg'])
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    expect(manifest.dsh).toEqual({ profile: { mode: 'manual' } })
+  })
+
+  it('still snapshots dependencies when a parseable profile field is malformed', async () => {
+    const { readProfileManifestSnapshot, restoreProfileManifest } = await import('../src/profile.ts')
+    const dir = writeProfile({
+      name: 'web-profile',
+      dsh: { profile: null },
+      dependencies: { 'kept-pkg': '^1.0.0' },
+    })
+    const snapshot = readProfileManifestSnapshot('web')
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: 'web-profile',
+      dsh: { profile: null },
+      dependencies: { 'kept-pkg': '^1.0.0', 'ghost-pkg': '^2.0.0' },
+    }))
+
+    expect(restoreProfileManifest('web', snapshot)).toEqual(['ghost-pkg'])
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    expect(manifest.dependencies).toEqual({ 'kept-pkg': '^1.0.0' })
+    expect(manifest.dsh).toEqual({ profile: null })
   })
 })
 


### PR DESCRIPTION
承 #344（@Jstn-1g），修 #339（@disheno 报告，@Astro-Han 与 @yuta2 分别独立定位）。**这是会让 dsh 起不来的 bug**，优先发。

回滚快照原来只有 `{ ...manifest.dependencies }`，而失败的 `dsh plugin add` 两个字段都写了；`resolveBundleDir` 恰恰只读 bundles，于是下次启动崩，而崩溃与操作之间隔着一次重启，导出日志永远是空的。

**我修了那条回归测试**——它原本两种情况都通过：设了 fake 的 bundle 写入标志，却从 github 分支装，而那条分支提前 return，孤行从未产生。改掉之后反向验证过：关掉恢复逻辑，manifest 里留下 `dsh-loop`，测试变红。

957 测试全过。