### PR TITLE
fix: 校验触发的卸载不能再把 bundle 行留成孤儿

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -9,7 +9,7 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import type { InstallResult, PluginRunner } from './dsh-cli.ts'
 import { classifyPnpmFailure, HOST_NAMESPACE_RE, isTransientPnpmFailure } from './pnpm-compat.ts'
-import { conflictingEntryIds, hasDshManifest, hasLoadableEntry, pluginSubdirs, profileDir, readInstalled, readManifestDeps, readProfileBundles } from './profile.ts'
+import { conflictingEntryIds, dropFromManifest, hasDshManifest, hasLoadableEntry, pluginSubdirs, profileDir, readInstalled, readManifestDeps, readProfileBundles } from './profile.ts'
 import { logEvent } from './log.ts'
 import { cleanOrphanedStore } from './store.ts'
 
@@ -261,7 +261,7 @@ export async function validateAddedPlugins(
     // ship no entry of their own (#103) and must not be uninstalled here.
     if (!hasDshManifest(packageDir) || !hasLoadableEntry(dir, n)) {
       removedBroken.push(n)
-      await run(profile, ['remove', n])
+      await removeAndReconcile(run, profile, dir, n)
       continue
     }
     const clash = conflictingEntryIds(dir, n, existingBundles)
@@ -271,12 +271,47 @@ export async function validateAddedPlugins(
       removedBroken.push(n)
       logEvent('error', 'install',
         `${n}: loader entry id conflict with ${clash[0].owner} (${clash.map(hit => hit.id).join(', ')}) — removing, it would break the next boot`)
-      await run(profile, ['remove', n])
+      await removeAndReconcile(run, profile, dir, n)
       continue
     }
     keep.push(n)
   }
   return { added: addedNow, keep, removedBroken, conflicts }
+}
+
+/**
+ * Run one removal this validation triggered and reconcile the manifest by
+ * disk truth afterwards.
+ *
+ * The plugin command reconciles `dsh.profile.bundles` only when pnpm exits
+ * 0, and a remove can fail AFTER completing every persistent step — the #65
+ * write-order family — or exit 0 with the reconcile still not reflected in
+ * the manifest. Either way the bundle row left behind names a package the
+ * next boot cannot resolve, and the loader dies on the first such row: the
+ * whole profile, not just this plugin, refuses to start, with the market's
+ * own page unreachable. Disk truth decides the repair, deliberately: a
+ * package that is gone gets its manifest rows dropped so the boot stays
+ * loadable, while a package still on disk keeps them, because a retry needs
+ * something to retry against.
+ * @param run - the plugin runner, as the caller received it.
+ * @param profile - the profile name for manifest writes.
+ * @param dir - the profile directory the validation reads.
+ * @param name - the package being removed.
+ */
+async function removeAndReconcile(run: PluginRunner, profile: string, dir: string, name: string): Promise<void> {
+  const result = await run(profile, ['remove', name])
+  const gone = !existsSync(join(dir, 'node_modules', name, 'package.json'))
+  if (gone) {
+    if (dropFromManifest(profile, name, dir)) {
+      logEvent('error', 'install',
+        `${name}: remove ${result.exitCode === 0 ? 'skipped the manifest reconcile' : `failed (exit ${String(result.exitCode)})`} but the package is gone from disk — dropped its dependency/bundle rows so the next boot stays loadable`)
+    }
+    return
+  }
+  if (result.exitCode !== 0 || result.timedOut || result.cancelled) {
+    logEvent('error', 'install',
+      `${name}: remove failed (exit ${String(result.exitCode)})${result.timedOut ? ' timed out' : ''}${result.cancelled ? ' cancelled' : ''} and the package is still installed — its rows stay in the manifest; retry the uninstall`)
+  }
 }
 
 /**

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,13 +1,19 @@
 /**
- * In-memory event log for issue reports: what the market did and how it
- * failed, exportable as plain text from `/dsh-market/logs`.
+ * Event log for issue reports: what the market did and how it failed,
+ * exportable as plain text from `/dsh-market/logs`.
  *
  * Privacy: entries are sanitized on write — the home directory collapses to
  * `~`, and common credential shapes (API keys, GitHub/npm tokens, bearer
- * headers) are masked. Nothing is persisted to disk; the buffer dies with the
- * process and holds at most {@link MAX_ENTRIES} entries.
+ * headers) are masked. The in-memory buffer dies with the process and holds
+ * at most {@link MAX_ENTRIES} entries; a process that also configures a
+ * persistent sink appends every event there, capped at
+ * {@link PERSISTENT_MAX_BYTES}, because the failures worth reporting most —
+ * the ones that only appear after a restart — used to take their story with
+ * them when the process died (#341).
  */
 
+import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
 import { homedir } from 'node:os'
 
 export type LogLevel = 'info' | 'warn' | 'error'
@@ -21,8 +27,10 @@ interface LogEntry {
 
 const MAX_ENTRIES = 200
 const DETAIL_MAX = 600
+const PERSISTENT_MAX_BYTES = 256 * 1024
 
 const entries: LogEntry[] = []
+let persistentFile: string | null = null
 
 function sanitize(text: string): string {
   return text
@@ -47,13 +55,69 @@ function sanitize(text: string): string {
  * @param detail - free-form context; credentials and home paths are masked.
  */
 export function logEvent(level: LogLevel, event: string, detail: string): void {
-  entries.push({
+  const entry = {
     at: new Date().toISOString(),
     level,
     event,
     detail: sanitize(detail).slice(0, DETAIL_MAX),
-  })
+  }
+  entries.push(entry)
   if (entries.length > MAX_ENTRIES) entries.splice(0, entries.length - MAX_ENTRIES)
+  if (persistentFile === null) return
+  try {
+    appendFileSync(persistentFile, `${JSON.stringify(entry)}\n`)
+  } catch {
+    // Only append failures reach this: a read-only or full disk. The
+    // in-memory log still serves this session's export; persistence
+    // disables itself so one bad write cannot break every future event.
+    persistentFile = null
+  }
+}
+
+/**
+ * Append events to a profile-owned file, or stop doing so.
+ *
+ * Called once per mount with `<profile>/.dsh-market/log.ndjson` and with
+ * `null` on dispose. An oversized file is trimmed to its newest half on
+ * configure, so one long-lived profile cannot grow it without bound.
+ * @param file - the sink file, or null to disable persistence.
+ */
+export function configurePersistentLog(file: string | null): void {
+  persistentFile = file
+  if (file === null) return
+  try {
+    mkdirSync(dirname(file), { recursive: true })
+    if (!existsSync(file) || statSync(file).size <= PERSISTENT_MAX_BYTES) return
+    const lines = readFileSync(file, 'utf8').split('\n').filter(line => line !== '')
+    let kept: string[] = []
+    let bytes = 0
+    for (let index = lines.length - 1; index >= 0 && bytes <= PERSISTENT_MAX_BYTES / 2; index -= 1) {
+      kept.unshift(`${lines[index]!}\n`)
+      bytes += lines[index]!.length + 1
+    }
+    writeFileSync(file, kept.join(''))
+  } catch {
+    // Only configure-time filesystem failures reach this (the directory
+    // cannot be created, the file cannot be read or rewritten). The market
+    // must mount regardless; the session simply runs memory-only.
+    persistentFile = null
+  }
+}
+
+/**
+ * The newest persisted lines, for the export's prior-session section.
+ * @param file - the sink file to read.
+ * @param maxLines - how many trailing lines to return.
+ * @returns parsed-or-raw lines, newest last; empty when nothing is readable.
+ */
+export function readPersistentLog(file: string, maxLines = 80): string[] {
+  try {
+    return readFileSync(file, 'utf8').split('\n').filter(line => line !== '').slice(-maxLines)
+  } catch {
+    // Only a missing or unreadable file reaches this: there are no prior
+    // sessions to show, which is the empty answer.
+    return []
+  }
 }
 
 /**
@@ -61,7 +125,7 @@ export function logEvent(level: LogLevel, event: string, detail: string): void {
  * @param header - environment lines to prepend (version, platform — no paths).
  * @returns plain text, newest entry last.
  */
-export function exportLogs(header: Record<string, string>, snapshot: string[] = []): string {
+export function exportLogs(header: Record<string, string>, snapshot: string[] = [], priorSessions: string[] = []): string {
   const head = Object.entries(header).map(([key, value]) => `${key}: ${sanitize(value)}`)
   const lines = entries.map(e => `${e.at} [${e.level}] ${e.event}: ${e.detail}`)
   return [
@@ -74,6 +138,7 @@ export function exportLogs(header: Record<string, string>, snapshot: string[] = 
     // appear after a restart — were exactly the ones whose export said
     // "(no events this session)". This part still answers.
     ...(snapshot.length > 0 ? ['## profile state', ...snapshot.map(line => sanitize(line)), ''] : []),
+    ...(priorSessions.length > 0 ? ['## previous sessions (persisted log)', ...priorSessions.map(line => sanitize(line)), ''] : []),
     '## events this session',
     ...(lines.length > 0 ? lines : ['(none — the buffer starts empty on every start)']),
     '',

--- a/src/log.ts
+++ b/src/log.ts
@@ -31,6 +31,8 @@ const PERSISTENT_MAX_BYTES = 256 * 1024
 
 const entries: LogEntry[] = []
 let persistentFile: string | null = null
+/** Bytes in the sink file, tracked so the cap holds without a stat per event. */
+let persistentBytes = 0
 
 function sanitize(text: string): string {
   return text
@@ -65,13 +67,36 @@ export function logEvent(level: LogLevel, event: string, detail: string): void {
   if (entries.length > MAX_ENTRIES) entries.splice(0, entries.length - MAX_ENTRIES)
   if (persistentFile === null) return
   try {
-    appendFileSync(persistentFile, `${JSON.stringify(entry)}\n`)
+    const line = `${JSON.stringify(entry)}\n`
+    appendFileSync(persistentFile, line)
+    persistentBytes += line.length
+    // Trimming only on mount left the cap unenforced for the life of a
+    // process: 20k events grew the file to 3.2 MB in a measurement, and a
+    // retry loop is exactly the situation that both logs hardest and never
+    // restarts. Re-trim in place once the ceiling is crossed.
+    if (persistentBytes > PERSISTENT_MAX_BYTES) trimPersistentLog(persistentFile)
   } catch {
     // Only append failures reach this: a read-only or full disk. The
     // in-memory log still serves this session's export; persistence
     // disables itself so one bad write cannot break every future event.
     persistentFile = null
   }
+}
+
+/**
+ * Rewrite the sink keeping only its newest half, and resync the byte count.
+ * @param file - the sink file to trim in place.
+ */
+function trimPersistentLog(file: string): void {
+  const lines = readFileSync(file, 'utf8').split('\n').filter(line => line !== '')
+  const kept: string[] = []
+  let bytes = 0
+  for (let index = lines.length - 1; index >= 0 && bytes <= PERSISTENT_MAX_BYTES / 2; index -= 1) {
+    kept.unshift(`${lines[index]!}\n`)
+    bytes += lines[index]!.length + 1
+  }
+  writeFileSync(file, kept.join(''))
+  persistentBytes = bytes
 }
 
 /**
@@ -87,15 +112,9 @@ export function configurePersistentLog(file: string | null): void {
   if (file === null) return
   try {
     mkdirSync(dirname(file), { recursive: true })
-    if (!existsSync(file) || statSync(file).size <= PERSISTENT_MAX_BYTES) return
-    const lines = readFileSync(file, 'utf8').split('\n').filter(line => line !== '')
-    let kept: string[] = []
-    let bytes = 0
-    for (let index = lines.length - 1; index >= 0 && bytes <= PERSISTENT_MAX_BYTES / 2; index -= 1) {
-      kept.unshift(`${lines[index]!}\n`)
-      bytes += lines[index]!.length + 1
-    }
-    writeFileSync(file, kept.join(''))
+    persistentBytes = existsSync(file) ? statSync(file).size : 0
+    if (persistentBytes <= PERSISTENT_MAX_BYTES) return
+    trimPersistentLog(file)
   } catch {
     // Only configure-time filesystem failures reach this (the directory
     // cannot be created, the file cannot be read or rewritten). The market

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,7 +18,7 @@ import {
   mountClientOnlyDeps, purgeMarketState, readMarketState, writeMarketState,
 } from './hot.ts'
 import { createGroup, deleteGroup, removeFromGroups, renameGroup, setGroupMembers } from './groups.ts'
-import { exportLogs, logEvent } from './log.ts'
+import { configurePersistentLog, exportLogs, logEvent, readPersistentLog } from './log.ts'
 import { marketFetch } from './net.ts'
 import { diagnosePackageManifests } from './diagnostics.ts'
 import {
@@ -197,6 +197,8 @@ export function mountMarketRoutes(
     throw new Error(message)
   }
   const activeProfileDir = profileDir(config.profile, config.profileDirectory)
+  const persistentLogFile = join(activeProfileDir, '.dsh-market', 'log.ndjson')
+  configurePersistentLog(persistentLogFile)
   let agentGuardUnavailableLogged = false
   /** Running-agent ids for the mutation gate; logs once when the host exposes no agents service. */
   const runningAgentsForGuard = (): string[] => {
@@ -1925,7 +1927,7 @@ export function mountMarketRoutes(
           platform: `${process.platform} ${process.arch}`,
           node: process.version,
           profile: config.profile,
-        }, snapshot))
+        }, snapshot, readPersistentLog(persistentLogFile)))
       },
     }),
 
@@ -3368,6 +3370,7 @@ export function mountMarketRoutes(
   ]
 
   return () => {
+    configurePersistentLog(null)
     for (const dispose of disposers) dispose()
   }
 }

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { InstallResult } from '../src/dsh-cli.ts'
@@ -143,6 +143,113 @@ describe('validateAddedPlugins (#18 / #21)', () => {
     const { keep, conflicts } = await validateAddedPlugins(recordingRunner().run, 'web', new Set(['plug-a']))
     expect(keep).toEqual(['plug-b'])
     expect(conflicts).toEqual([])
+  })
+
+  it('drops the bundle row a failed remove already took off disk (#122)', async () => {
+    // pnpm's #65 write-order failure, on the remove side: every persistent
+    // step completes — node_modules unlinked, dependency saved — and the
+    // command still exits 1 (a hoisted-linker file lock aborts the tail).
+    // The plugin command reconciles dsh.profile.bundles only on exit 0, so
+    // the row it leaves behind names a package the next boot cannot
+    // resolve: the whole profile, not just this plugin, refuses to start.
+    const dir = writeProfile({ '@deepseek-ai/dsh-web-app': '^1.0.0', '@scope/dsh-tui': 'github:o/dsh-tui' })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      dependencies: { '@deepseek-ai/dsh-web-app': '^1.0.0', '@scope/dsh-tui': 'github:o/dsh-tui' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-web-app', '@scope/dsh-tui'] } },
+    }))
+    const patch = (id: string, name: string) => `- insert:\n    - id: ${id}\n      name: '${name}'\n`
+    writePkg(dir, '@deepseek-ai/dsh-web-app', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'i.js' }, ['i.js'])
+    writeFileSync(join(dir, 'node_modules', '@deepseek-ai/dsh-web-app', 'cordis.patch.yml'), patch('storage', '@deepseek-ai/dsh-storage'))
+    writePkg(dir, '@scope/dsh-tui', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'i.js' }, ['i.js'])
+    writeFileSync(join(dir, 'node_modules', '@scope/dsh-tui', 'cordis.patch.yml'), patch('storage', '@deepseek-ai/dsh-storage'))
+
+    const calls: string[][] = []
+    const run = (profile: string, args: string[]): Promise<InstallResult> => {
+      calls.push(args)
+      if (args[0] === 'remove') {
+        const manifestFile = join(dir, 'package.json')
+        const manifest = JSON.parse(readFileSync(manifestFile, 'utf8')) as {
+          dependencies: Record<string, string>
+          dsh?: { profile?: { bundles?: string[] } }
+        }
+        delete manifest.dependencies[args[1]!]
+        writeFileSync(manifestFile, JSON.stringify(manifest, null, 2))
+        rmSync(join(dir, 'node_modules', args[1]!), { recursive: true, force: true })
+        return Promise.resolve({ ...ok, exitCode: 1 })
+      }
+      return Promise.resolve(ok)
+    }
+
+    const { removedBroken } = await validateAddedPlugins(run, 'web', new Set(['@deepseek-ai/dsh-web-app']))
+    expect(removedBroken).toEqual(['@scope/dsh-tui'])
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+      dsh: { profile: { bundles: string[] } }
+    }
+    expect(Object.keys(manifest.dependencies)).toEqual(['@deepseek-ai/dsh-web-app'])
+    expect(manifest.dsh.profile.bundles).toEqual(['@deepseek-ai/dsh-web-app'])
+  })
+
+  it('drops the bundle row when a clean-exit remove skipped the manifest reconcile', async () => {
+    // A remove that bypasses the plugin command (raw pnpm in the profile
+    // directory, a drift-recovery install re-run) cleans pnpm's own state
+    // and exits 0, but nothing reconciles dsh.profile.bundles. Disk truth
+    // is the same as the failing case and must land the same way.
+    const dir = writeProfile({ '@deepseek-ai/dsh-web-app': '^1.0.0', '@scope/dsh-tui': 'github:o/dsh-tui' })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      dependencies: { '@deepseek-ai/dsh-web-app': '^1.0.0', '@scope/dsh-tui': 'github:o/dsh-tui' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-web-app', '@scope/dsh-tui'] } },
+    }))
+    const patch = (id: string, name: string) => `- insert:\n    - id: ${id}\n      name: '${name}'\n`
+    writePkg(dir, '@deepseek-ai/dsh-web-app', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'i.js' }, ['i.js'])
+    writeFileSync(join(dir, 'node_modules', '@deepseek-ai/dsh-web-app', 'cordis.patch.yml'), patch('storage', '@deepseek-ai/dsh-storage'))
+    writePkg(dir, '@scope/dsh-tui', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'i.js' }, ['i.js'])
+    writeFileSync(join(dir, 'node_modules', '@scope/dsh-tui', 'cordis.patch.yml'), patch('storage', '@deepseek-ai/dsh-storage'))
+
+    const run = (profile: string, args: string[]): Promise<InstallResult> => {
+      if (args[0] !== 'remove') return Promise.resolve(ok)
+      const manifestFile = join(dir, 'package.json')
+      const manifest = JSON.parse(readFileSync(manifestFile, 'utf8')) as {
+        dependencies: Record<string, string>
+      }
+      delete manifest.dependencies[args[1]!]
+      writeFileSync(manifestFile, JSON.stringify(manifest, null, 2))
+      rmSync(join(dir, 'node_modules', args[1]!), { recursive: true, force: true })
+      return Promise.resolve(ok)
+    }
+
+    await validateAddedPlugins(run, 'web', new Set(['@deepseek-ai/dsh-web-app']))
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+      dsh: { profile: { bundles: string[] } }
+    }
+    expect(manifest.dsh.profile.bundles).toEqual(['@deepseek-ai/dsh-web-app'])
+  })
+
+  it('keeps the manifest rows of a failed remove whose package is still on disk', async () => {
+    // The other half of disk truth: a remove that failed BEFORE deleting
+    // anything leaves an intact installation. Dropping the rows here would
+    // orphan a dependency the profile can still load; a retry needs them.
+    const dir = writeProfile({ '@deepseek-ai/dsh-web-app': '^1.0.0', '@scope/dsh-tui': 'github:o/dsh-tui' })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      dependencies: { '@deepseek-ai/dsh-web-app': '^1.0.0', '@scope/dsh-tui': 'github:o/dsh-tui' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-web-app', '@scope/dsh-tui'] } },
+    }))
+    const patch = (id: string, name: string) => `- insert:\n    - id: ${id}\n      name: '${name}'\n`
+    writePkg(dir, '@deepseek-ai/dsh-web-app', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'i.js' }, ['i.js'])
+    writeFileSync(join(dir, 'node_modules', '@deepseek-ai/dsh-web-app', 'cordis.patch.yml'), patch('storage', '@deepseek-ai/dsh-storage'))
+    writePkg(dir, '@scope/dsh-tui', { dsh: { bundle: { patch: './cordis.patch.yml' } }, main: 'i.js' }, ['i.js'])
+    writeFileSync(join(dir, 'node_modules', '@scope/dsh-tui', 'cordis.patch.yml'), patch('storage', '@deepseek-ai/dsh-storage'))
+
+    const run = (_profile: string, args: string[]): Promise<InstallResult> =>
+      Promise.resolve(args[0] === 'remove' ? { ...ok, exitCode: 1 } : ok)
+
+    await validateAddedPlugins(run, 'web', new Set(['@deepseek-ai/dsh-web-app']))
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+      dsh: { profile: { bundles: string[] } }
+    }
+    expect(manifest.dependencies['@scope/dsh-tui']).toBe('github:o/dsh-tui')
+    expect(manifest.dsh.profile.bundles).toContain('@scope/dsh-tui')
   })
 
   it('groups clash hits by the installed plugin that owns them', () => {

--- a/tests/log-persistence.spec.ts
+++ b/tests/log-persistence.spec.ts
@@ -27,7 +27,12 @@ describe('persistent log sink', () => {
     const lines = readPersistentLog(logFile)
     expect(lines).toHaveLength(1)
     const entry = JSON.parse(lines[0]!) as { detail: string }
-    expect(entry.detail).toContain('~/.dsh/profiles/web')
+    // The redaction folds the home prefix to `~` and leaves the rest of the
+    // path exactly as the machine writes it — a log pasted into an issue
+    // should read like the reporter's own filesystem. So the expectation has
+    // to be built the same way rather than hardcoding a POSIX separator,
+    // which is what made this fail on Windows only.
+    expect(entry.detail).toContain(join('~', '.dsh', 'profiles', 'web'))
     expect(entry.detail).not.toContain('sk-abcdefgh12345678')
   })
 

--- a/tests/log-persistence.spec.ts
+++ b/tests/log-persistence.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { configurePersistentLog, exportLogs, logEvent, readPersistentLog } from '../src/log.ts'
@@ -38,6 +38,20 @@ describe('persistent log sink', () => {
     const trimmed = readFileSync(logFile, 'utf8')
     expect(trimmed.length).toBeLessThanOrEqual(128 * 1024 + 128)
     expect(trimmed.endsWith('x\n')).toBe(true)
+  })
+
+  it('holds the cap while the process keeps running, not only at mount', () => {
+    // Trimming only on configure left the ceiling unenforced for the life of
+    // a process. Measured before the fix: 20k events grew the file to 3.2 MB.
+    // A retry loop is precisely the case that logs hardest and never restarts,
+    // so the process that most needs this log is the one that would blow it up.
+    configurePersistentLog(logFile)
+    for (let i = 0; i < 6000; i++) logEvent('error', 'install', `${'x'.repeat(120)} ${i}`)
+    expect(statSync(logFile).size).toBeLessThanOrEqual(256 * 1024)
+    // Still usable, and still holding the NEWEST events rather than the oldest.
+    const lines = readPersistentLog(logFile)
+    expect(lines.length).toBeGreaterThan(0)
+    expect(JSON.parse(lines[lines.length - 1]!).detail).toContain('5999')
   })
 
   it('keeps exportLogs readable with and without prior sessions', () => {

--- a/tests/log-persistence.spec.ts
+++ b/tests/log-persistence.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Persistent log sink: every market event survives the process, capped and
+ * sanitized, and the export carries prior sessions alongside this one.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { configurePersistentLog, exportLogs, logEvent, readPersistentLog } from '../src/log.ts'
+
+let home: string
+let logFile: string
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'dshm-log-'))
+  logFile = join(home, '.dsh-market', 'log.ndjson')
+})
+afterEach(() => {
+  configurePersistentLog(null)
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe('persistent log sink', () => {
+  it('appends sanitized events as ndjson and reads the tail back', () => {
+    configurePersistentLog(logFile)
+    logEvent('warn', 'install', `failed under ${join(homedir(), '.dsh', 'profiles', 'web')} with token sk-abcdefgh12345678`)
+    const lines = readPersistentLog(logFile)
+    expect(lines).toHaveLength(1)
+    const entry = JSON.parse(lines[0]!) as { detail: string }
+    expect(entry.detail).toContain('~/.dsh/profiles/web')
+    expect(entry.detail).not.toContain('sk-abcdefgh12345678')
+  })
+
+  it('trims an oversized file to its newest half on configure', () => {
+    mkdirSync(join(home, '.dsh-market'), { recursive: true })
+    writeFileSync(logFile, `${'x'.repeat(64)}\n`.repeat(6000))
+    configurePersistentLog(logFile)
+    const trimmed = readFileSync(logFile, 'utf8')
+    expect(trimmed.length).toBeLessThanOrEqual(128 * 1024 + 128)
+    expect(trimmed.endsWith('x\n')).toBe(true)
+  })
+
+  it('keeps exportLogs readable with and without prior sessions', () => {
+    configurePersistentLog(logFile)
+    logEvent('error', 'install', 'remove failed (exit 1) but the package is gone')
+    configurePersistentLog(null)
+    logEvent('info', 'uninstall', 'a fresh process event')
+    const exported = exportLogs({ 'dsh-market': 'test' }, ['bundles (1):', '  plug-a: NOT RESOLVED'], readPersistentLog(logFile))
+    expect(exported).toContain('## previous sessions (persisted log)')
+    expect(exported).toContain('remove failed (exit 1)')
+    expect(exported).toContain('## events this session')
+    expect(exported).toContain('a fresh process event')
+    expect(exportLogs({}, [], readPersistentLog(join(home, 'absent.ndjson')))).not.toContain('previous sessions')
+  })
+})


### PR DESCRIPTION
Closes #387。

## 用户看到的现象

通过插件市场把 `@deepseek-harness-tui/dsh-tui`（TUI 应用 bundle）装进 web profile 后，**整个 profile 无法启动**：

```
dsh: cannot resolve profile bundle "@deepseek-harness-tui/dsh-tui"
```

报错发生在所有插件加载之前——Web UI、market 自己的页面全部不可访问。磁盘上是一个"半卸载"状态：`dependencies` 和 lockfile 里的包已消失、`node_modules` 只剩空 scope 目录、而 `dsh.profile.bundles` 里那一行还在，loader 读到它就整棵树拒绝加载。

## 根因

`validateAddedPlugins` 移除会搞坏下次启动的包（#122 的 loader 条目 id 冲突、#21 的纯源码包）时，调用插件命令的 `remove`——然后完全忽略其结果（1.31.1 和当前 main 都一样）：

```ts
removedBroken.push(n)
await run(profile, ['remove', n])
continue
```

插件命令只在 pnpm exit 0 时才 reconcile `dsh.profile.bundles`。而一次 remove 可以在**完成全部持久化步骤之后**才失败——#65 写序失败家族——或者 exit 0 但 reconcile 未体现在 manifest 里。无论哪种，留下的 bundle 行都指向一个下次启动无法解析的包。卸载路由从 #65/#339 起就用磁盘真相防御了完全相同的 pnpm 行为；校验路径从来没有。

## 修复

校验触发的每次移除之后，按卸载路由相同的磁盘真相复核：

- 包**已从磁盘消失** → `dropFromManifest`（依赖 + bundle 行），保住启动，并以 error 级事件说明发生了什么；
- 包**仍在磁盘上** → manifest 行原样保留，因为重试需要有据可依；失败的移除现在会大声记日志，而不是无声地当作"已移除"。

## 日志现在能在进程死后留存

事件日志原来只在内存里——最值得上报的失败（只在重启后出现的那些）的故事随进程一起消失；#341 用 profile 状态快照绕过了这个问题，但事件本身仍然会丢。

`mountMarketRoutes` 现在把 sink 指向 `<profile>/.dsh-market/log.ndjson`：

- 每次 `logEvent` 追加一行脱敏的 ndjson（与导出相同的脱敏：home 路径折叠、凭证形态打码）；
- 上限 256 KB，挂载时裁到最新一半；
- 追加失败则本会话禁用持久化——日志永远不能弄坏安装；
- `/dsh-market/logs` 在本会话事件之前新增 `## previous sessions (persisted log)` 段，brick 之后存活下来的那个进程的报告也能带出肇事那次的故事。

## 测试

`tests/install.spec.ts` —— 复核逻辑的三个行为测试：

1. remove 在把包从磁盘删掉之后以 1 退出 → 清掉孤儿 bundle 行（事故原形）；
2. exit 0 但 manifest 的 reconcile 被跳过 → 同样清掉；
3. remove 失败但包仍在磁盘上 → 所有行保留（可重试），与卸载路由的规则一致。

既有的 `validateAddedPlugins` 测试全部原样通过：录制型 fake 返回 exit 0 且包在磁盘上，正好落在"保留行"分支。

`tests/log-persistence.spec.ts` —— 追加 + 脱敏 + 尾部读取、挂载时裁剪、导出的前次会话段（文件有内容时出现，没有时不出现）。

## 套件之外的验证

在干净 `DSH_HOME` 下用真实 `dsh web`、以 `link:` 安装本分支的 market、走真实 HTTP 流程：

- 事件实时落进 `<profile>/.dsh-market/log.ndjson`；
- 杀掉并重启宿主后，`GET /dsh-market/logs` 在 `## previous sessions (persisted log)` 段下显示上一个进程的事件，而 `## events this session` 正确地为空。

本机全量 `npm test` 与未修改的 main 分支逐条失败一致（网络/region-probe 敏感的用例）；本分支不引入新失败，`npm run typecheck` 和 `npm run build` 通过。