### PR TITLE
fix: report the restored version after API rollback

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -979,13 +979,15 @@ export function mountMarketRoutes(
         try {
           const body = (await readJsonBody(request)) as { operationId?: unknown }
           const operationId = typeof body.operationId === 'string' ? body.operationId : ''
+          const trackedOperation = operationsV1.get(operationId)
           const legacyRollbackId = operationsV1.beginRollback(operationId)
-          if (legacyRollbackId === null) {
+          if (legacyRollbackId === null || trackedOperation === null) {
             sendJson(response, 409, { schema: UPDATE_API_V1_SCHEMA, error: 'rollback is not available for this operation' })
             return
           }
           const result = await invokeLegacy('/dsh-market/rollback', request, 'POST', { rollbackId: legacyRollbackId })
-          const operation = operationsV1.finishRollback(operationId, result.status, result.payload)
+          const installedVersion = readInstalledVersion(config.profile, trackedOperation.packageName, activeProfileDir)
+          const operation = operationsV1.finishRollback(operationId, result.status, result.payload, installedVersion)
           sendJson(response, 200, { schema: UPDATE_API_V1_SCHEMA, operation })
         } catch (error) {
           sendJson(response, 400, {

--- a/src/update-api-v1.ts
+++ b/src/update-api-v1.ts
@@ -239,11 +239,19 @@ export class UpdateOperationStoreV1 {
     return operation.legacyRollbackId
   }
 
-  finishRollback(operationId: string, status: number, payload: unknown): UpdateOperationV1 | null {
+  finishRollback(
+    operationId: string,
+    status: number,
+    payload: unknown,
+    installedVersion?: string | null,
+  ): UpdateOperationV1 | null {
     const operation = this.operations.get(operationId)
     if (operation === undefined) return null
     const body = record(payload) ?? {}
     const ok = status >= 200 && status < 300 && body.rolledBack === true
+    // The rollback endpoint supplies a fresh disk read. Keep the argument
+    // optional so existing store consumers retain source compatibility.
+    if (installedVersion !== undefined) operation.installedVersion = installedVersion
     operation.outcome.rollback.available = !ok && status !== 400
     operation.outcome.rollback.state = ok ? 'succeeded' : 'failed'
     operation.outcome.rollback.detail = ok ? null : text(body.error) ?? `rollback failed with HTTP ${String(status)}`

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -1268,6 +1268,7 @@ describe('update flow — no npm publishing required', () => {
     expect(rolledBack.status).toBe(200)
     expect(rolledBack.json.operation).toMatchObject({
       state: 'rolled-back',
+      installedVersion: '1.0.0',
       outcome: { restartRequired: true, rollback: { available: false, state: 'succeeded' } },
     })
     expect(installedSpec('dsh-loop')).toBe('^1.0.0')

--- a/tests/update-api-v1.spec.ts
+++ b/tests/update-api-v1.spec.ts
@@ -80,8 +80,9 @@ describe('public update API v1 operation model', () => {
     expect(completed).not.toHaveProperty('legacyRollbackId')
 
     expect(store.beginRollback(operation.operationId)).toBe('private-rollback-7')
-    expect(store.finishRollback(operation.operationId, 200, { rolledBack: true })).toMatchObject({
+    expect(store.finishRollback(operation.operationId, 200, { rolledBack: true }, '0.2.24')).toMatchObject({
       state: 'rolled-back',
+      installedVersion: '0.2.24',
       outcome: {
         restartRequired: true,
         rollback: { available: false, state: 'succeeded' },


### PR DESCRIPTION
## What changed
- reread the package version from the active profile after a compatibility rollback
- update the public operation record with that disk truth while preserving the existing JSON shape
- keep the new store argument optional for source compatibility
- add store-level and full route/manifest regressions

## Why
The v1 API promises terminal operation records contain the version actually installed. After a successful `1.0.0 -> 1.2.0 -> rollback` flow, the profile was correctly restored to `1.0.0` and the operation moved to `rolled-back`, but `installedVersion` remained `1.2.0`.

Provider clients are explicitly told to compare this field before offering restart, so the stale value could make a correct rollback look inconsistent. The rollback route now performs the same post-operation disk read used by update completion.

## Verification
- [x] regression failed before the fix and passed after
- [x] focused store + route rollback tests
- [x] `npm test` — 1,042 passed, 1 skipped
- [x] `npm run check`
- [x] preflight
- [x] registry validation
- [x] no client-source change; published client assets remain unchanged
- [x] no version bump