### PR TITLE
fix: an in-box bundle we cannot locate is not a broken profile

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -59,6 +59,12 @@ export interface BundleLayer {
   directory: string | null
   /** Absolute path of the layer's patch file; null when undeclared/missing. */
   patchPath: string | null
+  /**
+   * An in-box bundle whose directory could not be located — a gap in what
+   * this process can see, not a defect in the profile (#369). Distinct from
+   * `error`, which asserts the profile will not boot.
+   */
+  unresolvedInbox?: boolean
   /** Why this layer cannot load at boot (missing dir / no dsh.bundle / …). */
   error: string | null
   /** Loader entry ids this bundle's patch inserts. */
@@ -899,6 +905,22 @@ export function buildBundleLayers(
       parseError: null,
     }
     if (directory === null) {
+      // An in-box bundle is supplied by the dsh INSTALLATION, not by the
+      // profile — that is what makes it in-box. So failing to find one says
+      // we could not locate the installation, not that the profile is
+      // broken: on DSH Desktop dsh lives inside the app bundle and
+      // findDshInstallDir() walks up from process.argv[1], which is
+      // Electron's entry and leads nowhere near it.
+      //
+      // Calling that "will fail to boot" turned a working composition into a
+      // fatal verdict and rolled back a good update (#369) — while `dsh
+      // --dump-config` on the same profile exited 0. Unknown has to read as
+      // unknown; the profile's own bundles are still judged normally.
+      if (INBOX_BUNDLES.has(name)) {
+        layer.error = null
+        layer.unresolvedInbox = true
+        return layer
+      }
       layer.error = 'bundle package is not installed — the profile will fail to boot'
       return layer
     }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -581,7 +581,11 @@ export function mountMarketRoutes(
   function orphanBundles(): string[] {
     try {
       return analyzeProfile(activeProfileDir).bundles
-        .filter(layer => layer.directory === null)
+        // Not an in-box bundle we merely could not locate (#369): those are
+        // supplied by the dsh installation, and failing to find one is a gap
+        // in what this process can see rather than a profile that will not
+        // start. Reporting them here rolled back a good update.
+        .filter(layer => layer.directory === null && layer.unresolvedInbox !== true)
         .map(layer => layer.name)
     } catch (error) {
       logEvent('warn', 'install', `bundle resolution check failed: ${error instanceof Error ? error.message : String(error)}`)
@@ -1621,7 +1625,12 @@ export function mountMarketRoutes(
           for (const [name, spec] of Object.entries(installed)) snapshot.push(`  ${name}: ${spec}`)
           snapshot.push(`bundles (${String(report.bundles.length)}):`)
           for (const layer of report.bundles) {
-            snapshot.push(`  ${layer.name}: ${layer.directory === null ? 'NOT RESOLVED — the next start fails here' : 'ok'}`)
+            const state = layer.directory !== null
+          ? 'ok'
+          : layer.unresolvedInbox === true
+            ? 'supplied by the dsh installation (not locatable from here)'
+            : 'NOT RESOLVED — the next start fails here'
+        snapshot.push(`  ${layer.name}: ${state}`)
           }
           if (report.summary.errors.length > 0) {
             snapshot.push('errors:')

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -769,6 +769,51 @@ describe('suggestedOrder (#98 opt: LOOT-style auto-fix)', () => {
 
 })
 
+/** #369: on DSH Desktop the dsh installation lives inside the Electron app
+ * bundle, and findDshInstallDir walks up from process.argv[1] — Electron's
+ * entry, nowhere near it. Both anchors then miss the in-box bundles, which
+ * are supplied by that installation by definition, and the composition was
+ * declared unbootable. `dsh --dump-config` on the same profile exited 0. */
+describe('in-box bundles that cannot be located (#369)', () => {
+  /** `tmp` is assigned per test, so this has to be read inside one. */
+  const desktop = () => ({ dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
+
+  it('does not call an unlocatable in-box bundle a boot failure', () => {
+    const dir = pdir()
+    // The default profile template, and nothing in node_modules: the shape
+    // of every Desktop profile.
+    writeProfile(dir, {
+      name: 'web-profile',
+      dependencies: {},
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'] } },
+    })
+
+    const report = analyzeProfile(dir, desktop())
+
+    for (const layer of report.bundles) {
+      expect(layer.kind).toBe('official')
+      expect(layer.error, `${layer.name} was called broken`).toBeNull()
+      expect(layer.unresolvedInbox).toBe(true)
+    }
+    expect(report.summary.errors.join('\n')).not.toMatch(/is not installed/)
+  })
+
+  it('still calls a COMMUNITY bundle missing, which is a real defect', () => {
+    const dir = pdir()
+    writeProfile(dir, {
+      name: 'web-profile',
+      dependencies: {},
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'some-community-bundle'] } },
+    })
+
+    const report = analyzeProfile(dir, desktop())
+
+    const community = report.bundles.find(layer => layer.name === 'some-community-bundle')
+    expect(community?.error).toMatch(/not installed/)
+    expect(community?.unresolvedInbox).toBeUndefined()
+  })
+})
+
 describe('peer range mismatch', () => {
   // ^0.1.0 := >=0.1.0 <0.2.0 (exclusive upper bound), so resolved 0.2.0
   // must be reported as unsatisfied.

--- a/tests/trial.spec.ts
+++ b/tests/trial.spec.ts
@@ -50,6 +50,41 @@ function writeBundle(base: string, name: string, version: string, patch: unknown
   return dir
 }
 
+/** #369: on DSH Desktop the in-box bundles come from the app bundle, and the
+ * install directory is not discoverable from process.argv[1]. Trial
+ * validation then judged the profile unbootable and the update route rolled
+ * a good build back — the reporter's own `dsh --dump-config` exited 0 on the
+ * same profile, with the files already updated on disk. */
+describe('an unlocatable in-box bundle must not fail the trial (#369)', () => {
+  it('passes the trial, so a legitimate update is not rolled back', () => {
+    const dir = pdir()
+    writeProfile(dir, ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', 'dsh-smooth-stream'])
+    // Only the community plugin is on disk — the Desktop shape exactly.
+    writeBundle(dir, 'dsh-smooth-stream', '0.4.1', [{ insert: [{ id: 'smooth', name: 'dsh-smooth-stream' }] }])
+
+    const result = trialValidate(dir, ['dsh-smooth-stream'], {
+      dshInstallDir: null,
+      homeDir: join(tmp, 'empty-home'),
+    })
+
+    expect(result.errors.map(e => e.message).join('\n')).not.toMatch(/is not installed/)
+    expect(result.ok, 'a passing composition was called unbootable').toBe(true)
+  })
+
+  it('still fails the trial for a COMMUNITY bundle that really is absent', () => {
+    const dir = pdir()
+    writeProfile(dir, ['@deepseek-ai/dsh-base', 'ghost-bundle'])
+
+    const result = trialValidate(dir, ['ghost-bundle'], {
+      dshInstallDir: null,
+      homeDir: join(tmp, 'empty-home'),
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.errors.some(e => e.layer === 'ghost-bundle')).toBe(true)
+  })
+})
+
 describe('trialValidate (#98 trial boot)', () => {
   it('flags a candidate order where two bundles insert the same loader entry id', () => {
     const dir = pdir()


### PR DESCRIPTION
修 #369（@Ztyss）——**这是我在 1.30.0 加孤儿检查时留下的洞**，让桌面端的市场更新基本不可用。

内置 bundle 按定义由 dsh **安装目录**提供。桌面端 dsh 在 Electron app bundle 里，而 `findDshInstallDir` 从 `process.argv[1]`（Electron 的入口）往上走，根本走不到那儿 → 两个 anchor 全落空 → 每个默认 profile 都被判成"启动会失败"。

后果比报错难听更严重：`trialValidate` 读的是同一个 error，于是更新被判失败**并回滚**——文件已经落盘到新版本、manifest 却被滚回去。报告者说得准：重启前的状态自相矛盾。

现在找不到的**内置** bundle 报"无法判定"而不是"缺失"；社区 bundle 缺失仍然是真缺陷、照旧报错。

双向验证过：修复后 trial 通过；关掉修复，报告里那两条错误逐字复现。

976 测试全过。