### PR TITLE
fix: normalize DSH home resolution

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -28,10 +28,10 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { createRequire, isBuiltin } from 'node:module'
-import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { JSON_SCHEMA, Type, load } from 'js-yaml'
 import { findDshInstallDir } from './dsh-install.ts'
+import { resolveDshHome } from './home-paths.ts'
 import { INBOX_BUNDLES, readBundleRules, suggestOrder, validateOrder } from './order.ts'
 
 export { findDshInstallDir } from './dsh-install.ts'
@@ -984,7 +984,7 @@ export function buildBundleLayers(
  */
 export function analyzeProfile(profileDirectory: string, options: CheckOptions = {}): CheckReport {
   const dshInstall = options.dshInstallDir ?? findDshInstallDir()
-  const home = options.homeDir ?? process.env.DSH_HOME ?? join(homedir(), '.dsh')
+  const home = resolveDshHome(options.homeDir)
   const core = corePackageNames(dshInstall)
 
   // --- 1. bundle stack ---

--- a/src/home-paths.ts
+++ b/src/home-paths.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolve the Harness home with the same semantics as the current
+ * `@deepseek-ai/dsh-home-paths` package.
+ */
+
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+/** Default single-root Harness home. */
+export function defaultDshHome(): string {
+  return join(homedir(), '.dsh')
+}
+
+/** Expand the tilde forms supported by DSH configuration. */
+export function expandHomePath(path: string): string {
+  if (path === '~') return homedir()
+  if (path.startsWith('~/') || path.startsWith('~\\')) return join(homedir(), path.slice(2))
+  return path
+}
+
+/**
+ * Resolve an explicit home, `DSH_HOME`, or the default to one normalized
+ * absolute path. Blank environment values are unset, matching DSH alpha.
+ */
+export function resolveDshHome(
+  configured?: string,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const fromEnv = env.DSH_HOME
+  const selected = configured ?? (fromEnv !== undefined && fromEnv.trim().length > 0
+    ? fromEnv
+    : defaultDshHome())
+  return resolve(expandHomePath(selected))
+}

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -5,9 +5,9 @@
  */
 
 import { existsSync, readdirSync, readFileSync, realpathSync, renameSync, statSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
+import { resolveDshHome } from './home-paths.ts'
 import { githubRemoteIdentities, githubRepoIdentities } from './sources.ts'
 
 /**
@@ -36,8 +36,7 @@ export function isDshProfileName(profile: string): boolean {
 export function profileDir(profile: string, explicitDir?: string): string {
   if (explicitDir !== undefined) return explicitDir
   if (!isDshProfileName(profile)) throw new Error(`dsh-market: invalid profile name ${JSON.stringify(profile)}`)
-  const home = process.env.DSH_HOME ?? join(homedir(), '.dsh')
-  return join(home, 'profiles', profile)
+  return join(resolveDshHome(), 'profiles', profile)
 }
 
 /**

--- a/src/trial.ts
+++ b/src/trial.ts
@@ -25,12 +25,12 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 import {
   buildBundleLayers, composeLayers, findDshInstallDir, parsePatchFile,
   type DuplicateId, type LayerInput, type OrphanRow, type OverrideRow,
 } from './check.ts'
+import { resolveDshHome } from './home-paths.ts'
 import { mergeOrder, readBundleStack } from './order.ts'
 
 export interface TrialIssue {
@@ -104,7 +104,7 @@ export function trialValidate(
     patchLayers.push({ label: 'user-patch', kind: 'user', patches: patches ?? [], parseError: null })
     if (patches === null) errors.push({ layer: 'user-patch', message: 'cordis.patch.yml is not a valid entry list / cordis.patch.yml 不是合法的条目列表' })
   }
-  const home = options.homeDir ?? process.env.DSH_HOME ?? join(homedir(), '.dsh')
+  const home = resolveDshHome(options.homeDir)
   const homePatchPath = join(home, 'cordis.patch.yml')
   if (existsSync(homePatchPath)) {
     const patches = parsePatchFile(homePatchPath)

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -175,6 +175,28 @@ describe('workspace-root hoisted bundles (#98 review B1)', () => {
   })
 })
 
+describe('shared DSH home resolution', () => {
+  it('does not treat the process directory as home when DSH_HOME is empty', () => {
+    const dir = pdir('blank-home-profile')
+    const cwd = pdir('blank-home-cwd')
+    const previousCwd = process.cwd()
+    writeProfile(dir, { name: 'web-profile', dependencies: {} })
+    mkdirSync(cwd, { recursive: true })
+    writeFileSync(join(cwd, 'cordis.patch.yml'), dump([
+      { insert: [{ id: 'blank-home-trap', name: 'must-not-load' }] },
+    ]))
+    process.env.DSH_HOME = ''
+
+    try {
+      process.chdir(cwd)
+      const report = analyzeProfile(dir, { dshInstallDir: null })
+      expect(report.rows.map(row => row.id)).not.toContain('blank-home-trap')
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+})
+
 describe('user patch package resolution (#205)', () => {
   const resolutionErrors = (errors: string[]): string[] =>
     errors.filter(line => line.includes('loader package') || line.includes('loader specifier') || line.includes('has no module name'))

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -5,8 +5,9 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { homedir, tmpdir } from 'node:os'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { resolveDshHome } from '../src/home-paths.ts'
 import {
   addProfileBundle, conflictingEntryIds, dropFromManifest, entryArtifactExists, hasDshManifest, hasLoadableEntry, isDshProfileName, pluginSubdirs, profileDir,
   readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledRepoIdentities, readInstalledVersion, readLockCommits,
@@ -29,6 +30,34 @@ function writeProfile(manifest: unknown): string {
   writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest))
   return dir
 }
+
+describe('DSH home resolution (dsh-v0.1.2-alpha.1)', () => {
+  it.each([
+    ['undefined', undefined],
+    ['empty', ''],
+    ['whitespace', ' \t '],
+  ])('treats %s DSH_HOME as unset', (_label, value) => {
+    const env = value === undefined ? {} : { DSH_HOME: value }
+    const expected = join(homedir(), '.dsh')
+
+    expect(resolveDshHome(undefined, env)).toBe(expected)
+    if (value === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = value
+    expect(profileDir('web')).toBe(join(expected, 'profiles', 'web'))
+    expect(isAbsolute(profileDir('web'))).toBe(true)
+  })
+
+  it('normalizes a relative DSH_HOME to an absolute profile path', () => {
+    process.env.DSH_HOME = 'relative-dsh-home'
+    expect(profileDir('web')).toBe(join(resolve('relative-dsh-home'), 'profiles', 'web'))
+    expect(isAbsolute(profileDir('web'))).toBe(true)
+  })
+
+  it('expands a tilde DSH_HOME before resolving the profile', () => {
+    process.env.DSH_HOME = '~'
+    expect(profileDir('web')).toBe(join(homedir(), 'profiles', 'web'))
+  })
+})
 
 describe('profile names (#260)', () => {
   it('matches the DSH profile directory contract instead of an ASCII-only subset', () => {

--- a/tests/trial.spec.ts
+++ b/tests/trial.spec.ts
@@ -50,6 +50,28 @@ function writeBundle(base: string, name: string, version: string, patch: unknown
   return dir
 }
 
+describe('shared DSH home resolution', () => {
+  it('does not compose the process directory as home when DSH_HOME is empty', () => {
+    const dir = pdir('blank-home-profile')
+    const cwd = pdir('blank-home-cwd')
+    const previousCwd = process.cwd()
+    writeProfile(dir, [])
+    mkdirSync(cwd, { recursive: true })
+    writeFileSync(join(cwd, 'cordis.patch.yml'), dump([
+      { insert: [{ id: 'blank-home-trap', name: 'must-not-load' }] },
+    ]))
+    process.env.DSH_HOME = ''
+
+    try {
+      process.chdir(cwd)
+      const result = trialValidate(dir, [], { dshInstallDir: null })
+      expect(result.rows.map(row => row.id)).not.toContain('blank-home-trap')
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+})
+
 /** #369: on DSH Desktop the in-box bundles come from the app bundle, and the
  * install directory is not discoverable from process.argv[1]. Trial
  * validation then judged the profile unbootable and the update route rolled


### PR DESCRIPTION
## Summary

- centralize Harness-home resolution for profile, check, and trial paths
- treat empty or whitespace-only `DSH_HOME` as unset, matching current DSH alpha
- expand supported tilde forms and normalize configured homes to absolute paths
- add CWD-trap regressions so a blank environment cannot select `./profiles` or `./cordis.patch.yml`

## Impact

Before this change, `DSH_HOME=''` made Market use relative paths. Install/restore operations could therefore target the wrong profile, while diagnostics and trial composition could consume an unrelated patch from the process directory.

Explicit host-owned profile directories remain unchanged, and intentionally configured relative/tilde homes follow the same normalization rules as `@deepseek-ai/dsh-home-paths` in `dsh-v0.1.2-alpha.1`.

## Verification

- full unit suite: 53 files, 1,067 passed, 1 skipped
- compatibility suite: 11/11 passed
- Node 22.22.2 focused profile/check/trial suite: 111/111 passed
- TypeScript typecheck passed
- build and restart smoke passed
- independent exact-diff review approved with no findings
- no lockfile or generated client output changes