### PR TITLE
docs: add Local DSH to Friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ DSHM_REGISTRY_URL=https://your-mirror.example/plugins.json dsh web
 
 [dsh-app](https://github.com/RyensX/dsh-app) — a DeepSeek Harness desktop client built on Tauri 2 rather than Electron, so it ships a much smaller binary and uses the system webview. AGPL-3.0.
 
+### Local DSH
+
+[local-dsh](https://github.com/liangchen-harold/local-dsh) — an open-source DeepSeek Harness desktop client that runs LLMs locally through llama.cpp, built on Tauri and ships a smaller binary.
+
 ### DSH Get
 
 [DSH Get](https://www.dshget.com/) — a searchable web directory for discovering DeepSeek Harness plugins: category filters, bilingual descriptions, install commands and per-plugin detail pages. Its normalized catalog snapshot is public at [bobby-sheng/dshget-data](https://github.com/bobby-sheng/dshget-data).

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ DSHM_REGISTRY_URL=https://your-mirror.example/plugins.json dsh web
 
 ### Local DSH
 
-[local-dsh](https://github.com/liangchen-harold/local-dsh) — an open-source DeepSeek Harness desktop client that runs LLMs locally through llama.cpp, built on Tauri and ships a smaller binary.
+[local-dsh](https://github.com/liangchen-harold/local-dsh) — a DeepSeek Harness desktop client that can run the model on your own machine: it bundles llama.cpp next to Node, pnpm and DSH, so a downloaded GGUF model answers without any external API. Built on Tauri; Apple Silicon Macs for now. [localdsh.com](https://localdsh.com)
 
 ### DSH Get
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -114,7 +114,7 @@ DSHM_REGISTRY_URL=https://your-mirror.example/plugins.json dsh web
 
 ### Local DSH
 
-[local-dsh](https://github.com/liangchen-harold/local-dsh)——包含端侧模型运行能力的开源 DeepSeek Harness 桌面客户端，基于 Turi 构建，极致精简的打包，快速启动。
+[local-dsh](https://github.com/liangchen-harold/local-dsh)——可以把模型跑在本机的 DeepSeek Harness 桌面客户端：发行包内置 llama.cpp 与 Node、pnpm、DSH，下载一个 GGUF 模型就能对话，不必接外部 API。基于 Tauri 构建；目前支持 Apple 芯片的 Mac。[localdsh.com](https://localdsh.com)
 
 ### DSH Get
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -112,6 +112,10 @@ DSHM_REGISTRY_URL=https://your-mirror.example/plugins.json dsh web
 
 [dsh-app](https://github.com/RyensX/dsh-app)——基于 Tauri 2（而非 Electron）的 DeepSeek Harness 桌面客户端，因此安装包小得多，界面走系统 webview。AGPL-3.0。
 
+### Local DSH
+
+[local-dsh](https://github.com/liangchen-harold/local-dsh)——包含端侧模型运行能力的开源 DeepSeek Harness 桌面客户端，基于 Turi 构建，极致精简的打包，快速启动。
+
 ### DSH Get
 
 [DSH Get](https://www.dshget.com/)——DeepSeek Harness 插件的网页检索目录：分类筛选、中英描述、安装命令与插件详情页；其规范化的目录快照公开在 [bobby-sheng/dshget-data](https://github.com/bobby-sheng/dshget-data)。


### PR DESCRIPTION
Add [Local DSH](https://github.com/liangchen-harold/local-dsh) to the Friends

Local DSH is an open-source DeepSeek Harness desktop client that integrates local GGUF model inference through llama.cpp.
Local DSH是一个包含端侧模型运行能力的开源 DeepSeek Harness 桌面客户端，基于 Turi 构建，极致精简的打包，快速启动。

- Repository: https://github.com/liangchen-harold/local-dsh
- Website: https://localdsh.com

