### PR TITLE
fix: name the lockfile entry pnpm 11 refuses, and say how to recover

### DIFF
--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -116,6 +116,50 @@ function withDecodedPnpmDiagnostics(output: string): string {
 }
 
 /**
+ * Every package pnpm named as having no lockfile integrity, in order.
+ *
+ * Two shapes, because pnpm 11 rewrote this diagnostic and the market has to
+ * read both (verified against 10.28.2 / 11.21.0 / 11.22.0):
+ *
+ * - Up to pnpm 11.20, one package per error, quoted with its full URL:
+ *   `Cannot install package "name@https://…": its lockfile entry has no
+ *   "integrity" field`.
+ * - From pnpm 11.21, a supply-chain policy pass verifies the WHOLE lockfile
+ *   up front and reports every violator at once, as indented
+ *   `  name@version <reason>` lines under an `N lockfile entries failed
+ *   verification:` header (pnpm's own `formatEntry`; the mixed-code variant
+ *   inserts `[MISSING_TARBALL_INTEGRITY]` before the reason).
+ *
+ * Only the first shape was recognized, so on current pnpm the market fell
+ * back to a message that said an entry was bad without saying which one —
+ * and since pnpm refuses even to uninstall the offender, naming it is the
+ * whole of the user's recovery path (#422).
+ *
+ * The name is still never guessed. A candidate counts only when it carries a
+ * version-shaped suffix, which is what keeps a bare URL out and stops
+ * `alias@npm:real@1.0.0` from being read as `real` — `:` and `/` are absent
+ * from the version character class, and the lookbehind rejects a name that
+ * is really the tail of a longer token.
+ * @param diagnostic - decoded pnpm output.
+ * @returns the distinct package names, or an empty array when none is unambiguous.
+ */
+function integrityViolators(diagnostic: string): string[] {
+  const NAME = String.raw`(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*`
+  const found: string[] = []
+  const add = (name: string | undefined): void => {
+    if (name !== undefined && !found.includes(name)) found.push(name)
+  }
+  add(new RegExp(String.raw`Cannot (?:install|fetch) package\s+"(${NAME})@https?:\/\/[^"\s]+"(?: from the lockfile)?:\s*(?:its lockfile entry|it) has no "integrity" field`, 'i')
+    .exec(diagnostic)?.[1])
+  const listed = new RegExp(
+    String.raw`(?<![\w./:@-])(${NAME})@[A-Za-z0-9._+-]+(?:\s+\[MISSING_TARBALL_INTEGRITY\])? has no "integrity" field`,
+    'gi',
+  )
+  for (const match of diagnostic.matchAll(listed)) add(match[1])
+  return found
+}
+
+/**
  * Map a failed pnpm run's combined output to a known failure mode.
  *
  * dsh's own wrapper line ("dsh: pnpm failed in profile directory …") names no
@@ -166,20 +210,21 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
   //
   // Do not auto-repair this. Computing and writing a hash means choosing to
   // trust the bytes currently served by the URL, which is a supply-chain
-  // decision the market cannot safely make for the user. We only name the
-  // package when pnpm emits its canonical quoted `name@https-url` shape;
-  // aggregate or reworded diagnostics get the generic message rather than a
-  // guessed package name.
+  // decision the market cannot safely make for the user. So the ONE thing
+  // this message has to get right is WHICH entry to remove — see
+  // integrityViolators for why that was previously lost on pnpm 11.
   if (output.includes('ERR_PNPM_MISSING_TARBALL_INTEGRITY')) {
-    const diagnostic = withDecodedPnpmDiagnostics(output)
-    const pkg = /Cannot (?:install|fetch) package\s+"((?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*)@https?:\/\/[^"\s]+"(?: from the lockfile)?:\s*(?:its lockfile entry|it) has no "integrity" field/i.exec(diagnostic)?.[1]
-    const zh = pkg === undefined ? '' : `（${pkg}）`
-    const en = pkg === undefined ? '' : ` (${pkg})`
+    const named = integrityViolators(withDecodedPnpmDiagnostics(output))
+    // Only a single unambiguous name goes in `pkg`: callers treat it as "the
+    // package this failure is about", which a list is not.
+    const pkg = named.length === 1 ? named[0] : undefined
+    const zh = named.length === 0 ? '' : `（${named.join('、')}）`
+    const en = named.length === 0 ? '' : ` (${named.join(', ')})`
     return {
       code: 'missing-tarball-integrity',
       recoverable: false,
       pkg,
-      message: `profile 的 pnpm-lock.yaml 里有一个 tarball 依赖${zh}缺少 integrity，pnpm 因此拒绝所有安装和卸载。请先确认 URL 和 tarball 可信，再重新解析/下载该依赖以写入 sha512 integrity，或从可信的 lockfile 版本恢复该字段，然后重试；市场不会自动为未验证的字节生成校验值 / a tarball dependency${en} in this profile's pnpm-lock.yaml has no integrity, so pnpm refuses every install and uninstall. Verify the URL and tarball first, then re-resolve/download that dependency to record a sha512 integrity, or restore the field from a trusted lockfile version before retrying; the market will not generate a checksum for unverified bytes automatically`,
+      message: `profile 的 pnpm-lock.yaml 里有 tarball 依赖${zh}缺少 integrity，pnpm 因此拒绝这个 profile 里的所有安装和卸载——包括卸载它自己，所以装不回来也删不掉。这种条目通常是旧版市场留下的：它把 GitHub 插件写成了带镜像前缀的 tarball 地址，pnpm 认不出那是 GitHub，就要求一个它自己从不为 GitHub 源写入的校验值。新版市场改为交给 pnpm 原生的 GitHub 地址，不会再产生这种条目（#385）。请在 pnpm-lock.yaml 里删掉上面点名的那条依赖记录后重试，市场会用当前方式把它重新装回来；不要删整个 pnpm-lock.yaml，那会让其余插件全部重新解析版本。市场不会自动为未经验证的字节生成校验值 / a tarball dependency${en} in this profile's pnpm-lock.yaml has no integrity, so pnpm refuses every install and uninstall in this profile — including uninstalling that dependency itself, so it can be neither repaired nor removed. Entries like this usually come from an older market version, which installed GitHub plugins from a mirror-prefixed tarball URL: pnpm cannot tell that is GitHub, so it demands a checksum it never writes for GitHub sources. Current versions hand pnpm its own native GitHub target instead and no longer produce such entries (#385). Delete the named dependency's entry from pnpm-lock.yaml and retry — the market will reinstall it the current way. Do not delete the whole pnpm-lock.yaml; that re-resolves the versions of every other plugin too. The market will not generate a checksum for unverified bytes automatically`,
     }
   }
   // #222 by @MicroMilo: a patch in the profile that no longer applies.

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -122,8 +122,13 @@ so pnpm cannot verify the downloaded tarball.`)
     expect(failed?.pkg).toBe('dsh-think-translate')
     expect(failed?.message).toContain('dsh-think-translate')
     expect(failed?.message).toContain('pnpm-lock.yaml')
-    expect(failed?.message).toContain('sha512')
-    expect(failed?.message).toContain('拒绝所有安装和卸载')
+    expect(failed?.message).toContain('安装和卸载')
+    // Deliberately no longer advises "re-resolve to record a sha512": pnpm
+    // refuses every operation in the profile, including uninstalling the
+    // offender, so that was an instruction the user could not carry out
+    // (#422). The message now gives the one step that does work.
+    expect(failed?.message).not.toContain('sha512')
+    expect(failed?.message).toContain('市场不会自动为未经验证的字节生成校验值')
 
     const scoped = classifyPnpmFailure(`ERR_PNPM_MISSING_TARBALL_INTEGRITY Cannot fetch package "@scope/plugin@https://example.test/plugin.tgz" from the lockfile: it has no "integrity" field, so the downloaded tarball cannot be verified.`)
     expect(scoped?.pkg).toBe('@scope/plugin')
@@ -135,6 +140,41 @@ so pnpm cannot verify the downloaded tarball.`)
 
     const scoped = ndjson.replace('dsh-think-translate@https://', '@scope/plugin@https://')
     expect(classifyPnpmFailure(scoped)?.pkg).toBe('@scope/plugin')
+  })
+
+  it('names the violators in pnpm 11’s whole-lockfile verification report (#422)', () => {
+    // Captured verbatim from pnpm 11.22.0 refusing a profile whose lockfile
+    // an older market had written with a mirror-prefixed codeload URL. pnpm
+    // <= 11.20 named one package per error; 11.21+ verifies the whole
+    // lockfile up front and lists every violator, which the old parser could
+    // not read — leaving the user told an entry was bad but not which one,
+    // in the one failure where pnpm will not even let them uninstall it.
+    const report = classifyPnpmFailure(`[ERR_PNPM_MISSING_TARBALL_INTEGRITY] 1 lockfile entries failed verification:
+  dsh-music-huazai@0.1.0 has no "integrity" field, so its downloaded tarball cannot be verified
+
+The lockfile contains entries that the active policies reject.`)
+    expect(report?.code).toBe('missing-tarball-integrity')
+    expect(report?.recoverable).toBe(false)
+    expect(report?.pkg).toBe('dsh-music-huazai')
+    expect(report?.message).toContain('dsh-music-huazai')
+    // The recovery is one entry, not the file: deleting the lockfile
+    // re-resolves every other plugin in the profile.
+    expect(report?.message).toContain('不要删整个 pnpm-lock.yaml')
+    expect(report?.message).toContain('Do not delete the whole pnpm-lock.yaml')
+
+    // Several violators at once: all are named, but `pkg` stays undefined
+    // because callers read it as "the package this failure is about".
+    const many = classifyPnpmFailure(`[ERR_PNPM_MISSING_TARBALL_INTEGRITY] 2 lockfile entries failed verification:
+  @scope/plugin@1.2.0 has no "integrity" field, so its downloaded tarball cannot be verified
+  dsh-music-huazai@0.1.0 has no "integrity" field, so its downloaded tarball cannot be verified`)
+    expect(many?.pkg).toBeUndefined()
+    expect(many?.message).toContain('@scope/plugin')
+    expect(many?.message).toContain('dsh-music-huazai')
+
+    // pnpm's mixed-code variant inserts the violation code before the reason.
+    const mixed = classifyPnpmFailure(`ERR_PNPM_MISSING_TARBALL_INTEGRITY 1 lockfile entries failed verification:
+  dsh-music-huazai@0.1.0 [MISSING_TARBALL_INTEGRITY] has no "integrity" field, so its downloaded tarball cannot be verified`)
+    expect(mixed?.pkg).toBe('dsh-music-huazai')
   })
 
   it('classifies missing tarball integrity without guessing a package from ambiguous prose (#367)', () => {
@@ -153,6 +193,14 @@ so pnpm cannot verify the downloaded tarball.`)
     // expose as `pkg`; do not mistake a bare URL or npm alias for a name.
     expect(classifyPnpmFailure('ERR_PNPM_MISSING_TARBALL_INTEGRITY Cannot install package "https://example.test/fake.tgz": its lockfile entry has no "integrity" field')?.pkg).toBeUndefined()
     expect(classifyPnpmFailure('ERR_PNPM_MISSING_TARBALL_INTEGRITY Cannot install package "alias@npm:real@1.0.0": its lockfile entry has no "integrity" field')?.pkg).toBeUndefined()
+
+    // The same restraint in the pnpm 11 list shape, where there are no
+    // quotes to lean on: an alias must not be read as its target's name, and
+    // a bare URL is not a package name.
+    expect(classifyPnpmFailure(`ERR_PNPM_MISSING_TARBALL_INTEGRITY 1 lockfile entries failed verification:
+  alias@npm:real@1.0.0 has no "integrity" field, so its downloaded tarball cannot be verified`)?.pkg).toBeUndefined()
+    expect(classifyPnpmFailure(`ERR_PNPM_MISSING_TARBALL_INTEGRITY 1 lockfile entries failed verification:
+  https://example.test/fake.tgz has no "integrity" field, so its downloaded tarball cannot be verified`)?.pkg).toBeUndefined()
   })
 
   it('recognizes momentary network failures — and only those — as transient (#83)', () => {


### PR DESCRIPTION
Closes #422 (as far as the market can act on it — see "What this does not do").

## What #422 actually is

@fenglin-dev reported `ERR_PNPM_MISSING_TARBALL_INTEGRITY` still bricking a profile on 1.36.0, with this URL in the error:

```
dsh-music-huazai@https://gh-proxy.com/https://codeload.github.com/nxz1026/SinglePlayer/tar.gz/73e552c5…
```

I reproduced it end to end against real pnpm rather than reasoning about it. Four measured facts:

| # | Fact | How verified |
|---|---|---|
| 1 | pnpm classifies `codeload.github.com` URLs as **git-hosted** and deliberately writes **no** integrity for them. A mirror-prefixed URL is not codeload, so it is an ordinary remote tarball — which **does** need one. | Both forms installed; lockfile diffed |
| 2 | pnpm **≤ 10.24** writes the mirror-prefixed entry with no integrity; **10.26+** records it | Bisected with cold stores: 10.20/10.22/10.24 no → 10.26/10.28/10.29 yes |
| 3 | `ERR_PNPM_MISSING_TARBALL_INTEGRITY` exists **only in pnpm 11** — a fail-closed policy pass over the *whole* lockfile, before any work | String absent from every 9.x/10.x build, present in 11.x |
| 4 | Once tripped, pnpm 11 refuses **`remove`** as well — the plugin can be neither repaired nor uninstalled | Ran it; same error |

So the failing profile was written by an **older market**, back when it did prefix-proxy the tarball. `src/accelerate.ts` already stopped doing that in #385 and hands pnpm a native `github:owner/repo#<sha>` instead. What #422 exposes is that profiles already carrying such an entry stay dead — and go dead *later*, when pnpm reaches 11, long after the market stopped producing them.

## The bug this PR fixes

Because the market must not mint a checksum for bytes it has not verified (#367), **the message is the entire recovery path.** Which makes naming the offending entry the whole job — and it was not being named.

pnpm 11.21 replaced the per-package diagnostic with a list:

```
[ERR_PNPM_MISSING_TARBALL_INTEGRITY] 1 lockfile entries failed verification:
  dsh-music-huazai@0.1.0 has no "integrity" field, so its downloaded tarball cannot be verified
```

Only the old `Cannot install package "name@url": …` shape was parsed, so on current pnpm we fell back to a message saying an entry was bad without saying **which one** — for a failure the user cannot retry their way out of.

- Read both shapes, including pnpm's mixed-code `[MISSING_TARBALL_INTEGRITY]` variant, and list every violator.
- Replace the old advice — "re-resolve/download that dependency to record a sha512 integrity" — which was **impossible to follow**, since pnpm refuses every operation in that profile. The message now gives the step that works: delete that **one** entry, explicitly *not* the whole lockfile (which would re-resolve every other plugin's version), then retry so the market reinstalls it via the #385 path.

Names are still never guessed: a candidate needs a version-shaped suffix, so a bare URL is not a name, and a lookbehind stops `alias@npm:real@1.0.0` reading as `real`.

## What this does not do

It does not auto-repair the lockfile. Deleting the whole file loses every other plugin's pin, and writing a hash means trusting whatever the URL serves now — the #367 decision, unchanged. A surgical auto-removal of just the dead entry is arguable, but it is a lockfile mutation with supply-chain consequences and is not something to slip into a message fix.

## Verification

- Reproduced the exact failure: lockfile written by pnpm 10.20.0 → `pnpm@11.22.0 install` → the reporter's error.
- Classifier checked against the **verbatim captured stdout**, not only handcrafted strings → `pkg: dsh-music-huazai`.
- Message templates read out of pnpm 11.22.0's own `formatEntry`, so the pattern matches the source, not one sample.
- `npm test` 53 files / 1062 passed; `npm run check` (typecheck, both builds, restart smoke) passed.