### PR TITLE
Explain a Windows locked-file rename instead of showing pnpm's stack

### DIFF
--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -45,7 +45,7 @@ export const HOST_NAMESPACE_RE = /^@deepseek-ai\//
 export interface PnpmFailure {
   code: 'adding-to-root' | 'not-a-workspace' | 'hoist-pattern-diff' | 'pnpm-missing' | 'release-age-violation'
     | 'ignored-builds' | 'git-prepare-not-allowed' | 'fetch-404' | 'transient-network' | 'fetch-timeout'
-    | 'unexpected-store' | 'patch-failed' | 'missing-tarball-integrity'
+    | 'unexpected-store' | 'patch-failed' | 'missing-tarball-integrity' | 'windows-file-locked'
   /** Bilingual, actionable message shown to the user instead of the raw wall of text. */
   message: string
   /** True when re-running `pnpm install` in the profile is the documented recovery. */
@@ -266,6 +266,34 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
       recoverable: false,
       pkg,
       message: `有一个依赖在 registry 上不存在${zh}，pnpm 因此拒绝任何安装操作。它可能是之前失败操作残留在 profile package.json 里的幽灵依赖（可手动删除该行），也可能是需要登录的私有包 / a dependency cannot be resolved from the registry${en}; pnpm refuses every install while it is present. It may be a ghost entry left in the profile's package.json by an earlier failed operation (remove that line by hand), or a private package needing registry credentials`,
+    }
+  }
+  // #389 by @qq1054435284: on Windows, pnpm stages the new version in a
+  // sibling `<name>_tmp_<pid>_<n>` directory and renames it over the old one.
+  // Windows refuses that rename while any file underneath the target is open
+  // — and for an UPDATE the target is a plugin the running dsh has loaded, so
+  // its own files are exactly the ones held open. POSIX does not have this
+  // problem: replacing an open file there leaves the old inode alive for
+  // whoever still holds it.
+  //
+  // Not retried automatically. A retry from inside the same process cannot
+  // win, because that process is the thing holding the handles; retrying
+  // would only turn one clear failure into several slow ones. So this names
+  // the cause and the two ways out instead of guessing.
+  if (/ERR_PNPM_EPERM|EPERM: operation not permitted, rename/i.test(output)) {
+    // Read through the NDJSON reporter like the integrity classifier does:
+    // in production this arrives JSON-escaped, so every separator is doubled
+    // and a single-character class silently matches nothing.
+    const diagnostic = withDecodedPnpmDiagnostics(output)
+    const pkg = /node_modules[\\/]+((?:@[a-z0-9][a-z0-9._-]*[\\/]+)?[a-z0-9][a-z0-9._-]*)_tmp_\d+/i
+      .exec(diagnostic)?.[1]?.replace(/\\+/g, '/')
+    const zh = pkg === undefined ? '' : `（${pkg}）`
+    const en = pkg === undefined ? '' : ` (${pkg})`
+    return {
+      code: 'windows-file-locked',
+      recoverable: false,
+      ...(pkg === undefined ? {} : { pkg }),
+      message: `Windows 不允许替换正在被打开的文件，而更新一个插件${zh}要替换的正是当前 DeepSeek Harness 已经加载的那些文件，所以 pnpm 改名失败、更新没有生效（原来的版本没有被破坏，仍可正常使用）。两种做法：完全退出 DeepSeek Harness 后在命令行执行一次更新；或先在「已安装」里停用该插件、重启、再更新。杀毒软件或文件索引临时占用目录也会造成同样的报错，若上述都不适用可稍后重试 / Windows will not replace a file that is open, and updating a plugin${en} replaces exactly the files the running DeepSeek Harness has loaded, so pnpm's rename failed and the update did not apply (the existing version is intact and still works). Two ways round it: quit DeepSeek Harness completely and run the update from the command line, or disable the plugin under Installed, restart, then update. Antivirus or a file indexer holding the directory produces the same error, so a later retry is worth trying if neither applies`,
     }
   }
   // #83: pnpm replays the WHOLE dependency tree on every add/remove, so a

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -83,6 +83,32 @@ describe('classifyPnpmFailure', () => {
     expect(failed?.message).toContain('patchedDependencies')
   })
 
+  it('explains a Windows locked-file rename instead of showing pnpm\'s stack (#389)', () => {
+    // Verbatim from @qq1054435284's exported log: updating a plugin the
+    // running dsh has loaded. pnpm stages the new version beside the old one
+    // and renames it over; Windows refuses while the target's files are open,
+    // and for an update the process holding them is the one asking.
+    const failed = classifyPnpmFailure(String.raw`{"name":"pnpm","level":"error","err":{"code":"ERR_PNPM_EPERM","message":"[importPackage ~\\.dsh\\profiles\\web\\node_modules\\dsh-passwords] EPERM: operation not permitted, rename '~\\.dsh\\profiles\\web\\node_modules\\dsh-passwords_tmp_38728_10' -> '~\\.dsh\\profiles\\web\\node_modules\\dsh-passwords'"}}`)
+
+    expect(failed?.code).toBe('windows-file-locked')
+    expect(failed?.pkg).toBe('dsh-passwords')
+    // Says which plugin, that nothing was broken, and what to do about it.
+    expect(failed?.message).toContain('dsh-passwords')
+    expect(failed?.message).toContain('原来的版本没有被破坏')
+    expect(failed?.message).toContain('quit DeepSeek Harness')
+    // Not retried: the process that would retry is the one holding the files.
+    expect(failed?.recoverable).toBe(false)
+    expect(failed?.message).not.toContain('undefined')
+  })
+
+  it('classifies a locked rename with no readable package name (#389)', () => {
+    const generic = classifyPnpmFailure('ERR_PNPM_EPERM: something the reporter reworded')
+    expect(generic?.code).toBe('windows-file-locked')
+    expect(generic?.pkg).toBeUndefined()
+    expect(generic?.message).not.toContain('undefined')
+    expect(generic?.message).not.toContain('（）')
+  })
+
   it('names the tarball dependency whose lockfile entry has no integrity (#367)', () => {
     const failed = classifyPnpmFailure(`[ERR_PNPM_MISSING_TARBALL_INTEGRITY] Cannot install package
 "dsh-think-translate@https://gh-proxy.com/https://codeload.github.com/UncleK/dsh-think-translate/tar.gz/ba71a9bb88f52bc7bbf42225cfb69f7ef8d16900": its lockfile entry has no "integrity" field,


### PR DESCRIPTION
Closes #389.

@qq1054435284 pressed Update and got a pnpm stack trace ending in a path inside the pnpm store. What happened is specific and explainable:

pnpm stages the new version in a sibling `<name>_tmp_<pid>_<n>` directory and renames it over the old one. Windows refuses that rename while any file underneath the target is open — and for an **update** the target is a plugin the running dsh has loaded, so its own files are exactly the ones held open. POSIX never hits this: replacing an open file leaves the old inode alive for whoever still holds it.

The message now:

- names the plugin,
- says the existing version is intact — it is, the rename failed so nothing was replaced,
- gives two ways out: quit the harness and update from the command line, or disable the plugin under Installed, restart, then update,
- names antivirus and file indexers, which hold a directory long enough to produce the identical error and are the one case where a later retry does work.

**Not retried automatically**, deliberately: the process that would retry is the one holding the handles. A retry cannot win, and would turn one clear failure into several slow ones.

## One thing the tests caught

The package name is extracted through `withDecodedPnpmDiagnostics`, like the integrity classifier. In production the error arrives JSON-escaped from pnpm's NDJSON reporter with every separator doubled, so the first version of the regex — a single-character class — matched nothing. The test is built from @qq1054435284's actual exported log rather than a hand-written string, which is what surfaced it.

1035 tests pass.