### PR TITLE
fix: honor Windows npm global prefix

### DIFF
--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -603,7 +603,10 @@ export async function provisionPnpm(): Promise<{ ok: boolean; hint?: string }> {
   // instead of telling the user a successful install failed.
   if (npm.code === 0 || corepack.code === 0) {
     const prefix = await runQuiet('npm', ['prefix', '-g'], 30 * 1000)
-    const bin = prefix.code === 0 ? join(prefix.output.trim().split('\n').pop() ?? '', 'bin') : ''
+    const root = prefix.code === 0 ? prefix.output.trim().split('\n').pop() ?? '' : ''
+    // `npm prefix -g` already is the executable directory on Windows
+    // (`pnpm.cmd` lives directly under it). Unix keeps shims in `bin/`.
+    const bin = root === '' ? '' : process.platform === 'win32' ? root : join(root, 'bin')
     if (bin !== '' && isAbsolute(bin) && !extraPathDirs.includes(bin)) {
       extraPathDirs.push(bin)
       logEvent('info', 'setup-pnpm', `added npm's global bin to the probe path: ${bin}`)

--- a/tests/provision.spec.ts
+++ b/tests/provision.spec.ts
@@ -49,16 +49,18 @@ describe('provisionPnpm (#149)', () => {
     // WORKED — yet `pnpm --version` still fails, because the binary landed
     // in a prefix this process never had on PATH.
     const calls: string[][] = []
-    const globalBin = process.platform === 'win32' ? 'C:\\npm-prefix' : '/opt/custom-prefix'
+    const globalPrefix = process.platform === 'win32' ? 'C:\\npm-prefix' : '/opt/custom-prefix'
+    const globalBin = process.platform === 'win32' ? globalPrefix : `${globalPrefix}/bin`
+    const separator = process.platform === 'win32' ? ';' : ':'
     childProcess.spawn.mockImplementation((file: string, args: string[], options: { env?: Record<string, string> }) => {
       const command = commandOf(file, args)
       calls.push([command])
       if (command.startsWith('corepack')) return fakeChild(0)
       if (command.startsWith('npm install')) return fakeChild(0)
-      if (command.startsWith('npm prefix')) return fakeChild(0, `${globalBin}\n`)
+      if (command.startsWith('npm prefix')) return fakeChild(0, `${globalPrefix}\n`)
       // pnpm runs only once the discovered bin dir is on the spawn PATH.
       const path = options.env?.PATH ?? ''
-      return fakeChild(path.includes(globalBin) ? 0 : 1)
+      return fakeChild(path.split(separator).includes(globalBin) ? 0 : 1)
     })
 
     const { provisionPnpm } = await import('../src/dsh-cli.ts')


### PR DESCRIPTION
On Windows, \
pm prefix -g\ is already the directory containing \pnpm.cmd\. Appending \in\ makes a successful global pnpm installation invisible to the follow-up probe, so setup is still reported as failed.\n\nThis keeps the existing Unix \<prefix>/bin\ behavior, uses the prefix directly on Windows, and tightens the regression test to require an exact PATH entry instead of a substring match.\n\nVerification:\n- targeted provision tests: 5/5\n- full suite: 1041 passed, 2 skipped\n- all three TypeScript projects: typecheck passed