### PR TITLE
fix: resolve bundled DSH host in Desktop diagnostics

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -31,7 +31,10 @@ import { createRequire, isBuiltin } from 'node:module'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { JSON_SCHEMA, Type, load } from 'js-yaml'
+import { findDshInstallDir } from './dsh-install.ts'
 import { INBOX_BUNDLES, readBundleRules, suggestOrder, validateOrder } from './order.ts'
+
+export { findDshInstallDir } from './dsh-install.ts'
 
 /** js-yaml dialect for `!!js` scalars — identical to dsh-app-boot's entryListSchema. */
 const jsExpr = new Type('tag:yaml.org,2002:js', {
@@ -202,7 +205,7 @@ export interface CheckReport {
 }
 
 export interface CheckOptions {
-  /** DSH host installation dir; auto-detected from process.argv when omitted (tests inject it). */
+  /** DSH host install dir; auto-detected from the CLI entry or Desktop resources when omitted. */
   dshInstallDir?: string
   /** Harness home for the home-level patch layer; defaults to $DSH_HOME or ~/.dsh. */
   homeDir?: string
@@ -337,26 +340,6 @@ export function corePackageNames(dshInstallDir: string | null): Set<string> {
     if (typeof manifest.name === 'string') names.add(manifest.name)
   } catch { /* not a package dir */ }
   return names
-}
-
-/**
- * Locate the dsh host installation from the process entry (the same source
- * dsh-cli.ts uses to re-invoke the CLI): walk up from dirname(argv[1]) until
- * a package.json named @deepseek-ai/dsh is found.
- */
-export function findDshInstallDir(entry = process.argv[1]): string | null {
-  if (entry === undefined) return null
-  let dir = resolve(dirname(entry))
-  for (let depth = 0; depth < 10; depth += 1) {
-    try {
-      const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as { name?: unknown }
-      if (manifest.name === '@deepseek-ai/dsh') return dir
-    } catch { /* keep walking up */ }
-    const parent = dirname(dir)
-    if (parent === dir) return null
-    dir = parent
-  }
-  return null
 }
 
 /** Version of `name` as physically resolved at `base`/node_modules, or null. */
@@ -934,9 +917,8 @@ export function buildBundleLayers(
       // An in-box bundle is supplied by the dsh INSTALLATION, not by the
       // profile — that is what makes it in-box. So failing to find one says
       // we could not locate the installation, not that the profile is
-      // broken: on DSH Desktop dsh lives inside the app bundle and
-      // findDshInstallDir() walks up from process.argv[1], which is
-      // Electron's entry and leads nowhere near it.
+      // broken: unusual or older hosts can still hide the in-box installation
+      // from both the CLI-entry and packaged-Desktop discovery anchors.
       //
       // Calling that "will fail to boot" turned a working composition into a
       // fatal verdict and rolled back a good update (#369) — while `dsh

--- a/src/dsh-install.ts
+++ b/src/dsh-install.ts
@@ -1,0 +1,50 @@
+/** Locate the DSH host package in CLI and packaged Desktop runtimes. */
+
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+const DSH_PACKAGE = '@deepseek-ai/dsh'
+
+function isDshPackage(directory: string): boolean {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(directory, 'package.json'), 'utf8'),
+    ) as { name?: unknown }
+    return manifest.name === DSH_PACKAGE
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Walk up from the CLI entry first, then inspect Electron's authoritative
+ * resources directory. Desktop distributions may keep node_modules outside
+ * the ASAR, expose them through ASAR's virtual filesystem, or disable ASAR.
+ */
+export function findDshInstallDir(entry = process.argv[1]): string | null {
+  if (entry !== undefined) {
+    let directory = resolve(dirname(entry))
+    for (let depth = 0; depth < 10; depth += 1) {
+      if (isDshPackage(directory)) return directory
+      const parent = dirname(directory)
+      if (parent === directory) break
+      directory = parent
+    }
+  }
+
+  const electronProcess = process as NodeJS.Process & { resourcesPath?: unknown }
+  if (typeof electronProcess.resourcesPath !== 'string'
+    || electronProcess.resourcesPath.length === 0) return null
+
+  for (const applicationRoot of ['app.asar.unpacked', 'app.asar', 'app']) {
+    const candidate = join(
+      electronProcess.resourcesPath,
+      applicationRoot,
+      'node_modules',
+      '@deepseek-ai',
+      'dsh',
+    )
+    if (isDshPackage(candidate)) return candidate
+  }
+  return null
+}

--- a/src/order.ts
+++ b/src/order.ts
@@ -15,7 +15,8 @@
 
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { dirname, join, resolve } from 'node:path'
+import { join } from 'node:path'
+import { findDshInstallDir } from './dsh-install.ts'
 
 /** Profile bundles that ship with the dsh host and must stay put (#98). */
 export const INBOX_BUNDLES = new Set([
@@ -74,26 +75,6 @@ export function readBundleStack(profileDir: string): BundleStack {
   } catch {
     return { bundles: [], community: [] }
   }
-}
-
-/**
- * Locate the dsh host installation from the process entry (same source as
- * dsh-cli.ts / check.ts): walk up from dirname(argv[1]) until a package.json
- * named @deepseek-ai/dsh is found.
- */
-function findDshInstallDir(entry = process.argv[1]): string | null {
-  if (entry === undefined) return null
-  let dir = resolve(dirname(entry))
-  for (let depth = 0; depth < 10; depth += 1) {
-    try {
-      const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as { name?: unknown }
-      if (manifest.name === '@deepseek-ai/dsh') return dir
-    } catch { /* keep walking up */ }
-    const parent = dirname(dir)
-    if (parent === dir) return null
-    dir = parent
-  }
-  return null
 }
 
 /**

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -15,16 +15,24 @@ import {
   analyzeProfile,
   compareSemver,
   corePackageNames,
+  findDshInstallDir,
   satisfiesRange,
 } from '../src/check.ts'
+import { readBundleRules } from '../src/order.ts'
 
 let tmp: string
+const originalResourcesPath = Object.getOwnPropertyDescriptor(process, 'resourcesPath')
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), 'dshm-check-'))
   process.env.DSH_HOME = tmp
 })
 afterEach(() => {
   delete process.env.DSH_HOME
+  if (originalResourcesPath === undefined) {
+    delete (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+  } else {
+    Object.defineProperty(process, 'resourcesPath', originalResourcesPath)
+  }
   rmSync(tmp, { recursive: true, force: true })
 })
 
@@ -60,11 +68,17 @@ function writeLoadablePackage(base: string, name: string): string {
 }
 
 /** Write a dsh bundle package (dsh.bundle.patch entry-list) at base/node_modules/<name>. */
-function writeBundle(base: string, name: string, version: string, patch: unknown[]): string {
+function writeBundle(
+  base: string,
+  name: string,
+  version: string,
+  patch: unknown[],
+  order?: unknown,
+): string {
   const dir = writePackage(base, name, {
     name,
     version,
-    dsh: { bundle: { patch: './cordis.patch.yml' } },
+    dsh: { bundle: { patch: './cordis.patch.yml', ...(order === undefined ? {} : { order }) } },
   })
   writeFileSync(join(dir, 'cordis.patch.yml'), dump(patch))
   return dir
@@ -770,11 +784,10 @@ describe('suggestedOrder (#98 opt: LOOT-style auto-fix)', () => {
 
 })
 
-/** #369: on DSH Desktop the dsh installation lives inside the Electron app
- * bundle, and findDshInstallDir walks up from process.argv[1] — Electron's
- * entry, nowhere near it. Both anchors then miss the in-box bundles, which
- * are supplied by that installation by definition, and the composition was
- * declared unbootable. `dsh --dump-config` on the same profile exited 0. */
+/** #369: when no CLI or Desktop installation anchor is visible, the in-box
+ * bundles cannot be resolved. They are supplied by that installation by
+ * definition, so this unknown state must not declare the profile unbootable.
+ * `dsh --dump-config` on the same profile exited 0. */
 describe('in-box bundles that cannot be located (#369)', () => {
   /** `tmp` is assigned per test, so this has to be read inside one. */
   const desktop = () => ({ dshInstallDir: null, homeDir: join(tmp, 'empty-home') })
@@ -867,6 +880,105 @@ describe('in-box bundles that cannot be located (#369)', () => {
     const community = report.bundles.find(layer => layer.name === 'some-community-bundle')
     expect(community?.error).toMatch(/not installed/)
     expect(community?.unresolvedInbox).toBeUndefined()
+  })
+})
+
+describe('Desktop host discovery (#405)', () => {
+  it.each(['app.asar.unpacked', 'app.asar', 'app'])(
+    'finds a validated host package in resources/%s',
+    applicationRoot => {
+      const resources = join(tmp, `resources-${applicationRoot}`)
+      const dshInstall = writePackage(join(resources, applicationRoot), '@deepseek-ai/dsh', {
+        name: '@deepseek-ai/dsh',
+        version: '0.1.1-rc.2',
+      })
+      Object.defineProperty(process, 'resourcesPath', {
+        value: resources,
+        configurable: true,
+      })
+
+      expect(findDshInstallDir(join(tmp, 'electron-entry', 'main.js'))).toBe(dshInstall)
+    },
+  )
+
+  it('keeps CLI-entry discovery ahead of the Desktop fallback', () => {
+    const cliInstall = pdir('cli-install')
+    mkdirSync(join(cliInstall, 'bin'), { recursive: true })
+    writeFileSync(join(cliInstall, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh' }))
+
+    const resources = pdir('desktop-resources')
+    writePackage(join(resources, 'app.asar.unpacked'), '@deepseek-ai/dsh', {
+      name: '@deepseek-ai/dsh',
+    })
+    Object.defineProperty(process, 'resourcesPath', {
+      value: resources,
+      configurable: true,
+    })
+
+    expect(findDshInstallDir(join(cliInstall, 'bin', 'dsh.js'))).toBe(cliInstall)
+  })
+
+  it('rejects a Desktop candidate with the wrong package identity', () => {
+    const resources = pdir('wrong-package-resources')
+    writePackage(join(resources, 'app.asar.unpacked'), '@deepseek-ai/dsh', {
+      name: 'not-the-dsh-host',
+    })
+    Object.defineProperty(process, 'resourcesPath', {
+      value: resources,
+      configurable: true,
+    })
+
+    expect(findDshInstallDir(join(tmp, 'electron-entry', 'main.js'))).toBeNull()
+  })
+
+  it('loads hoisted in-box rows before composing community patches', () => {
+    const resources = join(tmp, 'resources')
+    const applicationRoot = join(resources, 'app.asar.unpacked')
+    const dshInstall = writePackage(applicationRoot, '@deepseek-ai/dsh', {
+      name: '@deepseek-ai/dsh',
+      version: '0.1.1-rc.2',
+    })
+    const dshBase = writeBundle(applicationRoot, '@deepseek-ai/dsh-base', '0.1.1-rc.2', [
+      { insert: [{ id: 'attachment-local', name: '@deepseek-ai/dsh-attachment-local' }] },
+    ], { before: ['dsh-vision-router'] })
+
+    const dir = pdir()
+    writeProfile(dir, {
+      name: 'web-profile',
+      dependencies: { 'dsh-vision-router': '2.0.1' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dsh-vision-router'] } },
+    })
+    writeBundle(dir, 'dsh-vision-router', '2.0.1', [
+      { id: 'attachment-local', config: { local: true } },
+    ])
+    Object.defineProperty(process, 'resourcesPath', {
+      value: resources,
+      configurable: true,
+    })
+
+    expect(findDshInstallDir(join(tmp, 'electron-entry', 'main.js'))).toBe(dshInstall)
+    const report = analyzeProfile(dir, { homeDir: join(tmp, 'empty-home') })
+
+    const official = report.bundles.find(bundle => bundle.name === '@deepseek-ai/dsh-base')
+    expect(official).toMatchObject({
+      directory: dshBase,
+      entries: ['attachment-local'],
+    })
+    expect(official?.unresolvedInbox).toBeUndefined()
+    expect(report.orphans).toEqual([])
+    expect(report.overrides).toEqual([{
+      id: 'attachment-local',
+      layer: 'dsh-vision-router',
+      overriddenLayers: ['@deepseek-ai/dsh-base'],
+    }])
+    expect(readBundleRules(dir)).toContainEqual({
+      name: '@deepseek-ai/dsh-base',
+      before: ['dsh-vision-router'],
+      after: [],
+    })
+    expect(report.summary.warnings).not.toContain(
+      'dsh-vision-router: attachment-local — patch target not found',
+    )
   })
 })
 


### PR DESCRIPTION
Closes #405

## What changed

- keep the existing CLI-entry lookup, then resolve the host from Electron's authoritative `process.resourcesPath`
- support `app.asar.unpacked`, Electron's virtual `app.asar`, and non-ASAR `app` layouts, accepting only a manifest named `@deepseek-ai/dsh`
- share one locator between composition diagnostics and bundle-order rule resolution
- add realistic packaged-layout regressions with hoisted in-box bundles

## Why

Desktop starts from an Electron entry that is unrelated to the bundled DSH CLI. The old argv-only lookup therefore left official in-box bundles unresolved, so valid community reconfiguration rows such as `attachment-local` were falsely reported as orphan patches. Resolving the packaged host loads the official row first and records the community change as an override instead.

The integration regression verifies that the official `dsh-base` row is loaded, no unresolved-inbox or orphan warning remains, the override provenance is correct, and order-rule lookup uses the same Desktop anchor.

## Verification

- [x] `npm test` — 1,048 passed, 1 skipped
- [x] `npm run check`
- [x] `npm run prepack`
- [x] `npm run validate:registry`
- [x] no package version bump
- [x] no client-source change, so generated client assets are unchanged