### PR TITLE
feat: the exported log names the host version and where it came from

### DIFF
--- a/src/dsh-install.ts
+++ b/src/dsh-install.ts
@@ -5,15 +5,56 @@ import { dirname, join, resolve } from 'node:path'
 
 const DSH_PACKAGE = '@deepseek-ai/dsh'
 
-function isDshPackage(directory: string): boolean {
+/**
+ * The host package's own manifest, or null when `directory` is not it.
+ * @returns the parsed manifest of `@deepseek-ai/dsh`, or null.
+ */
+function readDshManifest(directory: string): { name: string; version?: unknown } | null {
   try {
     const manifest = JSON.parse(
       readFileSync(join(directory, 'package.json'), 'utf8'),
-    ) as { name?: unknown }
-    return manifest.name === DSH_PACKAGE
+    ) as { name?: unknown; version?: unknown }
+    return manifest.name === DSH_PACKAGE ? { name: DSH_PACKAGE, version: manifest.version } : null
   } catch {
-    return false
+    return null
   }
+}
+
+function isDshPackage(directory: string): boolean {
+  return readDshManifest(directory) !== null
+}
+
+/**
+ * The version of the DSH host this market is running inside.
+ *
+ * Read from the same manifest `findDshInstallDir` already parses to identify
+ * the package — the version was sitting in that object and being discarded.
+ *
+ * Worth reporting because the host version has repeatedly been the thing
+ * neither side could see. #293 turned on it (the reporter was on
+ * 0.1.1-rc.2 while every attempt to reproduce had been on 0.1.0-rc.8, which
+ * nobody knew until three rounds in), and #404 is entirely about a plugin
+ * that requires a host newer than the Desktop build it was installed on.
+ *
+ * The directory comes back too, because WHERE it was found is the other half
+ * of the answer: a path under Electron's resources is a Desktop-bundled host,
+ * which #139 established can be older than whatever `npm ls` would report.
+ * Asking the user is not a substitute — that is the number they do not have.
+ * @returns the host version and the directory it was read from, or null when
+ * no host package is locatable (a plain `dsh web` from a global install can
+ * legitimately land here).
+ */
+export function dshHostInfo(entry = process.argv[1]): { version: string; directory: string } | null {
+  const directory = findDshInstallDir(entry)
+  if (directory === null) return null
+  const manifest = readDshManifest(directory)
+  // Located but unversioned: report the directory anyway. "The host is here
+  // and declares no version" is a fact worth carrying, and it is not the
+  // same fact as "no host found".
+  const version = typeof manifest?.version === 'string' && manifest.version !== ''
+    ? manifest.version
+    : 'unknown'
+  return { version, directory }
 }
 
 /**

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,6 +18,7 @@ import {
   mountClientOnlyDeps, purgeMarketState, readMarketState, writeMarketState,
 } from './hot.ts'
 import { createGroup, deleteGroup, removeFromGroups, renameGroup, setGroupMembers } from './groups.ts'
+import { dshHostInfo } from './dsh-install.ts'
 import { configurePersistentLog, exportLogs, logEvent, readPersistentLog } from './log.ts'
 import { marketFetch } from './net.ts'
 import { diagnosePackageManifests } from './diagnostics.ts'
@@ -1929,8 +1930,18 @@ export function mountMarketRoutes(
         } catch (error) {
           snapshot.push(`profile state unavailable: ${error instanceof Error ? error.message : String(error)}`)
         }
+        // The host version, and where it was found. Absent until now, and
+        // it is the field investigations kept stalling on: #293 spent three
+        // rounds before it emerged that the reporter's host was newer than
+        // every attempt to reproduce, and a path under Electron's resources
+        // is how a Desktop-bundled (possibly older, #139) host announces
+        // itself. sanitize() rewrites the home prefix in the value.
+        const host = dshHostInfo()
         response.end(exportLogs({
           'dsh-market': version,
+          'dsh host': host === null
+            ? 'not locatable from this process'
+            : `${host.version} (${host.directory})`,
           platform: `${process.platform} ${process.arch}`,
           node: process.version,
           profile: config.profile,

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -18,6 +18,7 @@ import {
   findDshInstallDir,
   satisfiesRange,
 } from '../src/check.ts'
+import { dshHostInfo } from '../src/dsh-install.ts'
 import { readBundleRules } from '../src/order.ts'
 
 let tmp: string
@@ -902,6 +903,56 @@ describe('in-box bundles that cannot be located (#369)', () => {
     const community = report.bundles.find(layer => layer.name === 'some-community-bundle')
     expect(community?.error).toMatch(/not installed/)
     expect(community?.unresolvedInbox).toBeUndefined()
+  })
+})
+
+describe('host version for the exported log (REIN-280)', () => {
+  it('reports the version and the directory it came from', () => {
+    const cliInstall = writePackage(join(tmp, 'cli'), '@deepseek-ai/dsh', {
+      name: '@deepseek-ai/dsh',
+      version: '0.1.1-rc.2',
+    })
+
+    expect(dshHostInfo(join(cliInstall, 'bin', 'dsh.js')))
+      .toEqual({ version: '0.1.1-rc.2', directory: cliInstall })
+  })
+
+  it('reports a Desktop-bundled host by the resources path it was found at', () => {
+    // The directory is half the answer: a path under Electron's resources is
+    // how a bundled host — which #139 established can be older than anything
+    // npm would report — identifies itself without asking the user.
+    const resources = join(tmp, 'resources-desktop')
+    const dshInstall = writePackage(join(resources, 'app.asar'), '@deepseek-ai/dsh', {
+      name: '@deepseek-ai/dsh',
+      version: '0.1.0-rc.8',
+    })
+    Object.defineProperty(process, 'resourcesPath', { value: resources, configurable: true })
+
+    expect(dshHostInfo(join(tmp, 'electron-entry', 'main.js')))
+      .toEqual({ version: '0.1.0-rc.8', directory: dshInstall })
+  })
+
+  it('distinguishes "located but unversioned" from "no host found"', () => {
+    // Two different facts. A host that is present and declares no version
+    // still tells the reader where it is; null says the market could not
+    // find one at all, which is a legitimate state for a global install.
+    const unversioned = writePackage(join(tmp, 'noversion'), '@deepseek-ai/dsh', {
+      name: '@deepseek-ai/dsh',
+    })
+    expect(dshHostInfo(join(unversioned, 'bin', 'dsh.js')))
+      .toEqual({ version: 'unknown', directory: unversioned })
+
+    delete (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+    expect(dshHostInfo(join(tmp, 'nothing-here', 'main.js'))).toBeNull()
+  })
+
+  it('does not accept a package that merely sits at the right path', () => {
+    const impostor = writePackage(join(tmp, 'impostor'), '@deepseek-ai/dsh', {
+      name: 'something-else',
+      version: '9.9.9',
+    })
+    delete (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+    expect(dshHostInfo(join(impostor, 'bin', 'dsh.js'))).toBeNull()
   })
 })
 

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -728,6 +728,23 @@ describe('backup and restore (#55)', () => {
     expect(text).toMatch(/ghost-bundle: NOT RESOLVED/)
   })
 
+  /** REIN-280: the host version was the field investigations kept stalling
+   * on. #293 ran three rounds before it emerged that the reporter's host was
+   * newer than every attempt to reproduce; #404 is a plugin requiring a host
+   * newer than the Desktop build it was installed on. The export never
+   * carried it, so every such question had to be asked by hand. */
+  it('names the host version in the export, or says plainly that it could not find one', async () => {
+    const r = await bed.dispatch('GET', '/dsh-market/logs')
+    expect(r.status).toBe(200)
+    const line = r.text.split('\n').find(row => row.startsWith('dsh host: '))
+    expect(line, `no "dsh host" line in:\n${r.text.slice(0, 400)}`).toBeDefined()
+    // Under the test harness there is no locatable host package, and that
+    // must read as a stated fact rather than a blank or "undefined" — an
+    // empty field would look like a bug in the export itself.
+    expect(line).toBe('dsh host: not locatable from this process')
+    expect(r.text).not.toContain('undefined')
+  })
+
   /** #346: a catalog entry can name a monorepo subpackage its author has
    * since moved. pnpm's failure for that is unrecognisable — the user sees a
    * resolver error with no reason to suspect the entry rather than their own


### PR DESCRIPTION
Implements step 1 of REIN-280, opened off #404. Also directly serves #293 and #384.

## Why now

The host version has repeatedly been the one fact neither side could see, and the exported log never carried it — so every time it mattered, it had to be asked for by hand.

- **#293** ran three rounds before it emerged that the reporter was on `0.1.1-rc.2` while every attempt to reproduce had been on `0.1.0-rc.8`. Nobody was withholding it; nobody had thought to ask.
- **#404** *is* a host-version problem: a plugin requiring a Remote gateway newer than the Desktop build it was silently installed on.
- I asked two reporters today (#293, #384) to send an export. **That export would not have carried this.**

## The value was already in hand

`findDshInstallDir` parses the host's `package.json` to check `name`, then drops the object — `version` included:

```ts
) as { name?: unknown }
return manifest.name === DSH_PACKAGE
```

So this reads the manifest once and keeps both fields. No new lookup, no new failure mode.

## The directory is half the answer

A path under Electron's `resourcesPath` is how a **Desktop-bundled** host announces itself, and #139 established that one can be older than anything `npm ls` would report. That is precisely the #404 case — and precisely the number a user cannot self-report, because they do not have it.

Three states, kept distinct:

```
dsh host: 0.1.1-rc.2 (/usr/lib/node_modules/@deepseek-ai/dsh)
dsh host: unknown (…/resources/app.asar/node_modules/@deepseek-ai/dsh)
dsh host: not locatable from this process
```

"Located but declares no version" is not "no host found", and neither is a blank field — an empty value in an export reads as a bug in the export itself.

## What this does not do

No precheck, no blocking, no capability probing. #404 asks for `engines.dsh` enforcement; I verified that would not have caught its own incident (`dsh-sidebar-qa@0.4.1` declares `engines: {node:'>=20'}` and no `dsh` field), so that part stays in REIN-280 pending the ecosystem side. This is only the half that needs no cooperation from anyone: state the version, and say plainly when it is unknown.

## Verification

- New tests cover all four paths: CLI-entry discovery, Desktop `resourcesPath` discovery, located-but-unversioned, and not-found. Plus a name-mismatch impostor at the right path, which must not be accepted.
- Route-level test asserts the field reaches the downloaded file, and that the not-found case is a stated sentence rather than blank or `undefined`.
- **Confirmed the route test genuinely fails** without the field (removed it, went red with `no "dsh host" line in: …`, restored, green).
- `npm test` 55 files / 1109 passed; `npm run check` passed.

`sanitize()` already rewrites the home prefix in header values, so the path carries no more than the log's other lines.
