### PR TITLE
fix(e2e): a category that fits on one page is an answer, not a timeout

### DIFF
--- a/tests/web/market.e2e.ts
+++ b/tests/web/market.e2e.ts
@@ -100,9 +100,18 @@ describe.skipIf(!HAS_DSH)('web e2e: plugin market', () => {
     // narrowing to one category of several must leave fewer pages than "All",
     // whatever today's catalog looks like and whichever chip is second.
     const pages = async (): Promise<number> => {
-      const label = await page.locator('[class*="pageInfo"]').first().textContent()
+      // No pagination control means the result fits on ONE page, which is a
+      // real answer and not a failure. The catalog now carries categories of
+      // four entries and of one (`identity`, `agi`), so whichever chip sits
+      // second is no longer guaranteed to span pages — waiting for a control
+      // that will never render just spent the 30s timeout and read as a bug
+      // in whatever change happened to be under test.
+      const info = page.locator('[class*="pageInfo"]').first()
+      if (await info.count() === 0) return 1
+      const label = await info.textContent({ timeout: 5000 }).catch(() => null)
+      if (label === null) return 1
       // "第 3 / 56 页" / "Page 3 of 56" — the last number is the total.
-      const numbers = (label ?? '').match(/\d+/gu) ?? []
+      const numbers = label.match(/\d+/gu) ?? []
       return Number(numbers[numbers.length - 1] ?? 0)
     }
 


### PR DESCRIPTION
main 目前是红的，这条修它。

**不是任何一次代码改动造成的**——线上目录里出现了只有 4 条（`identity`）和 1 条（`agi`）的分类，它们**不足一页、分页控件根本不渲染**，而测试在干等那个控件、耗满 30 秒超时。

证明方式：把 `DSHM_REGISTRY_URL` 指向 origin（CI 走的 global 线路）后本地一次复现；然后回到 **CI 当时是绿的那个提交**，同样红。

被测性质没变（某分类的页数必须少于全部），只是 1 < 96 现在也算通过。