### PR TITLE
fix: a stale profile copy is not evidence for the layer the host loaded

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -379,15 +379,29 @@ function readNodeModulesVersion(base: string, name: string): string | null {
  * hoisting (`<profiles>/node_modules/…` when the profile lives under
  * `<profiles>/<name>`) and mirrors the Loader's package search roots.
  */
-function resolvePackageDir(anchorPackageJson: string, name: string): string | null {
+function resolvePackageDir(
+  anchorPackageJson: string,
+  name: string,
+  ignoredPackageDirectory?: string,
+): string | null {
   let paths: string[] = []
   try {
     paths = createRequire(anchorPackageJson).resolve.paths(name) ?? []
   } catch {
     return null
   }
+  const ignored = ignoredPackageDirectory === undefined
+    ? null
+    : resolve(ignoredPackageDirectory)
   for (const searchPath of paths) {
     const candidate = join(searchPath, name)
+    if (ignored !== null) {
+      const resolvedCandidate = resolve(candidate)
+      const matchesIgnored = process.platform === 'win32'
+        ? resolvedCandidate.toLowerCase() === ignored.toLowerCase()
+        : resolvedCandidate === ignored
+      if (matchesIgnored) continue
+    }
     if (existsSync(join(candidate, 'package.json'))) return candidate
   }
   return null
@@ -884,14 +898,26 @@ export function buildBundleLayers(
   dshInstallDir: string | null,
 ): { bundles: BundleLayer[]; layers: LayerInput[] } {
   const bundles: BundleLayer[] = bundleNames.map((name) => {
-    const anchors = [
-      dshInstallDir !== null ? join(dshInstallDir, 'package.json') : null,
-      join(profileDirectory, 'package.json'),
+    // The real loader gives the DSH installation first refusal for in-box
+    // bundles. Desktop keeps that installation private from plugins, so a
+    // DIRECT profile-local copy with the same official name is only a stale
+    // shadow, never evidence for the layer the running host loaded (#371).
+    // Keep walking the profile anchor's parent search paths: Desktop heals an
+    // authoritative host fallback at <profiles>/node_modules.
+    const ignoredProfilePackage = dshInstallDir === null && INBOX_BUNDLES.has(name)
+      ? join(profileDirectory, 'node_modules', name)
+      : undefined
+    const anchors: Array<{ anchor: string | null; ignoredPackageDirectory?: string }> = [
+      { anchor: dshInstallDir !== null ? join(dshInstallDir, 'package.json') : null },
+      {
+        anchor: join(profileDirectory, 'package.json'),
+        ignoredPackageDirectory: ignoredProfilePackage,
+      },
     ]
     let directory: string | null = null
-    for (const anchor of anchors) {
+    for (const { anchor, ignoredPackageDirectory } of anchors) {
       if (anchor === null) continue
-      directory = resolvePackageDir(anchor, name)
+      directory = resolvePackageDir(anchor, name, ignoredPackageDirectory)
       if (directory !== null) break
     }
     const layer: BundleLayer = {

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -85,7 +85,8 @@ describe('bundle stack (#98 diagnostics)', () => {
       { insert: [{ id: 'dsh-market', name: 'dshmarket' }] },
     ])
 
-    const report = analyzeProfile(dir)
+    // This fixture deliberately models a visible DSH installation anchor.
+    const report = analyzeProfile(dir, { dshInstallDir: dir })
 
     // Order comes straight from dsh.profile.bundles.
     expect(report.bundles.map(b => b.name)).toEqual(['@deepseek-ai/dsh-base', 'dsh-market'])
@@ -113,7 +114,7 @@ describe('bundle stack (#98 diagnostics)', () => {
     })
     writeBundle(dir, '@deepseek-ai/dsh-base', '4.0.1', [{ insert: [{ id: 'x' }] }])
 
-    const report = analyzeProfile(dir)
+    const report = analyzeProfile(dir, { dshInstallDir: dir })
     const missing = report.bundles.find(b => b.name === 'missing-bundle')
     expect(missing).toBeDefined()
     expect(missing?.directory).toBeNull()
@@ -582,7 +583,7 @@ describe('duplicate loader entry ids (#98 boot failure)', () => {
       { insert: [{ id: 'shared-entry', name: 'from-user' }] },
     ]))
 
-    const report = analyzeProfile(dir)
+    const report = analyzeProfile(dir, { dshInstallDir: dir })
     const dup = report.duplicates.find(d => d.id === 'shared-entry')
     expect(dup).toBeDefined()
     expect(dup?.id).toBe('shared-entry')
@@ -608,7 +609,7 @@ describe('duplicate loader entry names (#98 opt: runtime shadowing)', () => {
       { insert: [{ id: 'two', name: 'same-plugin' }] },
     ]))
 
-    const report = analyzeProfile(dir)
+    const report = analyzeProfile(dir, { dshInstallDir: dir })
     // The shadowing pair stays structurally visible with the SAME shape
     // ({name, layers, count}) for the diagnostics panel to render.
     const dup = report.duplicateNames.find(d => d.name === 'same-plugin')
@@ -796,6 +797,61 @@ describe('in-box bundles that cannot be located (#369)', () => {
       expect(layer.unresolvedInbox).toBe(true)
     }
     expect(report.summary.errors.join('\n')).not.toMatch(/is not installed/)
+  })
+
+  it('does not inspect a stale profile copy when the in-box host is hidden', () => {
+    const dir = pdir()
+    writeProfile(dir, {
+      name: 'web-profile',
+      dependencies: { '@deepseek-ai/dsh-base': '^0.0.1' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } },
+    })
+    const stale = writePackage(dir, '@deepseek-ai/dsh-base', {
+      name: '@deepseek-ai/dsh-base',
+      version: '0.0.1',
+      dsh: {},
+    })
+
+    const report = analyzeProfile(dir, desktop())
+    const official = report.bundles[0]
+
+    expect(official).toMatchObject({
+      directory: null,
+      unresolvedInbox: true,
+      error: null,
+    })
+    expect(official?.directory).not.toBe(stale)
+    expect(report.summary.ok).toBe(true)
+  })
+
+  it('uses the healed parent fallback behind a stale direct in-box shadow', () => {
+    const dir = pdir('profiles/web')
+    writeProfile(dir, {
+      name: 'web-profile',
+      dependencies: { '@deepseek-ai/dsh-base': '^0.0.1' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } },
+    })
+    writePackage(dir, '@deepseek-ai/dsh-base', {
+      name: '@deepseek-ai/dsh-base',
+      version: '0.0.1',
+      dsh: {},
+    })
+    const fallback = writeBundle(
+      join(tmp, 'profiles'),
+      '@deepseek-ai/dsh-base',
+      '4.0.1',
+      [{ insert: [{ id: 'host-base' }] }],
+    )
+
+    const report = analyzeProfile(dir, desktop())
+    const official = report.bundles[0]
+
+    expect(official?.directory).toBe(fallback)
+    expect(official?.unresolvedInbox).toBeUndefined()
+    expect(official?.error).toBeNull()
+    expect(official?.entries).toEqual(['host-base'])
+    expect(report.rows.map(row => row.id)).toEqual(['host-base'])
+    expect(report.summary.ok).toBe(true)
   })
 
   it('still calls a COMMUNITY bundle missing, which is a real defect', () => {

--- a/tests/trial.spec.ts
+++ b/tests/trial.spec.ts
@@ -71,6 +71,62 @@ describe('an unlocatable in-box bundle must not fail the trial (#369)', () => {
     expect(result.ok, 'a passing composition was called unbootable').toBe(true)
   })
 
+  it('ignores a stale profile copy that the hidden in-box host outranks', () => {
+    const dir = pdir()
+    writeProfile(dir, ['@deepseek-ai/dsh-base', 'dsh-smooth-stream'])
+    const stale = join(dir, 'node_modules', '@deepseek-ai', 'dsh-base')
+    mkdirSync(stale, { recursive: true })
+    writeFileSync(join(stale, 'package.json'), JSON.stringify({
+      name: '@deepseek-ai/dsh-base',
+      version: '0.0.1',
+      dsh: {},
+    }))
+    writeBundle(dir, 'dsh-smooth-stream', '0.4.1', [{ insert: [{ id: 'smooth' }] }])
+
+    const result = trialValidate(dir, ['dsh-smooth-stream'], {
+      dshInstallDir: null,
+      homeDir: join(tmp, 'empty-home'),
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it('detects conflicts through the healed parent fallback behind a stale direct shadow', () => {
+    const dir = pdir('profiles/web')
+    writeProfile(dir, ['@deepseek-ai/dsh-base', 'dsh-smooth-stream'])
+    const stale = join(dir, 'node_modules', '@deepseek-ai', 'dsh-base')
+    mkdirSync(stale, { recursive: true })
+    writeFileSync(join(stale, 'package.json'), JSON.stringify({
+      name: '@deepseek-ai/dsh-base',
+      version: '0.0.1',
+      dsh: {},
+    }))
+    writeBundle(
+      join(tmp, 'profiles'),
+      '@deepseek-ai/dsh-base',
+      '4.0.1',
+      [{ insert: [{ id: 'shared-entry', name: 'host-base' }] }],
+    )
+    writeBundle(dir, 'dsh-smooth-stream', '0.4.1', [
+      { insert: [{ id: 'shared-entry', name: 'smooth' }] },
+    ])
+
+    const result = trialValidate(dir, ['dsh-smooth-stream'], {
+      dshInstallDir: null,
+      homeDir: join(tmp, 'empty-home'),
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.errors.some(issue => issue.message.includes('duplicate'))).toBe(true)
+    expect(result.duplicates).toHaveLength(1)
+    expect(result.duplicates[0]).toMatchObject({
+      id: 'shared-entry',
+      count: 2,
+      layers: ['@deepseek-ai/dsh-base', 'dsh-smooth-stream'],
+    })
+  })
+
   it('still fails the trial for a COMMUNITY bundle that really is absent', () => {
     const dir = pdir()
     writeProfile(dir, ['@deepseek-ai/dsh-base', 'ghost-bundle'])
@@ -194,7 +250,7 @@ describe('trialValidate (#98 trial boot)', () => {
     writeBundle(dir, 'alpha', '1.0.0', [{ insert: [{ id: 'alpha-entry', name: 'alpha' }] }])
     writeBundle(dir, 'beta', '1.0.0', [{ insert: [{ id: 'beta-entry', name: 'beta' }] }])
 
-    const result = trialValidate(dir, ['beta', 'alpha'])
+    const result = trialValidate(dir, ['beta', 'alpha'], { dshInstallDir: dir })
     expect(result.ok).toBe(true)
     expect(result.rows.map(r => r.id)).toEqual(['base-entry', 'beta-entry', 'alpha-entry'])
   })


### PR DESCRIPTION
承 #374（@Jstn-1g），#371 的后续。

合并前验了我最担心的一点：**普通 `dsh web` 上 `findDshInstallDir()` 同样返回 null**，所以这条规则在那里也生效。实测其 bundle 仍然 `dir=ok`——Node 会继续往上层走到真正被加载的那一份，普通安装的诊断没有被误伤。是拿真实 dsh 跑出来的，不是推理。

986 测试全过。