### PR TITLE
fix: explain missing tarball integrity

### DIFF
--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -45,7 +45,7 @@ export const HOST_NAMESPACE_RE = /^@deepseek-ai\//
 export interface PnpmFailure {
   code: 'adding-to-root' | 'not-a-workspace' | 'hoist-pattern-diff' | 'pnpm-missing' | 'release-age-violation'
     | 'ignored-builds' | 'git-prepare-not-allowed' | 'fetch-404' | 'transient-network' | 'fetch-timeout'
-    | 'unexpected-store' | 'patch-failed'
+    | 'unexpected-store' | 'patch-failed' | 'missing-tarball-integrity'
   /** Bilingual, actionable message shown to the user instead of the raw wall of text. */
   message: string
   /** True when re-running `pnpm install` in the profile is the documented recovery. */
@@ -85,6 +85,33 @@ export function isTransientPnpmFailure(output: string): boolean {
  */
 export function isFetchTimeoutFailure(output: string): boolean {
   return /operation was aborted due to timeout|TimeoutError|error \(23\)/i.test(output)
+}
+
+/**
+ * Add human diagnostics decoded from pnpm's NDJSON reporter to its raw output.
+ *
+ * Mutating market commands always use `--reporter=ndjson`, so an error's
+ * message normally arrives as a JSON string: quotes are escaped and embedded
+ * newlines are `\n`. Matching only the raw stream therefore misses the exact
+ * production form even when it works against pnpm's pretty reporter.
+ */
+function withDecodedPnpmDiagnostics(output: string): string {
+  const messages: string[] = []
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('{')) continue
+    try {
+      const event = JSON.parse(trimmed) as { message?: unknown; err?: unknown }
+      if (typeof event.message === 'string') messages.push(event.message)
+      if (typeof event.err === 'object' && event.err !== null) {
+        const message = (event.err as Record<string, unknown>).message
+        if (typeof message === 'string') messages.push(message)
+      }
+    } catch {
+      // Human reporter output and truncated NDJSON remain available verbatim.
+    }
+  }
+  return messages.length === 0 ? output : `${output}\n${messages.join('\n')}`
 }
 
 /**
@@ -129,6 +156,28 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
       code: 'unexpected-store',
       recoverable: false,
       message: `这个 profile 的 node_modules 链接到的 pnpm store，和当前 pnpm 默认使用的 store 不是同一个，pnpm 因此拒绝所有安装与卸载。${detail}\n在 profile 目录里执行一次 \`pnpm install --store-dir <上面第一个路径>\` 重新链接即可（dsh 运行时可能占用文件，必要时先退出 dsh）/ this profile's node_modules is linked to a different pnpm store than the one pnpm now resolves, so pnpm refuses every install and uninstall.${detail}\nRelink by running \`pnpm install --store-dir <the first path above>\` once in the profile directory (stop dsh first if files are locked)`,
+    }
+  }
+  // #367: pnpm verifies every tarball resolution in the lockfile before it
+  // performs ANY add/remove. One old or half-written entry without an
+  // integrity hash therefore blocks unrelated plugin operations too.
+  //
+  // Do not auto-repair this. Computing and writing a hash means choosing to
+  // trust the bytes currently served by the URL, which is a supply-chain
+  // decision the market cannot safely make for the user. We only name the
+  // package when pnpm emits its canonical quoted `name@https-url` shape;
+  // aggregate or reworded diagnostics get the generic message rather than a
+  // guessed package name.
+  if (output.includes('ERR_PNPM_MISSING_TARBALL_INTEGRITY')) {
+    const diagnostic = withDecodedPnpmDiagnostics(output)
+    const pkg = /Cannot (?:install|fetch) package\s+"((?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*)@https?:\/\/[^"\s]+"(?: from the lockfile)?:\s*(?:its lockfile entry|it) has no "integrity" field/i.exec(diagnostic)?.[1]
+    const zh = pkg === undefined ? '' : `（${pkg}）`
+    const en = pkg === undefined ? '' : ` (${pkg})`
+    return {
+      code: 'missing-tarball-integrity',
+      recoverable: false,
+      pkg,
+      message: `profile 的 pnpm-lock.yaml 里有一个 tarball 依赖${zh}缺少 integrity，pnpm 因此拒绝所有安装和卸载。请先确认 URL 和 tarball 可信，再重新解析/下载该依赖以写入 sha512 integrity，或从可信的 lockfile 版本恢复该字段，然后重试；市场不会自动为未验证的字节生成校验值 / a tarball dependency${en} in this profile's pnpm-lock.yaml has no integrity, so pnpm refuses every install and uninstall. Verify the URL and tarball first, then re-resolve/download that dependency to record a sha512 integrity, or restore the field from a trusted lockfile version before retrying; the market will not generate a checksum for unverified bytes automatically`,
     }
   }
   // #222 by @MicroMilo: a patch in the profile that no longer applies.

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -83,6 +83,49 @@ describe('classifyPnpmFailure', () => {
     expect(failed?.message).toContain('patchedDependencies')
   })
 
+  it('names the tarball dependency whose lockfile entry has no integrity (#367)', () => {
+    const failed = classifyPnpmFailure(`[ERR_PNPM_MISSING_TARBALL_INTEGRITY] Cannot install package
+"dsh-think-translate@https://gh-proxy.com/https://codeload.github.com/UncleK/dsh-think-translate/tar.gz/ba71a9bb88f52bc7bbf42225cfb69f7ef8d16900": its lockfile entry has no "integrity" field,
+so pnpm cannot verify the downloaded tarball.`)
+
+    expect(failed?.code).toBe('missing-tarball-integrity')
+    expect(failed?.recoverable).toBe(false)
+    expect(failed?.pkg).toBe('dsh-think-translate')
+    expect(failed?.message).toContain('dsh-think-translate')
+    expect(failed?.message).toContain('pnpm-lock.yaml')
+    expect(failed?.message).toContain('sha512')
+    expect(failed?.message).toContain('拒绝所有安装和卸载')
+
+    const scoped = classifyPnpmFailure(`ERR_PNPM_MISSING_TARBALL_INTEGRITY Cannot fetch package "@scope/plugin@https://example.test/plugin.tgz" from the lockfile: it has no "integrity" field, so the downloaded tarball cannot be verified.`)
+    expect(scoped?.pkg).toBe('@scope/plugin')
+  })
+
+  it('extracts the package from the escaped NDJSON form used in production (#367)', () => {
+    const ndjson = String.raw`{"name":"pnpm","level":"error","err":{"code":"ERR_PNPM_MISSING_TARBALL_INTEGRITY","message":"Cannot install package\n\"dsh-think-translate@https://gh-proxy.com/https://codeload.github.com/UncleK/dsh-think-translate/tar.gz/ba71a9bb88f52bc7bbf42225cfb69f7ef8d16900\": its lockfile entry has no \"integrity\" field, so pnpm cannot verify the downloaded tarball."}}`
+    expect(classifyPnpmFailure(ndjson)?.pkg).toBe('dsh-think-translate')
+
+    const scoped = ndjson.replace('dsh-think-translate@https://', '@scope/plugin@https://')
+    expect(classifyPnpmFailure(scoped)?.pkg).toBe('@scope/plugin')
+  })
+
+  it('classifies missing tarball integrity without guessing a package from ambiguous prose (#367)', () => {
+    const generic = classifyPnpmFailure(`ERR_PNPM_MISSING_TARBALL_INTEGRITY 1 lockfile entries failed verification:
+  a rewritten diagnostic whose package shape is not stable`)
+    expect(generic?.code).toBe('missing-tarball-integrity')
+    expect(generic?.recoverable).toBe(false)
+    expect(generic?.pkg).toBeUndefined()
+    expect(generic?.message).not.toContain('undefined')
+
+    // The prose alone is not enough: another tool quoting pnpm's message in
+    // a log or help page must not be classified as the active pnpm failure.
+    expect(classifyPnpmFailure('Cannot install package "dsh-fake@https://example.test/fake.tgz": its lockfile entry has no "integrity" field')).toBeNull()
+
+    // Even with the code, only the canonical name@https-url shape is safe to
+    // expose as `pkg`; do not mistake a bare URL or npm alias for a name.
+    expect(classifyPnpmFailure('ERR_PNPM_MISSING_TARBALL_INTEGRITY Cannot install package "https://example.test/fake.tgz": its lockfile entry has no "integrity" field')?.pkg).toBeUndefined()
+    expect(classifyPnpmFailure('ERR_PNPM_MISSING_TARBALL_INTEGRITY Cannot install package "alias@npm:real@1.0.0": its lockfile entry has no "integrity" field')?.pkg).toBeUndefined()
+  })
+
   it('recognizes momentary network failures — and only those — as transient (#83)', () => {
     const flake = classifyPnpmFailure('FetchError: request to https://codeload.github.com/o/r/tar.gz/abc failed, reason: socket hang up')
     expect(flake?.code).toBe('transient-network')


### PR DESCRIPTION
Closes #367.

## What changed
- classify `ERR_PNPM_MISSING_TARBALL_INTEGRITY` with a bilingual actionable message
- decode the actual `pnpm --reporter=ndjson` error payload before extracting the affected package
- safely name only canonical quoted `name@https-url` packages; use a generic fallback otherwise
- keep it non-recoverable and never generate integrity for unverified bytes automatically

## Verification
- [x] `npm test` — 969 passed, 1 skipped
- [x] `npm run check` — typecheck, build, and restart smoke pass
- [x] regression covers human output plus realistic escaped NDJSON, scoped/unscoped packages, and false-positive shapes
- [x] no version bump; no client source change

Exact head: `ee9815f439319acc72353430e4560a5b83ead4cb`