### PR TITLE
docs: add DSH App to Friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ DSHM_REGISTRY_URL=https://your-mirror.example/plugins.json dsh web
 
 [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) — an Electron desktop app for DeepSeek Harness built around the idea that everything is a plugin, including the desktop itself: profile switching, a bundled Node and pnpm, and a recoverable install path that snapshots the profile before a change. [dshdesktop.cn](https://dshdesktop.cn)
 
+### DSH App
+
+[dsh-app](https://github.com/RyensX/dsh-app) — a DeepSeek Harness desktop client built on Tauri 2 rather than Electron, so it ships a much smaller binary and uses the system webview. AGPL-3.0.
+
 ### DSH Get
 
 [DSH Get](https://www.dshget.com/) — a searchable web directory for discovering DeepSeek Harness plugins: category filters, bilingual descriptions, install commands and per-plugin detail pages. Its normalized catalog snapshot is public at [bobby-sheng/dshget-data](https://github.com/bobby-sheng/dshget-data).

--- a/README.zh.md
+++ b/README.zh.md
@@ -106,6 +106,10 @@ DSHM_REGISTRY_URL=https://your-mirror.example/plugins.json dsh web
 
 [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop)——基于 Electron 的 DeepSeek Harness 桌面客户端，理念是「万物皆插件，桌面本身也是插件」：支持 profile 切换、内置 Node 与 pnpm，安装前会先给 profile 拍快照以便回滚。[dshdesktop.cn](https://dshdesktop.cn)
 
+### DSH App
+
+[dsh-app](https://github.com/RyensX/dsh-app)——基于 Tauri 2（而非 Electron）的 DeepSeek Harness 桌面客户端，因此安装包小得多，界面走系统 webview。AGPL-3.0。
+
 ### DSH Get
 
 [DSH Get](https://www.dshget.com/)——DeepSeek Harness 插件的网页检索目录：分类筛选、中英描述、安装命令与插件详情页；其规范化的目录快照公开在 [bobby-sheng/dshget-data](https://github.com/bobby-sheng/dshget-data)。


### PR DESCRIPTION
承 #338（@RyensX）。文案改写过：原文是"轻量、稳定、易用"——作者自评的形容词，读者无从核实，而这个列表里其他条目都是在说这东西**做什么**。

改成可核实且真正有区分度的一条：基于 Tauri 2 而非 Electron，所以安装包小得多、走系统 webview。这才是有人会在已列的三个 Electron 客户端之外选它的理由。

"100% 适配、不要求插件做任何适配"那句没有采用——可能是真的，但这个列表不该替一个没人验证过的兼容性承诺背书。