### PR TITLE
fix: clean stale pnpm tmp dirs before install to prevent EPERM rename…

### DIFF
--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Process layer: re-invoking the dsh CLI that launched this host, spawning
  * `dsh plugin` commands with timeouts and live progress, and provisioning
  * pnpm. This is the only module that starts child processes.
@@ -9,7 +9,7 @@
 
 import { spawn } from 'node:child_process'
 import type { ChildProcess, SpawnOptions } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, rmSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { logEvent } from './log.ts'
@@ -821,6 +821,41 @@ function makeProgressFeeder(tracker: ReturnType<typeof createProgressTracker>): 
   }
 }
 
+/**
+ * Remove stale pnpm temp directories from node_modules before install.
+ *
+ * pnpm sometimes leaves `*_tmp_*` directories after a failed or interrupted
+ * install (observed on Windows 10 22H2 with native modules like node-hid).
+ * On the next install, pnpm tries to rename the temp dir into place and fails
+ * with EPERM: operation not permitted, rename '..._tmp_...' -> '...'.
+ *
+ * Scanning and removing these stale dirs before each install is a defensive
+ * fix that makes the retry path work without manual intervention.
+ */
+function cleanupTmpDirsInNodeModules(profileDirectory: string): void {
+  const nodeModulesDir = join(profileDirectory, 'node_modules')
+  if (!existsSync(nodeModulesDir)) return
+  let cleaned = 0
+  try {
+    const entries = readdirSync(nodeModulesDir)
+    for (const name of entries) {
+      if (name.includes('_tmp_')) {
+        const tmpPath = join(nodeModulesDir, name)
+        try {
+          rmSync(tmpPath, { recursive: true, force: true })
+          cleaned++
+        } catch (e) {
+          logEvent('warn', 'install', `failed to remove stale tmp dir ${name}: ${(e as Error).message}`)
+        }
+      }
+    }
+    if (cleaned > 0) {
+      logEvent('info', 'install', `cleaned up ${cleaned} stale tmp dir(s) in node_modules to prevent EPERM rename failures`)
+    }
+  } catch (err) {
+    logEvent('warn', 'install', `failed to scan node_modules for tmp dirs: ${(err as Error).message}`)
+  }
+}
 /** Run one `dsh plugin --profile <p> …` command with timeout and progress tracking. */
 export function runDshPlugin(profile: string, pluginArgs: string[]): Promise<InstallResult> {
   const { file, args, cwd, viaShell } = dshArgv()
@@ -836,6 +871,7 @@ export function runDshPlugin(profile: string, pluginArgs: string[]): Promise<Ins
   }
   pluginArgs = prepared.args
   const tracker = beginProgress(prepared.target)
+  cleanupTmpDirsInNodeModules(profileDir(profile))
   const feed = makeProgressFeeder(tracker)
   return new Promise((resolvePromise) => {
     const child = spawnShim(file, [...args, 'plugin', '--profile', profile, ...pluginArgs], {

--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Process layer: re-invoking the dsh CLI that launched this host, spawning
  * `dsh plugin` commands with timeouts and live progress, and provisioning
  * pnpm. This is the only module that starts child processes.
@@ -829,26 +829,91 @@ function makeProgressFeeder(tracker: ReturnType<typeof createProgressTracker>): 
  * On the next install, pnpm tries to rename the temp dir into place and fails
  * with EPERM: operation not permitted, rename '..._tmp_...' -> '...'.
  *
- * Scanning and removing these stale dirs before each install is a defensive
- * fix that makes the retry path work without manual intervention.
+ * This is a defensive cleanup for the interrupted-then-retry path only.
+ * It does NOT fix #389 (the pnpm live-lock scenario where a running pnpm
+ * holds locks and never exits); that requires pnpm-level changes.
+ *
+ * Safety:
+ * - pnpm temp dirs are named <name>_tmp_<pid>_<random>. We extract the pid
+ *   and check liveness with process.kill(pid, 0) before deleting.
+ * - If the pid is alive, we skip — deleting a running pnpm's work dir would
+ *   cause exactly the corruption this cleanup is meant to prevent.
+ * - EPERM from kill(pid, 0) means the process exists but belongs to another
+ *   user; we treat that as "alive" (conservative, safe direction).
+ * - Pid reuse is a known limitation: a stale dir whose pid got reassigned to
+ *   an unrelated process will never be cleaned. This is deliberate — the
+ *   conservative direction is safer than accidentally deleting a live dir.
+ *
+ * Scope:
+ * - Top-level node_modules/<name>_tmp_*
+ * - node_modules/.pnpm/<pkg>@<ver>/node_modules/<name>_tmp_*
+ * We do NOT recursively walk all of .pnpm/ (thousands of dirs on Windows);
+ * temp dir locations are predictable from pnpm's layout.
  */
-function cleanupTmpDirsInNodeModules(profileDirectory: string): void {
+export function cleanupTmpDirsInNodeModules(profileDirectory: string): void {
   const nodeModulesDir = join(profileDirectory, 'node_modules')
   if (!existsSync(nodeModulesDir)) return
   let cleaned = 0
+  const tmpDirPattern = /_tmp_(\d+)_/
+
+  function isPidAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0)
+      return true
+    } catch (err) {
+      // ESRCH = no such process → dead
+      // EPERM = process exists but belongs to another user → treat as alive
+      const code = (err as NodeJS.ErrnoException).code
+      return code === 'EPERM'
+    }
+  }
+
+  function tryRemoveTmpDir(dirPath: string, name: string): void {
+    const pidMatch = name.match(tmpDirPattern)
+    if (pidMatch) {
+      const pid = parseInt(pidMatch[1]!, 10)
+      if (isPidAlive(pid)) {
+        logEvent('info', 'install', `skipping live pnpm tmp dir ${name} (pid ${pid} is alive)`)
+        return
+      }
+    }
+    try {
+      rmSync(dirPath, { recursive: true, force: true })
+      cleaned++
+    } catch (e) {
+      logEvent('warn', 'install', `failed to remove stale tmp dir ${name}: ${(e as Error).message}`)
+    }
+  }
+
   try {
+    // Scan top-level node_modules
     const entries = readdirSync(nodeModulesDir)
     for (const name of entries) {
       if (name.includes('_tmp_')) {
-        const tmpPath = join(nodeModulesDir, name)
+        tryRemoveTmpDir(join(nodeModulesDir, name), name)
+      }
+    }
+
+    // Scan .pnpm/<pkg>@<ver>/node_modules/ (predictable locations, no full recursion)
+    const pnpmDir = join(nodeModulesDir, '.pnpm')
+    if (existsSync(pnpmDir)) {
+      const pnpmEntries = readdirSync(pnpmDir)
+      for (const pkgDir of pnpmEntries) {
+        const nestedNodeModules = join(pnpmDir, pkgDir, 'node_modules')
+        if (!existsSync(nestedNodeModules)) continue
         try {
-          rmSync(tmpPath, { recursive: true, force: true })
-          cleaned++
-        } catch (e) {
-          logEvent('warn', 'install', `failed to remove stale tmp dir ${name}: ${(e as Error).message}`)
+          const nestedEntries = readdirSync(nestedNodeModules)
+          for (const name of nestedEntries) {
+            if (name.includes('_tmp_')) {
+              tryRemoveTmpDir(join(nestedNodeModules, name), name)
+            }
+          }
+        } catch {
+          // skip unreadable nested node_modules
         }
       }
     }
+
     if (cleaned > 0) {
       logEvent('info', 'install', `cleaned up ${cleaned} stale tmp dir(s) in node_modules to prevent EPERM rename failures`)
     }

--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -869,8 +869,8 @@ export function cleanupTmpDirsInNodeModules(profileDirectory: string): void {
   }
 
   function tryRemoveTmpDir(dirPath: string, name: string): void {
-    const pidMatch = name.match(tmpDirPattern)
-    if (pidMatch) {
+    const pidMatch = tmpDirPattern.exec(name)
+    if (pidMatch !== null) {
       const pid = parseInt(pidMatch[1]!, 10)
       if (isPidAlive(pid)) {
         logEvent('info', 'install', `skipping live pnpm tmp dir ${name} (pid ${pid} is alive)`)
@@ -880,8 +880,8 @@ export function cleanupTmpDirsInNodeModules(profileDirectory: string): void {
     try {
       rmSync(dirPath, { recursive: true, force: true })
       cleaned++
-    } catch (e) {
-      logEvent('warn', 'install', `failed to remove stale tmp dir ${name}: ${(e as Error).message}`)
+    } catch (err) {
+      logEvent('warn', 'install', `failed to remove stale tmp dir ${name}: ${(err as Error).message}`)
     }
   }
 
@@ -921,6 +921,7 @@ export function cleanupTmpDirsInNodeModules(profileDirectory: string): void {
     logEvent('warn', 'install', `failed to scan node_modules for tmp dirs: ${(err as Error).message}`)
   }
 }
+
 /** Run one `dsh plugin --profile <p> …` command with timeout and progress tracking. */
 export function runDshPlugin(profile: string, pluginArgs: string[]): Promise<InstallResult> {
   const { file, args, cwd, viaShell } = dshArgv()

--- a/tests/cleanup-tmp-dirs.spec.ts
+++ b/tests/cleanup-tmp-dirs.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for cleanupTmpDirsInNodeModules: defensive cleanup of stale pnpm
+ * temp directories before install, to prevent EPERM rename failures on
+ * Windows after interrupted installs.
+ *
+ * Coverage:
+ * - no-op when node_modules does not exist
+ * - removes stale top-level tmp dirs with dead pids
+ * - skips tmp dirs whose pid is still alive
+ * - scans .pnpm/<pkg>@<ver>/node_modules/ for nested tmp dirs
+ * - does not throw on unreadable directories
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { cleanupTmpDirsInNodeModules } from '../src/dsh-cli.ts'
+
+let profileDir: string
+
+beforeEach(() => {
+  profileDir = mkdtempSync(join(tmpdir(), 'dsh-test-'))
+  mkdirSync(join(profileDir, 'node_modules'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(profileDir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+describe('cleanupTmpDirsInNodeModules', () => {
+  it('does nothing when node_modules does not exist', () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'dsh-empty-'))
+    expect(() => cleanupTmpDirsInNodeModules(emptyDir)).not.toThrow()
+    rmSync(emptyDir, { recursive: true, force: true })
+  })
+
+  it('removes stale top-level tmp dirs with dead pids', () => {
+    const tmpDir = join(profileDir, 'node_modules', 'node-hid_tmp_99999_abc123')
+    mkdirSync(tmpDir, { recursive: true })
+    writeFileSync(join(tmpDir, 'package.json'), '{}')
+
+    cleanupTmpDirsInNodeModules(profileDir)
+
+    expect(() => mkdirSync(tmpDir)).not.toThrow() // dir was removed, can recreate
+  })
+
+  it('skips tmp dirs whose pid is still alive', () => {
+    // Use the current process pid — it is definitely alive
+    const livePid = process.pid
+    const tmpDir = join(profileDir, 'node_modules', `node-hid_tmp_${livePid}_abc123`)
+    mkdirSync(tmpDir, { recursive: true })
+    writeFileSync(join(tmpDir, 'package.json'), '{}')
+
+    cleanupTmpDirsInNodeModules(profileDir)
+
+    // Dir should still exist because pid is alive
+    expect(() => mkdirSync(tmpDir)).toThrow() // EEXIST means dir still there
+  })
+
+  it('scans .pnpm/<pkg>@<ver>/node_modules/ for nested tmp dirs', () => {
+    const nestedTmp = join(profileDir, 'node_modules', '.pnpm', 'node-hid@2.1.2', 'node_modules', 'node-hid_tmp_99998_def456')
+    mkdirSync(nestedTmp, { recursive: true })
+    writeFileSync(join(nestedTmp, 'index.js'), 'module.exports = {}')
+
+    cleanupTmpDirsInNodeModules(profileDir)
+
+    expect(() => mkdirSync(nestedTmp)).not.toThrow() // nested dir was removed
+  })
+
+  it('does not throw on unreadable nested node_modules', () => {
+    // Create a .pnpm dir without node_modules — should be skipped gracefully
+    mkdirSync(join(profileDir, 'node_modules', '.pnpm', 'some-pkg@1.0.0'), { recursive: true })
+
+    expect(() => cleanupTmpDirsInNodeModules(profileDir)).not.toThrow()
+  })
+
+  it('treats tmp dirs without pid pattern as stale (no liveness check possible)', () => {
+    const tmpDir = join(profileDir, 'node_modules', 'some-package_tmp_nopid')
+    mkdirSync(tmpDir, { recursive: true })
+
+    cleanupTmpDirsInNodeModules(profileDir)
+
+    expect(() => mkdirSync(tmpDir)).not.toThrow() // dir was removed
+  })
+})


### PR DESCRIPTION
## 问题描述

pnpm 在 Windows 上安装包含原生模块（如 node-hid）的插件时，如果前一次安装失败或被中断，会在 `node_modules` 中留下 `*_tmp_*` 临时目录。

下一次安装时，pnpm 尝试将临时目录重命名为目标目录，但由于 Windows 文件锁或权限问题，重命名失败：

```
ERR_PNPM_EPERM: [importPackage .../node_modules/node-hid] EPERM: operation not permitted, rename '.../node_modules/node-hid_tmp_4304_2' -> '.../node_modules/node-hid'
```

## 复现环境

- **操作系统**: Windows 10 22H2
- **DeepSeek Harness**: 桌面版
- **dsh-market 版本**: 1.36.0
- **触发插件**: SinglePlayer（依赖 node-hid）

## 复现步骤

1. 安装一个包含原生模块的插件（如 SinglePlayer）
2. 安装过程中中断或失败（如首次安装时构建脚本被拦截）
3. 再次安装同一插件
4. 出现 `ERR_PNPM_EPERM: rename ..._tmp_... -> ...` 错误

## 修复方案

在 `runDshPlugin()` 执行 pnpm 安装之前，调用 `cleanupTmpDirsInNodeModules()` 扫描 `node_modules` 目录，删除所有 `*_tmp_*` 残留临时目录。

这是一个防御性修复，确保重试路径能够正常工作，无需用户手动清理。

## 修改内容

- `src/dsh-cli.ts`:
  - 添加 `cleanupTmpDirsInNodeModules(profileDirectory)` 函数
  - 在 `runDshPlugin()` 中，`beginProgress()` 之后调用该函数
  - 添加 `readdirSync` 和 `rmSync` 到 `node:fs` 导入

## 测试情况

- 在 Windows 10 22H2 上手动测试：模拟残留临时目录后安装插件，修复后能够正常安装
- 清理操作有日志记录，便于排查问题
- 不影响正常安装流程（无残留目录时不执行任何操作）
