### PR TITLE
fix: check a github plugin for updates without spending REST quota

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dshmarket",
-  "version": "1.29.3",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dshmarket",
-      "version": "1.29.3",
+      "version": "1.30.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dshmarket",
   "description": "Visual plugin market inside DeepSeek Harness — browse, search, and one-click install community plugins. · DSH 可视化插件市场：逛一逛，点一下，装好。",
-  "version": "1.29.3",
+  "version": "1.30.0",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -5,7 +5,9 @@
  */
 
 import { DIST_TAG, type Channel } from './channels.ts'
+import { headCommit } from './accelerate.ts'
 import { marketFetch } from './net.ts'
+import { activeRegion, routesFor } from './regions.ts'
 import { profileDir, readInstalled, readInstalledVersion, readLockCommits } from './profile.ts'
 import { repoOfTarget } from './sources.ts'
 
@@ -279,8 +281,14 @@ export async function checkUpdates(
         // exact thing that was fetched, with no lookup in between.
         const pinned = /codeload\.github\.com\/[^/\s]+\/[^/\s]+\/tar\.gz\/([0-9a-f]{40})/.exec(spec)
         const current = pinned?.[1] ?? lockCommits.get(repo) ?? null
-        const head = (await fetchJson(`https://api.github.com/repos/${repo}/commits/HEAD`)) as { sha?: string }
-        const latest = typeof head.sha === 'string' ? head.sha : null
+        // git's own ref advertisement, NOT api.github.com/repos/…/commits.
+        // The REST API allows 60 requests an hour per IP unauthenticated,
+        // shared across every plugin AND every check — a handful of
+        // github-installed plugins exhausts it and the whole list silently
+        // stops reporting updates (#349). The ref endpoint git itself uses
+        // has no such quota; this is the same call `acceleratedTarget`
+        // already makes to resolve a commit for the China region.
+        const latest = await headCommit(repo, routesFor(activeRegion()).githubProxy)
         result[name] = {
           kind: 'github', version, current, latest,
           updateAvailable: current !== null && latest !== null && current !== latest,

--- a/tests/updates.spec.ts
+++ b/tests/updates.spec.ts
@@ -113,8 +113,18 @@ describe('checkUpdates — github pins', () => {
 
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'dshm-updhome-'))
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true, status: 200, json: async () => ({ sha: HEAD }),
+    // The github branch reads git's own ref advertisement rather than the
+    // REST API, whose 60/hour unauthenticated quota is shared across every
+    // plugin and every check (#349). The stub answers in that wire format —
+    // `<sha> HEAD\0<capabilities>` — so the parsing is pinned too, and a
+    // regression back to a JSON `{sha}` endpoint fails here.
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ sha: HEAD }),
+      text: async () => String(url).includes('info/refs')
+        ? `001e# service=git-upload-pack\n00000155${HEAD} HEAD\0multi_ack symref=HEAD:refs/heads/main\n`
+        : '',
     })))
   })
 


### PR DESCRIPTION
修 #349（@pan17）。更新检查原本用 `api.github.com/repos/{repo}/commits/HEAD`——未认证 60 次/小时/IP，且**所有插件、每一轮检查共享**，装几个 GitHub 插件很快就打光，然后整张列表集体不报更新且不说原因。

改用 git 自己的 ref 广播端点，没有这个配额。这不是新发现：`acceleratedTarget` 早就在用同一个调用（当时是因为 REST 端点经镜像会间歇 403）。

**实测过报告者本人的仓库**：连打 8 次全 200，之后 REST 配额仍是 60/60。

测试桩改成 ref 广播的线格式而非 JSON `{sha}`，退回吃配额的端点会红。