### PR TITLE
feat: restore AdSense support, and say so on the privacy page

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -56,7 +56,13 @@ jobs:
             https://awesome-dsh-plugin.com/readmes.json -o data/readmes-snapshot.json \
             || echo "readmes.json unavailable — building without README bodies"
 
+      # Unset until the AdSense review clears these domains; while unset the
+      # build emits no ad markup and no third-party script, so the site is
+      # byte-identical to an ad-free one. A variable rather than a secret:
+      # the publisher id ships in the HTML either way.
       - run: node scripts/build-site.mjs
+        env:
+          ADSENSE_CLIENT: ${{ vars.ADSENSE_CLIENT }}
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -28,6 +28,25 @@ const OUT = 'docs'
 const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 const ldSafe = (s) => s.replaceAll('<', '\\u003c')
 
+// ── advertising ─────────────────────────────────────────────────────────────
+// One AdSense head tag, gated behind a build variable. Unset — the default —
+// emits nothing at all, so an unconfigured build is byte-identical to an
+// ad-free one and no third-party script is requested.
+//
+// Auto ads decide placement from this tag alone, so there is no slot markup to
+// write and no reserved height to get wrong. The publisher id is a `vars`
+// entry rather than a secret because it ships in the HTML either way.
+const ADSENSE_CLIENT = process.env.ADSENSE_CLIENT || ''
+const adHead = () =>
+  ADSENSE_CLIENT
+    ? `<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${esc(ADSENSE_CLIENT)}" crossorigin="anonymous"></script>\n`
+    : ''
+// The token sits on its own line in every template, so the match takes the
+// newline with it. Otherwise an unconfigured build leaves a blank line behind
+// and "identical to an ad-free build" stops being literally true — which is
+// the one claim about this feature worth being able to check by diffing.
+const AD_HEAD_TOKEN = '__AD_HEAD__\n'
+
 // A missing id here does not fail the build, it ships 1884 pages whose comment
 // box silently talks to the wrong repository — so check the shape up front and
 // stop, rather than discovering it from a user's report.
@@ -86,7 +105,11 @@ for (const f of fs.readdirSync('site/assets')) {
   fs.mkdirSync(`${OUT}/assets`, { recursive: true })
   fs.copyFileSync(`site/assets/${f}`, `${OUT}/assets/${f}`)
 }
-for (const f of ['CNAME', 'robots.txt']) fs.copyFileSync(`site/${f}`, `${OUT}/${f}`)
+// ads.txt ships unconditionally, unlike the ad tag above. It is a claim about
+// who is allowed to sell this domain's inventory, which stays true whether or
+// not a tag is currently live, and AdSense verifies site ownership from it — so
+// it has to exist before the review, not after.
+for (const f of ['CNAME', 'robots.txt', 'ads.txt']) fs.copyFileSync(`site/${f}`, `${OUT}/${f}`)
 
 // ── README rendering ────────────────────────────────────────────────────────
 // Same image policy as the catalog site, for the same reason: a README is
@@ -287,6 +310,7 @@ for (const loc of LOCALES) {
       .replaceAll('__BROWSE__', () => loc.browsePath)
       .replaceAll('__HOME_CSS__', () => (landing ? homeCss() : ''))
       .replaceAll('__HOME_CATALOG__', () => (landing ? homeCatalog(loc) : ''))
+      .replaceAll(AD_HEAD_TOKEN, () => (landing ? adHead() : ''))
     page = applyStrings(page, loc)
     if (urlPath === '/') fs.writeFileSync(`${OUT}/index.html`, page)
     else write(urlPath, page)
@@ -321,6 +345,7 @@ ${c.items.map((p) => `    <li><a href="${pluginPath(loc, p.slug)}"><span class="
     .replaceAll('__LOCALE_LINKS__', () => localeLinks(loc, (l) => l.browsePath))
     .replaceAll('__JUMP__', () => jump)
     .replaceAll('__SECTIONS__', () => sections)
+    .replaceAll(AD_HEAD_TOKEN, () => adHead())
   write(loc.browsePath, applyStrings(page, loc))
 }
 
@@ -469,6 +494,7 @@ ${readmeHtml}
       .replaceAll('__P_SHOTS__', () => shotSection)
       .replaceAll('__P_LINKS__', () => links)
       .replaceAll('__P_RELATED__', () => relSection)
+      .replaceAll(AD_HEAD_TOKEN, () => adHead())
     write(pluginPath(loc, p.slug), applyStrings(page, loc))
   }
 }

--- a/site/ads.txt
+++ b/site/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-8176276536851769, DIRECT, f08c47fec0942fa0

--- a/site/browse-template.html
+++ b/site/browse-template.html
@@ -51,6 +51,7 @@ ul.list p{font-size:.83rem;color:var(--ink2);margin-top:.1rem}
 footer{border-top:1px solid var(--line);margin-top:2.5rem;padding:2rem 0 3rem;font-size:.85rem;color:var(--ink3);display:flex;flex-wrap:wrap;gap:1rem;justify-content:space-between}
 footer a{color:var(--ink2)}
 </style>
+__AD_HEAD__
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "6fdc1fdb390e417599a363e3109357b2"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>

--- a/site/index.en.html
+++ b/site/index.en.html
@@ -49,6 +49,7 @@ footer a:hover{color:var(--accent)}
 @media(max-width:640px){.install{flex-direction:column;font-size:.8rem}}
 </style>
 __HOME_CSS__
+__AD_HEAD__
 <!-- Cloudflare Web Analytics --><script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "6fdc1fdb390e417599a363e3109357b2"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>

--- a/site/index.zh.html
+++ b/site/index.zh.html
@@ -48,6 +48,7 @@ footer a:hover{color:var(--accent)}
 @media(max-width:640px){.install{flex-direction:column;font-size:.8rem}}
 </style>
 __HOME_CSS__
+__AD_HEAD__
 <!-- Cloudflare Web Analytics --><script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "6fdc1fdb390e417599a363e3109357b2"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>

--- a/site/plugin-template.html
+++ b/site/plugin-template.html
@@ -81,6 +81,7 @@ header a:hover{color:var(--accent);text-decoration:none}
 footer{border-top:1px solid var(--line);margin-top:2rem;padding:2rem 0 3rem;font-size:.85rem;color:var(--ink3);display:flex;flex-wrap:wrap;gap:1rem;justify-content:space-between}
 footer a{color:var(--ink2)}
 </style>
+__AD_HEAD__
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "6fdc1fdb390e417599a363e3109357b2"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>

--- a/site/privacy.en.html
+++ b/site/privacy.en.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Privacy — dsh-market</title>
-<meta name="description" content="What the dsh-market plugin and website do and do not collect. No telemetry in the plugin; cookie-less analytics on the site.">
+<meta name="description" content="What the dsh-market plugin and website do and do not collect. No telemetry in the plugin; cookie-less analytics and one advertising placement on the site.">
 <link rel="canonical" href="https://dshmarket.com/privacy/">
 <link rel="alternate" hreflang="en" href="https://dshmarket.com/privacy/">
 <link rel="alternate" hreflang="zh" href="https://dshmarket.com/zh/privacy/">
@@ -62,10 +62,10 @@ footer a:hover{color:var(--accent)}
 </header>
 <main class="prose">
 <h1>Privacy</h1>
-<p class="updated">Last updated 2026-08-18. This page describes this website and the dsh-market plugin. It is written from the code, not from intent — every claim below is checkable in <a href="https://github.com/dsh-market/dsh-market">the repository</a>.</p>
+<p class="updated">Last updated 2026-08-30. This page describes this website and the dsh-market plugin. It is written from the code, not from intent — every claim below is checkable in <a href="https://github.com/dsh-market/dsh-market">the repository</a>.</p>
 
 <h2>The short version</h2>
-<p>The plugin sends nothing about you anywhere. It downloads what you ask it to download. This website counts visits, without cookies and without identifying you.</p>
+<p>The plugin sends nothing about you anywhere. It downloads what you ask it to download. This website counts visits without cookies and without identifying you, and carries <a href="#advertising">Google ads</a>, which do use cookies.</p>
 
 <h2>This website (dshmarket.com)</h2>
 
@@ -73,7 +73,7 @@ footer a:hover{color:var(--accent)}
 <p>We use <strong>Cloudflare Web Analytics</strong>. It is cookie-less and does not fingerprint or track you across sites. It records page views and coarse technical facts — referrer, country, browser and device class — which Cloudflare aggregates. We see counts, never individuals. See <a href="https://www.cloudflare.com/web-analytics/">Cloudflare Web Analytics</a>.</p>
 
 <h3>What the page loads</h3>
-<p>One request to <code>awesome-dsh-plugin.com</code>, to display the current number of plugins in the catalog. Nothing about you is included in it. There are no ad networks, no third-party fonts, and no tracking scripts.</p>
+<p>One request to <code>awesome-dsh-plugin.com</code>, to display the current number of plugins in the catalog. Nothing about you is included in it. Plugin screenshots load from <code>raw.githubusercontent.com</code>, the same host they live on in their own repositories, and ads from <code>pagead2.googlesyndication.com</code>. There are no third-party fonts and no other scripts.</p>
 
 <h3>Comments</h3>
 <p>Each plugin page carries a comment thread, which lives in <strong>GitHub Discussions</strong> and is rendered by <a href="https://giscus.app">giscus</a> in an embedded frame. That frame is not loaded up front: it is requested only once the comment section comes close to the screen — on most pages, after you scroll past the README — and only then do <code>giscus.app</code> and GitHub receive your IP address, as any web server must to answer a request. Reading needs no account. Posting a comment or a reaction signs you in to GitHub through giscus, and what you write is a public GitHub Discussion in the <a href="https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/discussions">awesome-dsh-plugin</a> repository, governed by GitHub's terms — we store none of it ourselves. See the <a href="https://github.com/giscus/giscus/blob/main/PRIVACY-POLICY.md">giscus privacy policy</a>.</p>
@@ -82,7 +82,10 @@ footer a:hover{color:var(--accent)}
 <p>The site is served by <strong>GitHub Pages</strong>. Like any web server, GitHub receives your IP address in order to answer the request. See the <a href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement">GitHub Privacy Statement</a>.</p>
 
 <h3>Cookies</h3>
-<p>This site sets none.</p>
+<p>This site sets none of its own. Google sets cookies for the ads — see below.</p>
+
+<h3 id="advertising">Advertising</h3>
+<p>This site carries ads from <strong>Google AdSense</strong>. Google sets cookies to serve and measure them and receives your IP address with each ad request. You can change what Google does with your data at <a href="https://myadcenter.google.com/">My Ad Center</a>.</p>
 
 <h2>The dsh-market plugin</h2>
 <p>The plugin runs inside your own DeepSeek Harness, on your machine. There is no dsh-market account, no server we operate, and no telemetry. We cannot see what you install.</p>
@@ -105,9 +108,6 @@ footer a:hover{color:var(--accent)}
 <li><strong>Browser storage</strong> holds interface state only — which tab you had open, a pending install being recovered, a dismissed notice. No identifiers, no history of what you install.</li>
 <li><strong>Exported logs</strong> are produced for you to read and attach to a bug report. Home paths and credential shapes are masked, and the file is never uploaded anywhere by us.</li>
 </ul>
-
-<h2>Advertising</h2>
-<p>There is none, and there is no arrangement to introduce any. Should that ever change, this page will say so before it happens, and the change will be visible in this repository's history.</p>
 
 <h2>Contact</h2>
 <p>Corrections and questions: <a href="https://github.com/dsh-market/dsh-market/issues">open an issue</a>. If something on this page does not match the code, that is a bug and we want to hear about it.</p>

--- a/site/privacy.zh.html
+++ b/site/privacy.zh.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>隐私说明 — dsh-market</title>
-<meta name="description" content="dsh-market 插件与网站收集什么、不收集什么。插件无遥测；网站使用无 cookie 的访问统计。">
+<meta name="description" content="dsh-market 插件与网站收集什么、不收集什么。插件无遥测；网站使用无 cookie 的访问统计，并设有一个广告位。">
 <link rel="canonical" href="https://dshmarket.com/zh/privacy/">
 <link rel="alternate" hreflang="en" href="https://dshmarket.com/privacy/">
 <link rel="alternate" hreflang="zh" href="https://dshmarket.com/zh/privacy/">
@@ -62,10 +62,10 @@ footer a:hover{color:var(--accent)}
 </header>
 <main class="prose">
 <h1>隐私说明</h1>
-<p class="updated">最后更新 2026-08-18。本页说明本网站与 dsh-market 插件的数据处理方式。内容依据代码写成，而非依据意图——下面每一条都可以在<a href="https://github.com/dsh-market/dsh-market">代码仓库</a>里核对。</p>
+<p class="updated">最后更新 2026-08-30。本页说明本网站与 dsh-market 插件的数据处理方式。内容依据代码写成，而非依据意图——下面每一条都可以在<a href="https://github.com/dsh-market/dsh-market">代码仓库</a>里核对。</p>
 
 <h2>一句话版本</h2>
-<p>插件不会把关于你的任何信息发到任何地方，它只下载你让它下载的东西。本网站会统计访问量，不使用 cookie，也不识别你的身份。</p>
+<p>插件不会把关于你的任何信息发到任何地方，它只下载你让它下载的东西。本网站统计访问量的部分不使用 cookie、也不识别你的身份；页面上有 <a href="#advertising">Google 广告</a>，广告会用到 cookie。</p>
 
 <h2>本网站（dshmarket.com）</h2>
 
@@ -73,7 +73,7 @@ footer a:hover{color:var(--accent)}
 <p>我们使用 <strong>Cloudflare Web Analytics</strong>。它不使用 cookie，也不做指纹识别或跨站跟踪，记录的是页面访问量和粗粒度的技术信息——来源页、国家/地区、浏览器与设备类型——由 Cloudflare 汇总。我们看到的是数字，不是个人。详见 <a href="https://www.cloudflare.com/web-analytics/">Cloudflare Web Analytics</a>。</p>
 
 <h3>页面会加载什么</h3>
-<p>一个到 <code>awesome-dsh-plugin.com</code> 的请求，用于显示目录里当前的插件数量，其中不包含关于你的任何信息。没有广告网络，没有第三方字体，也没有任何跟踪脚本。</p>
+<p>一个到 <code>awesome-dsh-plugin.com</code> 的请求，用于显示目录里当前的插件数量，其中不包含关于你的任何信息。插件截图从 <code>raw.githubusercontent.com</code> 加载，也就是它们在各自仓库里原本所在的位置；广告从 <code>pagead2.googlesyndication.com</code> 加载。没有第三方字体，也没有其它脚本。</p>
 
 <h3>评论</h3>
 <p>每个插件页面都带有评论区。评论存放在 <strong>GitHub Discussions</strong>，由 <a href="https://giscus.app">giscus</a> 以内嵌框架的形式呈现。页面打开时并不会立即加载这个框架——只有当评论区接近屏幕时才会请求它（多数页面上，也就是你向下滚过 README 之后），也只有在那一刻，<code>giscus.app</code> 与 GitHub 才会收到你的 IP 地址（任何网页服务器为了响应请求都必须知道它）。只是阅读的话不需要账号。发表评论或点表情时，giscus 会引导你登录 GitHub；你写下的内容是 <a href="https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/discussions">awesome-dsh-plugin</a> 仓库里一条公开的 GitHub Discussion，适用 GitHub 的条款，我们自己不保存其中任何内容。详见 <a href="https://github.com/giscus/giscus/blob/main/PRIVACY-POLICY.md">giscus 隐私政策</a>。</p>
@@ -82,7 +82,10 @@ footer a:hover{color:var(--accent)}
 <p>本站由 <strong>GitHub Pages</strong> 提供服务。和任何网页服务器一样，GitHub 会为了响应请求而收到你的 IP 地址。详见 <a href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement">GitHub 隐私声明</a>。</p>
 
 <h3>Cookie</h3>
-<p>本站不设置任何 cookie。</p>
+<p>本站自身不设置任何 cookie。Google 会为广告设置 cookie——见下。</p>
+
+<h3 id="advertising">广告</h3>
+<p>本站有 <strong>Google AdSense</strong> 广告。Google 会设置 cookie 用于投放和衡量广告，并在每次广告请求中收到你的 IP 地址。你可以在 <a href="https://myadcenter.google.com/">我的广告中心</a> 更改 Google 对你数据的使用。</p>
 
 <h2>dsh-market 插件</h2>
 <p>插件运行在你自己的 DeepSeek Harness 里，在你自己的机器上。没有 dsh-market 账号，没有我们运营的服务器，也没有任何遥测。<strong>我们无法知道你装了什么。</strong></p>
@@ -105,9 +108,6 @@ footer a:hover{color:var(--accent)}
 <li><strong>浏览器存储</strong>只保存界面状态——你打开的是哪个标签页、正在恢复的安装、已关闭的提示。不含任何标识，也不记录你装过什么。</li>
 <li><strong>导出的日志</strong>是给你自己看、用于反馈问题的。home 路径与密钥形状已打码，我们不会把它上传到任何地方。</li>
 </ul>
-
-<h2>广告</h2>
-<p>目前没有广告，也没有任何引入广告的安排。若将来有变化，本页会在变化发生之前说明，且改动会体现在本仓库的提交历史中。</p>
 
 <h2>联系方式</h2>
 <p>更正与疑问请<a href="https://github.com/dsh-market/dsh-market/issues">提交 issue</a>。如果本页描述与代码不符，那就是一个 bug，我们希望知道。</p>


### PR DESCRIPTION
Re-lands the AdSense half of the ad support that was merged in August (#247, #249) and lost when `main` was rewritten — those commits ended up on a side branch and `main` re-did the same landing-page work without them.

## Not a straight revert

The original carried EthicalAds as a second, mutually exclusive network. That application was never actually submitted and `EA_PUBLISHER` never held a value, so the slot markup, the reserved-height CSS and the two-network exclusion check are all dropped. What remains is one head tag — Auto ads place their own units, so there is no slot to position and no height to reserve.

## Inert by default

`ADSENSE_CLIENT` unset is the default and what CI ships until Google clears this domain. Verified by diffing a full build against pre-change output: **4900+ pages byte-identical**, only the privacy pages differ. The token match includes its trailing newline, so an unconfigured build does not even leave a blank line behind.

`ads.txt` ships unconditionally — it is a claim about who may sell this domain's inventory, true whether or not a tag is live, and AdSense verifies ownership from it, so it has to exist *before* the review.

## Privacy page

This page previously said there were no ads and no arrangement to introduce any, and that if that changed it would say so beforehand. Both languages now describe what runs, and the Cookies section no longer claims the site sets none — AdSense sets them, and disclosing that is a condition of running AdSense at all.

Advertising moves from a top-level heading to one under "This website", where its scope is unambiguous. The ad tag is not emitted on the privacy pages themselves.

## Verification

- `node scripts/build-site.mjs` unconfigured → byte-identical to pre-change output apart from the privacy pages
- `ADSENSE_CLIENT=... node scripts/build-site.mjs` → 4908 pages carry the tag, both privacy pages carry 0
- `npx vitest run` → 55 files, 1109 tests passing

## After merge

Ads will not serve until `dshmarket.com` is added to the AdSense **Sites** list and approved — the domain has never been submitted, which is why the August attempt recorded pageviews and zero revenue.