### PR TITLE
fix(update): reject resolved version downgrades

### DIFF
--- a/UPDATE-API-V1.md
+++ b/UPDATE-API-V1.md
@@ -74,6 +74,22 @@ pnpm provides it. Terminal operations include:
 - a stable failure code, bounded user-facing message and retryability;
 - whether a compatibility rollback is currently available.
 
+For npm updates, Market verifies the package version that pnpm actually placed
+on disk before reporting success. This prevents pnpm's release-age policy or a
+lagging registry mirror from silently turning `@latest` into an older or
+unexpected build. A mismatch is restored from the pre-update recovery point
+and reported as one of these stable failures:
+
+- `DOWNGRADE_DETECTED`: the resolved version is older than the version present
+  before the operation; not retryable without a new target.
+- `RESOLVED_VERSION_MISMATCH`: the resolved version differs from the registry
+  target checked immediately before installation; retryable after registry or
+  mirror convergence.
+
+Provider clients should still compare `beforeVersion`, the target they showed
+to the user, and `installedVersion` before offering restart. That independent
+check protects clients connected to another compatible provider implementation.
+
 Up to 50 operation records live in the current Host process. A boot id is
 embedded in every operation id, so a client never mistakes a stale browser
 record for a task belonging to the replacement process.

--- a/UPDATE-API-V1.md
+++ b/UPDATE-API-V1.md
@@ -82,9 +82,10 @@ and reported as one of these stable failures:
 
 - `DOWNGRADE_DETECTED`: the resolved version is older than the version present
   before the operation; not retryable without a new target.
-- `RESOLVED_VERSION_MISMATCH`: the resolved version differs from the registry
+- `RESOLVED_VERSION_MISMATCH`: the resolved version is BELOW the registry
   target checked immediately before installation; retryable after registry or
-  mirror convergence.
+  mirror convergence. A version above that target is accepted — `latest` can
+  move forward while the install is still running.
 
 Provider clients should still compare `beforeVersion`, the target they showed
 to the user, and `installedVersion` before offering restart. That independent

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -39,7 +39,7 @@ import { asChannel, CHANNELS, DIST_TAG, resolveChannel, type Channel } from './c
 import { asRegion, REGIONS, routesFor, setActiveRegion, type Region } from './regions.ts'
 import { resolveRegion } from './region-probe.ts'
 import { acceleratedTarget, resolveHeadCommit } from './accelerate.ts'
-import { checkUpdates, fetchNpmLatest, invalidateUpdates, isUpgrade, latestPublishedRecently, setUpdateRegistry, versionOnChannel } from './updates.ts'
+import { checkUpdates, compareVersions, fetchNpmLatest, invalidateUpdates, isUpgrade, latestPublishedRecently, setUpdateRegistry, versionOnChannel } from './updates.ts'
 import { createThemeManager, type LoaderEntry } from './themes.ts'
 import { readJsonBody, sameOrigin, sendJson } from './http.ts'
 import { detectedSupervisor, restartAllowed, scheduleRestart, servingPort, trustedRestartRequest, trustedDownloadRequest } from './restart.ts'
@@ -2066,6 +2066,7 @@ export function mountMarketRoutes(
             // The market follows its channel; everything else is `latest`.
             const selfChannel = SELF_NAMES.has(name) ? activeChannel() : null
             const tag = selfChannel === null ? 'latest' : DIST_TAG[selfChannel]
+            let expectedNpmVersion: string | null = null
             // Re-accelerated from the unpinned shortcut, never from the
             // installed URL: that one names the commit already on disk, so
             // reusing it would be an update that can never move.
@@ -2101,6 +2102,7 @@ export function mountMarketRoutes(
               const registryLatest = selfChannel === null
                 ? await fetchNpmLatest(name)
                 : await versionOnChannel(name, selfChannel, await fetchNpmLatest(name))
+              expectedNpmVersion = registryLatest
               const refuse = selfChannel === null
                 ? installedVersion !== null && registryLatest !== null && !isUpgrade(installedVersion, registryLatest)
                 : installedVersion !== null && registryLatest !== null && installedVersion === registryLatest
@@ -2148,6 +2150,10 @@ export function mountMarketRoutes(
             }
             let ok = result.exitCode === 0 && !result.timedOut && !cancelled
             let stale = false
+            let versionFailureCode: 'DOWNGRADE_DETECTED' | 'RESOLVED_VERSION_MISMATCH' | null = null
+            let versionFailureError: string | null = null
+            let rollbackOk = true
+            let rollbackDetail: string | null = null
             let activation: Record<string, ReturnType<typeof verifyActivation>> | undefined
             if (ok) {
               if (restore) {
@@ -2169,6 +2175,35 @@ export function mountMarketRoutes(
                 if (stale) ok = false
               }
             }
+            // pnpm's minimumReleaseAge can silently resolve `@latest` to an
+            // OLDER release and still exit 0. The old stale check only caught
+            // "same version"; a real 0.2.24 -> 0.2.23 regression therefore
+            // looked like a successful update. Verify the bytes that actually
+            // landed against both the pre-update version and the registry
+            // target, then rematerialize the previous build on any mismatch.
+            if (ok && !isGit && !restore) {
+              const afterVersion = readInstalledVersion(config.profile, name, activeProfileDir)
+              const direction = beforeVersion !== null && afterVersion !== null
+                ? compareVersions(afterVersion, beforeVersion)
+                : null
+              const unexpectedDowngrade = selfChannel === null && direction !== null && direction < 0
+              const targetMismatch = expectedNpmVersion !== null && afterVersion !== expectedNpmVersion
+              if (unexpectedDowngrade || targetMismatch) {
+                versionFailureCode = unexpectedDowngrade ? 'DOWNGRADE_DETECTED' : 'RESOLVED_VERSION_MISMATCH'
+                versionFailureError = unexpectedDowngrade
+                  ? `${name} 更新实际解析为 v${afterVersion ?? 'unknown'}，低于更新前的 v${beforeVersion ?? 'unknown'}；已拒绝降级并自动恢复原版本。 / ${name} resolved to v${afterVersion ?? 'unknown'}, below the installed v${beforeVersion ?? 'unknown'}; the downgrade was rejected and the previous build was restored.`
+                  : `${name} 更新目标为 v${expectedNpmVersion ?? 'unknown'}，但实际安装为 v${afterVersion ?? 'unknown'}；已自动恢复原版本。 / ${name} targeted v${expectedNpmVersion ?? 'unknown'} but installed v${afterVersion ?? 'unknown'}; the previous build was restored.`
+                ok = false
+                const rollback = await rollbackUpdateBuild(name, manifestBefore)
+                rollbackOk = rollback.ok
+                rollbackDetail = rollback.detail
+                if (!rollback.ok) {
+                  versionFailureError += ` 回滚未能恢复原版本文件：${rollback.detail ?? 'unknown'} / Rollback could not restore the previous build: ${rollback.detail ?? 'unknown'}`
+                }
+                logEvent('error', 'update-version',
+                  `${name}: ${versionFailureCode} before=${beforeVersion ?? 'unknown'} expected=${expectedNpmVersion ?? 'unknown'} actual=${afterVersion ?? 'unknown'}${rollback.ok ? '; previous build restored' : `; rollback failed: ${rollback.detail ?? 'unknown'}`}`)
+              }
+            }
             // The new build has to be loadable (#159). pnpm exits 0 for any
             // tarball it can extract, and the version really did change, so
             // nothing above notices a package that arrived without its entry
@@ -2181,8 +2216,6 @@ export function mountMarketRoutes(
             // the OLD code that is already in memory. The failure only
             // surfaces on the next boot, as a profile that will not start.
             let brokenEntry = false
-            let rollbackOk = true
-            let rollbackDetail: string | null = null
             if (ok && !hasLoadableEntry(activeProfileDir, name)) {
               brokenEntry = true
               ok = false
@@ -2309,7 +2342,8 @@ export function mountMarketRoutes(
               // ever sees this when something really is unbootable.
               ...(() => { const orphans = orphanBundles(); return orphans.length > 0 ? { orphanBundles: orphans } : {} })(),
               staleReason: staleReason ?? undefined,
-              error: trialError ?? brokenEntryError ?? staleError ?? undefined,
+              failureCode: versionFailureCode ?? undefined,
+              error: versionFailureError ?? trialError ?? brokenEntryError ?? staleError ?? undefined,
               exitCode: result.exitCode,
               timedOut: result.timedOut,
               stdout: result.stdout,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2187,7 +2187,26 @@ export function mountMarketRoutes(
                 ? compareVersions(afterVersion, beforeVersion)
                 : null
               const unexpectedDowngrade = selfChannel === null && direction !== null && direction < 0
-              const targetMismatch = expectedNpmVersion !== null && afterVersion !== expectedNpmVersion
+              // Only a version BELOW the target is a mismatch. `latest` can move
+              // forward while pnpm is still downloading — a large plugin gives
+              // the author minutes of window — and rejecting the newer release
+              // that arrives would roll back a good update and report it as a
+              // failure. Getting less than we asked for is the actual symptom.
+              const target = expectedNpmVersion
+              const targetOrder = target !== null && afterVersion !== null
+                ? compareVersions(afterVersion, target)
+                : null
+              const targetMismatch = target !== null && (
+                afterVersion === null
+                || (targetOrder !== null
+                  // Comparable: getting LESS than we asked for is the symptom.
+                  // A version above the target is `latest` moving forward while
+                  // pnpm was still downloading, which is a good update.
+                  ? targetOrder < 0
+                  // Not comparable as semver. With no way to tell forward from
+                  // back, keep the exact check this replaced.
+                  : afterVersion !== target)
+              )
               if (unexpectedDowngrade || targetMismatch) {
                 versionFailureCode = unexpectedDowngrade ? 'DOWNGRADE_DETECTED' : 'RESOLVED_VERSION_MISMATCH'
                 versionFailureError = unexpectedDowngrade

--- a/src/update-api-v1.ts
+++ b/src/update-api-v1.ts
@@ -77,6 +77,8 @@ function bool(value: unknown): boolean {
 }
 
 function failureCode(status: number, body: Record<string, unknown>): string {
+  const explicit = text(body.failureCode)
+  if (explicit === 'DOWNGRADE_DETECTED' || explicit === 'RESOLVED_VERSION_MISMATCH') return explicit
   if (body.agentsBusy === true) return 'AGENTS_RUNNING'
   if (body.busy === true || status === 409) return 'OPERATION_BUSY'
   if (body.stale === true && body.staleReason === 'release-age') return 'RELEASE_TOO_FRESH'
@@ -100,6 +102,7 @@ function failureOf(status: number, body: Record<string, unknown>): UpdateFailure
       || code === 'OPERATION_BUSY'
       || code === 'RELEASE_TOO_FRESH'
       || code === 'VERSION_UNCHANGED'
+      || code === 'RESOLVED_VERSION_MISMATCH'
       || code === 'UPDATE_TIMEOUT',
   }
 }

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -1103,6 +1103,21 @@ describe('update flow — no npm publishing required', () => {
     expect(installed.version).toBe('1.0.0')
   })
 
+  it('accepts a release published while the install was still running', async () => {
+    advanceNpmLatest('1.2.0')
+    fake.npm['dsh-loop'].versions['1.2.1'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
+    // The author publishes 1.2.1 while pnpm is still downloading 1.2.0. A big
+    // plugin leaves minutes of window for that, and rolling the update back
+    // would report a good, newer build as a failure.
+    fake.resolvedNpmVersionOnce = '1.2.1'
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.json).toMatchObject({ ok: true })
+    const installed = JSON.parse(readFileSync(join(fake.profileDir, 'node_modules', 'dsh-loop', 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.2.1')
+  })
+
   it('rejects and rolls back when pnpm resolves a newer but unexpected release', async () => {
     advanceNpmLatest('1.2.0')
     fake.npm['dsh-loop'].versions['1.1.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -34,6 +34,8 @@ const fake = vi.hoisted(() => ({
   tarballs: {} as Record<string, { name: string; manifest: unknown; artifacts?: string[] }>,
   /** Simulate pnpm minimumReleaseAge: adds resolve to the ALREADY INSTALLED version, exit 0. */
   staleUpdates: false,
+  /** Resolve the next npm add to this version even though the dist-tag points elsewhere. */
+  resolvedNpmVersionOnce: null as string | null,
   /** Fail the next N mutating commands with the hoist-pattern drift error. */
   hoistDiffTimes: 0,
   /** Simulate a too-young release in the lockfile (#39): every mutation
@@ -247,7 +249,8 @@ vi.mock('../src/dsh-cli.ts', () => {
       // pnpm minimumReleaseAge: "Already up to date", old version kept, exit 0.
       return ok
     }
-    const version = pkg.latest
+    const version = fake.resolvedNpmVersionOnce ?? pkg.latest
+    fake.resolvedNpmVersionOnce = null
     writeDep(name, `^${version}`)
     writePkg(name, { version, ...(pkg.versions[version].manifest as object) }, pkg.versions[version].artifacts, pkg.versions[version].artifactContents)
     if (fake.profileBundleOnNextAdd !== null) {
@@ -461,6 +464,7 @@ beforeEach(() => {
   fake.npm = {}
   fake.repos = {}
   fake.staleUpdates = false
+  fake.resolvedNpmVersionOnce = null
   fake.hoistDiffTimes = 0
   fake.youngLockfile = false
   fake.gate = null
@@ -1082,6 +1086,36 @@ describe('update flow — no npm publishing required', () => {
     // disk, `/dsh-market/status` still reporting 1.11.3, an unchanged boot
     // id, and this route calling it hot-loaded in the same response.
     expect(r.json.activation['dsh-loop']).toMatchObject({ state: 'restart', hot: false })
+  })
+
+  it('rejects and rolls back when pnpm silently resolves latest to an older release', async () => {
+    advanceNpmLatest('1.2.0')
+    fake.npm['dsh-loop'].versions['0.9.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
+    fake.resolvedNpmVersionOnce = '0.9.0'
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(502)
+    expect(r.json).toMatchObject({ ok: false, failureCode: 'DOWNGRADE_DETECTED' })
+    expect(String(r.json.error)).toMatch(/拒绝降级|downgrade was rejected/)
+    expect(installedSpec('dsh-loop')).toBe('^1.0.0')
+    const installed = JSON.parse(readFileSync(join(fake.profileDir, 'node_modules', 'dsh-loop', 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.0.0')
+  })
+
+  it('rejects and rolls back when pnpm resolves a newer but unexpected release', async () => {
+    advanceNpmLatest('1.2.0')
+    fake.npm['dsh-loop'].versions['1.1.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
+    fake.resolvedNpmVersionOnce = '1.1.0'
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(502)
+    expect(r.json).toMatchObject({ ok: false, failureCode: 'RESOLVED_VERSION_MISMATCH' })
+    expect(String(r.json.error)).toMatch(/目标为 v1\.2\.0|targeted v1\.2\.0/)
+    expect(installedSpec('dsh-loop')).toBe('^1.0.0')
+    const installed = JSON.parse(readFileSync(join(fake.profileDir, 'node_modules', 'dsh-loop', 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.0.0')
   })
 
   it('exposes a versioned capability and update-check contract for plugin-owned UIs', async () => {

--- a/tests/update-api-v1.spec.ts
+++ b/tests/update-api-v1.spec.ts
@@ -149,4 +149,27 @@ describe('public update API v1 operation model', () => {
       failure: { code: 'VERSION_UNCHANGED', retryable: true },
     })
   })
+
+  it('preserves post-install version-integrity failures for provider clients', () => {
+    const store = new UpdateOperationStoreV1('boot-version-integrity')
+    const downgrade = store.create('dsh-mcp-connector', '0.2.24')
+    store.start(downgrade.operationId)
+    expect(store.finish(downgrade.operationId, 502, {
+      failureCode: 'DOWNGRADE_DETECTED',
+      error: 'resolved to 0.2.23; previous build restored',
+    }, '0.2.24')).toMatchObject({
+      state: 'failed',
+      installedVersion: '0.2.24',
+      failure: { code: 'DOWNGRADE_DETECTED', retryable: false },
+    })
+
+    const mismatch = store.create('dsh-mcp-connector', '0.2.24')
+    store.start(mismatch.operationId)
+    expect(store.finish(mismatch.operationId, 502, {
+      failureCode: 'RESOLVED_VERSION_MISMATCH',
+      error: 'targeted 0.2.25 but installed 0.2.24; previous build restored',
+    }, '0.2.24')).toMatchObject({
+      failure: { code: 'RESOLVED_VERSION_MISMATCH', retryable: true },
+    })
+  })
 })


### PR DESCRIPTION
## What changed

- Verify the npm package version that pnpm actually installed before an update is reported as successful.
- Reject and automatically restore the pre-update build when pnpm resolves an older version or a version different from the registry target.
- Preserve `DOWNGRADE_DETECTED` and `RESOLVED_VERSION_MISMATCH` through the public Update API v1 operation model.
- Document the integrity guarantees and the client-side defense-in-depth requirement.

## Why

With pnpm `minimumReleaseAge` (or a lagging mirror), `pnpm add package@latest` can exit 0 while resolving an older release. The previous stale-update check only rejected an unchanged version, so a real downgrade such as 0.2.24 -> 0.2.23 was treated as a successful update.

## Checklist

- [x] `npm test` passes locally (50 test files, 1013 tests)
- [x] `npm run check` passes locally
- [x] Regression tests fail without the fix and cover both downgrade and unexpected-newer-version resolution
- [x] No version bump in `package.json`
- [x] No `src/client/` changes; generated client bundle is unchanged

## Verification

- TypeScript type checks passed
- Server and client builds passed
- Restart smoke test passed
- Public Update API v1 failure-code normalization tests passed
