### PR TITLE
fix: bypass PowerShell policy for Windows restart

### DIFF
--- a/src/restart.ts
+++ b/src/restart.ts
@@ -167,13 +167,18 @@ export function respawnInvocation(
     return { file: launch.file, args: launch.args, viaShell: launch.viaShell, detached: true }
   }
   // PowerShell single-quoting: only embedded single quotes need escaping
-  // (doubled). The & call operator runs .exe/.cmd/.bat alike, so the
-  // original viaShell (cmd-shim) case needs no extra shell.
+  // (doubled). Name the cmd shim explicitly: invoking bare `dsh` lets
+  // PowerShell prefer dsh.ps1, which a default Restricted execution policy
+  // refuses before the replacement can start (#397). `dsh.cmd` is produced
+  // by the same npm install and is not governed by PowerShell script policy.
   const quote = (part: string): string => `'${part.replace(/'/g, "''")}'`
+  const file = launch.viaShell && !/\.(?:cmd|bat)$/iu.test(launch.file)
+    ? `${launch.file}.cmd`
+    : launch.file
   return {
     file: 'powershell.exe',
     args: ['-NoProfile', '-WindowStyle', 'Hidden', '-Command',
-      [`& ${quote(launch.file)}`, ...launch.args.map(quote)].join(' ')],
+      [`& ${quote(file)}`, ...launch.args.map(quote)].join(' ')],
     viaShell: false,
     detached: false,
   }

--- a/tests/restart.spec.ts
+++ b/tests/restart.spec.ts
@@ -31,6 +31,11 @@ describe('respawnInvocation (#40)', () => {
     expect(spawned.args[4]).toBe("& 'C:\\it''s here\\dsh.cmd'")
   })
 
+  it('names the cmd shim explicitly so Restricted policy cannot select dsh.ps1 (#397)', () => {
+    const spawned = respawnInvocation({ file: 'dsh', args: ['web'], viaShell: true }, 'win32')
+    expect(spawned.args[4]).toBe("& 'dsh.cmd' 'web'")
+  })
+
   it('keeps the plain detached spawn on POSIX', () => {
     const spawned = respawnInvocation({ file: 'node', args: ['bin.ts'], viaShell: false }, 'darwin')
     expect(spawned).toEqual({ file: 'node', args: ['bin.ts'], viaShell: false, detached: true })


### PR DESCRIPTION
Fixes #397

### What happened

On the rare `dshArgv()` fallback, Windows restart handed bare `dsh` to a hidden PowerShell. PowerShell prefers `dsh.ps1`; a Restricted execution policy refuses it after the old host has already exited, so the replacement never starts.

### What changed

When the restart launch is explicitly marked as a Windows cmd-shim fallback, name `dsh.cmd` in the hidden PowerShell invocation. npm installs both shims, and `.cmd` is not governed by PowerShell script execution policy. Direct Node/source launches and already explicit `.cmd`/`.bat` paths are unchanged.

### Verification

- Reproduced with npm's equivalent shim pair under `-ExecutionPolicy Restricted`: bare `npm` failed on `npm.ps1`; `npm.cmd` succeeded.
- `npx vitest run tests/restart.spec.ts tests/restart-helper.spec.ts` — 25 passed
- `npm test` — 1,040 passed, 1 skipped (1,041 total)
- `npm run check` — typecheck, build, client bundle, restart smoke
- `node scripts/validate-registry.mjs` — registry ok
