### PR TITLE
feat: the exported log says what the profile looks like now

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -61,14 +61,21 @@ export function logEvent(level: LogLevel, event: string, detail: string): void {
  * @param header - environment lines to prepend (version, platform — no paths).
  * @returns plain text, newest entry last.
  */
-export function exportLogs(header: Record<string, string>): string {
+export function exportLogs(header: Record<string, string>, snapshot: string[] = []): string {
   const head = Object.entries(header).map(([key, value]) => `${key}: ${sanitize(value)}`)
   const lines = entries.map(e => `${e.at} [${e.level}] ${e.event}: ${e.detail}`)
   return [
     '# dsh-market log export',
     ...head,
     '',
-    ...(lines.length > 0 ? lines : ['(no events this session)']),
+    // The state of the profile RIGHT NOW, which does not depend on anything
+    // having been recorded this session (#341). The buffer dies with the
+    // process, so the failures worth reporting most — the ones that only
+    // appear after a restart — were exactly the ones whose export said
+    // "(no events this session)". This part still answers.
+    ...(snapshot.length > 0 ? ['## profile state', ...snapshot.map(line => sanitize(line)), ''] : []),
+    '## events this session',
+    ...(lines.length > 0 ? lines : ['(none — the buffer starts empty on every start)']),
     '',
   ].join('\n')
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1539,12 +1539,34 @@ export function mountMarketRoutes(
           'content-type': 'text/plain; charset=utf-8',
           'content-disposition': 'attachment; filename="dsh-market-log.txt"',
         })
+        // Built here, not in log.ts: this is the composition, and the log
+        // module deliberately knows nothing about profiles. Each declared
+        // bundle is marked with whether it actually resolves, because an
+        // unresolvable one is what stops the next boot (#339, #341) and it
+        // is invisible in a manifest listing on its own.
+        const snapshot: string[] = []
+        try {
+          const report = analyzeProfile(activeProfileDir)
+          const installed = readInstalled(config.profile, activeProfileDir)
+          snapshot.push(`dependencies (${String(Object.keys(installed).length)}):`)
+          for (const [name, spec] of Object.entries(installed)) snapshot.push(`  ${name}: ${spec}`)
+          snapshot.push(`bundles (${String(report.bundles.length)}):`)
+          for (const layer of report.bundles) {
+            snapshot.push(`  ${layer.name}: ${layer.directory === null ? 'NOT RESOLVED — the next start fails here' : 'ok'}`)
+          }
+          if (report.summary.errors.length > 0) {
+            snapshot.push('errors:')
+            for (const line of report.summary.errors) snapshot.push(`  ${line}`)
+          }
+        } catch (error) {
+          snapshot.push(`profile state unavailable: ${error instanceof Error ? error.message : String(error)}`)
+        }
         response.end(exportLogs({
           'dsh-market': version,
           platform: `${process.platform} ${process.arch}`,
           node: process.version,
           profile: config.profile,
-        }))
+        }, snapshot))
       },
     }),
 

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -441,7 +441,7 @@ function createTestbed(
     await handler(request, response)
     let json: any = null
     try { json = JSON.parse(payload) } catch { /* non-JSON (logs route) */ }
-    return { status, json }
+    return { status, json, text: payload }
   }
   return { dispatch, loaderEntries, dispose }
 }
@@ -702,6 +702,26 @@ describe('backup and restore (#55)', () => {
     const restored = await bed.dispatch('POST', '/dsh-market/restore', { backup: exported.json })
     expect(restored.status).toBe(200)
     expect(restored.json.bootErrors).toBeUndefined()
+  })
+
+  /** #341: the log buffer dies with the process, so a failure that only
+   * appears after a restart exported "(no events this session)" — the class
+   * of bug that most needs a log is exactly the class whose log is gone. The
+   * export now also states what the profile looks like right now, which does
+   * not depend on anything having been recorded. */
+  it('exports the profile state even when nothing happened this session', async () => {
+    const manifestPath = join(profileDir('web'), 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    manifest.dsh = { profile: { bundles: [...(manifest.dsh?.profile?.bundles ?? []), 'ghost-bundle'] } }
+    writeFileSync(manifestPath, JSON.stringify(manifest))
+
+    const r = await bed.dispatch('GET', '/dsh-market/logs')
+    expect(r.status).toBe(200)
+    const text = r.text
+    expect(text).toContain('## profile state')
+    // The unresolvable row is called out, because that is the thing that
+    // stops the next boot and a plain manifest listing does not show it.
+    expect(text).toMatch(/ghost-bundle: NOT RESOLVED/)
   })
 
   it('rejects cross-origin restore requests', async () => {


### PR DESCRIPTION
承 #341（@Astro-Han）。他的说法最到位：**最值得上报的那类故障，恰好是导出不到东西的那类**——凡是重启后才暴露的问题，重启这一下就把证据清空了。#339 就是活例子，报告者照模板附了日志，全文是`(no events this session)`。

导出现在额外带一份**不依赖历史事件**的即时状态：依赖清单、每个声明的 bundle、以及**每个 bundle 是否真的能解析**。最后这条是重点——无法解析的那一行正是让下次启动崩掉的东西，而单纯列 manifest 是看不出来的。

**他的另一条建议（缓冲区落盘）没做**：想法是好的，但它会推翻代码里写死的一条承诺（"Nothing is persisted to disk; the buffer dies with the process"），这种事我不打算悄悄反转——虽然有 `sanitize()` 在，落盘并不会比现在的导出多暴露任何东西。