### PR TITLE
fix: restore previous build after failed update

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -469,9 +469,13 @@ export function mountMarketRoutes(
    * next start still fails. Re-run pnpm install against the restored
    * manifest to rematerialize the previous build's files.
    */
-  async function rollbackUpdateBuild(name: string, manifestBefore: ProfileManifestSnapshot): Promise<{ ok: boolean; detail: string | null }> {
+  async function rollbackUpdateBuild(
+    name: string,
+    manifestBefore: ProfileManifestSnapshot,
+    rematerializeWhenManifestUnchanged = false,
+  ): Promise<{ ok: boolean; detail: string | null }> {
     const rolledBack = restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
-    if (rolledBack.length === 0) return { ok: true, detail: null }
+    if (rolledBack.length === 0 && !rematerializeWhenManifestUnchanged) return { ok: true, detail: null }
     // CI=true (the market always runs pnpm that way) turns frozen-lockfile
     // on, and the restored manifest pin now disagrees with the lockfile the
     // bad add just wrote — without the flag this restore run fails with
@@ -484,6 +488,42 @@ export function mountMarketRoutes(
     const ok = reinstall.exitCode === 0 && !reinstall.timedOut && !reinstall.cancelled
     if (ok) logEvent('info', 'update', `${name}: previous build rematerialized (${rolledBack.join(', ')})`)
     return { ok, detail: ok ? null : failureDetail(reinstall) }
+  }
+
+  /**
+   * Restore the exact npm build that was on disk before an update started.
+   * Reinstalling a restored range is not sufficient: the failed add may have
+   * advanced the lockfile to another version that still satisfies that range,
+   * so `pnpm install` can keep the rejected bytes while reporting success.
+   */
+  async function rollbackNpmBuild(
+    name: string,
+    manifestBefore: ProfileManifestSnapshot,
+    beforeVersion: string | null,
+  ): Promise<{ ok: boolean; detail: string | null }> {
+    restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
+    if (beforeVersion === null) {
+      return { ok: false, detail: 'the previous installed version is unknown; exact rollback is unavailable' }
+    }
+    const add = await runPlugin(config.profile, ['add', RELEASE_AGE_OVERRIDE, `${name}@${beforeVersion}`])
+      .finally(() => {
+        // The exact add deliberately pins its target. Preserve the user's
+        // durable range/tag spelling even when the command rejects or fails
+        // after a partial manifest write.
+        restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
+      })
+    if (add.exitCode !== 0 || add.timedOut || add.cancelled) {
+      return { ok: false, detail: failureDetail(add) }
+    }
+    const restoredVersion = readInstalledVersion(config.profile, name, activeProfileDir)
+    if (restoredVersion !== beforeVersion) {
+      return { ok: false, detail: `expected v${beforeVersion} after rollback, found v${restoredVersion ?? 'unknown'}` }
+    }
+    if (!hasLoadableEntry(activeProfileDir, name)) {
+      return { ok: false, detail: 'the previous version was reinstalled without a loadable entry' }
+    }
+    logEvent('info', 'update-rollback', `${name}: restored npm build v${beforeVersion}`)
+    return { ok: true, detail: null }
   }
 
   interface PendingRollback {
@@ -521,13 +561,28 @@ export function mountMarketRoutes(
     }
     restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
     const add = await runPlugin(config.profile, ['add', RELEASE_AGE_OVERRIDE, rollbackTarget])
+      .finally(() => {
+        // Keep the durable source spelling (including a floating github:
+        // target or #path selector) even when the exact recovery add rejects
+        // or fails after writing its commit-pinned target into package.json.
+        restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
+      })
     if (add.exitCode !== 0 || add.timedOut || add.cancelled) {
       return { ok: false, detail: failureDetail(add) }
+    }
+    const repoKey = repoOfTarget(rollbackTarget)?.split('#')[0] ?? null
+    const restoredCommit = repoKey === null
+      ? null
+      : readLockCommits(config.profile, activeProfileDir).get(repoKey.toLowerCase()) ?? null
+    if (restoredCommit !== beforeCommit) {
+      return { ok: false, detail: `expected commit ${beforeCommit} after rollback, found ${restoredCommit ?? 'unknown'}` }
+    }
+    if (!hasLoadableEntry(activeProfileDir, name)) {
+      return { ok: false, detail: 'the previous commit was reinstalled without a loadable entry' }
     }
     // pnpm wrote a commit-pinned spec; the profile's durable spec must stay
     // the original `github:owner/repo` form. The lockfile keeps the restored
     // commit resolution for the next boot.
-    restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
     logEvent('info', 'update-rollback', `${name}: restored github build at ${beforeCommit}`)
     return { ok: true, detail: null }
   }
@@ -2192,16 +2247,34 @@ export function mountMarketRoutes(
             const manifestBefore = readProfileManifestSnapshot(config.profile, activeProfileDir)
             const result = await runPlugin(config.profile, addArgs)
             const cancelled = result.cancelled
-            if ((result.exitCode !== 0 || result.timedOut) && !cancelled) {
-              const rolledBack = restoreProfileManifest(config.profile, manifestBefore, activeProfileDir)
-              if (rolledBack.length > 0) logEvent('warn', 'update', `${name}: rolled back manifest residue of the failed run: ${rolledBack.join(', ')}`)
+            let rollbackOk = true
+            let rollbackDetail: string | null = null
+            let hardFailureRollbackError: string | null = null
+            // A non-zero exit or timeout can happen after pnpm has replaced
+            // both package.json and node_modules. Restoring the manifest alone
+            // leaves the rejected build running after restart. Reinstall the
+            // exact prior source identity unless the host rejected the start
+            // as busy or the user deliberately cancelled and chose to inspect
+            // the resulting partial state.
+            if ((result.exitCode !== 0 || result.timedOut) && !cancelled && result.busy !== true) {
+              const rollback = isGit && !restore
+                ? await rollbackGitBuild(name, manifestBefore, target, beforeCommit)
+                : !isGit && !restore
+                  ? await rollbackNpmBuild(name, manifestBefore, beforeVersion)
+                  : await rollbackUpdateBuild(name, manifestBefore, true)
+              rollbackOk = rollback.ok
+              rollbackDetail = rollback.detail
+              if (rollback.ok) {
+                logEvent('warn', 'update', `${name}: failed update command; previous build restored and verified`)
+              } else {
+                hardFailureRollbackError = `${name} 更新失败，且更新前的构建未能验证恢复（${rollback.detail ?? 'unknown'}）；请先检查该 profile，再重新启动。 / ${name} update failed and restoration of the previous build could not be verified (${rollback.detail ?? 'unknown'}); inspect this profile before restarting.`
+                logEvent('error', 'update-rollback', `${name}: failed update command and restoration of the previous build could not be verified — ${rollback.detail ?? 'unknown'}`)
+              }
             }
             let ok = result.exitCode === 0 && !result.timedOut && !cancelled
             let stale = false
             let versionFailureCode: 'DOWNGRADE_DETECTED' | 'RESOLVED_VERSION_MISMATCH' | null = null
             let versionFailureError: string | null = null
-            let rollbackOk = true
-            let rollbackDetail: string | null = null
             let activation: Record<string, ReturnType<typeof verifyActivation>> | undefined
             if (ok) {
               if (restore) {
@@ -2410,7 +2483,7 @@ export function mountMarketRoutes(
               ...(() => { const orphans = orphanBundles(); return orphans.length > 0 ? { orphanBundles: orphans } : {} })(),
               staleReason: staleReason ?? undefined,
               failureCode: versionFailureCode ?? undefined,
-              error: versionFailureError ?? trialError ?? brokenEntryError ?? staleError ?? undefined,
+              error: versionFailureError ?? trialError ?? brokenEntryError ?? hardFailureRollbackError ?? staleError ?? undefined,
               exitCode: result.exitCode,
               timedOut: result.timedOut,
               stdout: result.stdout,

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -69,6 +69,11 @@ const fake = vi.hoisted(() => ({
    * is written before registry fetches and the build-script check run.
    */
   failAfterWriteStderrOnce: '',
+  /** Keep the dependency spec unchanged while the next npm add replaces its
+   * package files, matching a range that already admits the new version. */
+  preserveManifestOnNextAdd: false,
+  /** Fail one exact add target after writing, without affecting the update attempt before it. */
+  failAddTargetOnce: null as { target: string; stderr: string } | null,
   /** Simulate dsh adding a profile bundle before that same add later fails (#339). */
   profileBundleOnNextAdd: null as string | null,
   /** Make restore's bulk install fail so its per-plugin fallback is exercised. */
@@ -249,10 +254,21 @@ vi.mock('../src/dsh-cli.ts', () => {
       // pnpm minimumReleaseAge: "Already up to date", old version kept, exit 0.
       return ok
     }
-    const version = fake.resolvedNpmVersionOnce ?? pkg.latest
+    const exactVersion = /@(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/.exec(target)?.[1] ?? null
+    const version = fake.resolvedNpmVersionOnce ?? exactVersion ?? pkg.latest
     fake.resolvedNpmVersionOnce = null
+    const previousSpec = readManifest().dependencies?.[name]
     writeDep(name, `^${version}`)
     writePkg(name, { version, ...(pkg.versions[version].manifest as object) }, pkg.versions[version].artifacts, pkg.versions[version].artifactContents)
+    if (fake.preserveManifestOnNextAdd) {
+      fake.preserveManifestOnNextAdd = false
+      if (previousSpec !== undefined) writeDep(name, previousSpec)
+    }
+    if (fake.failAddTargetOnce?.target === target) {
+      const stderr = fake.failAddTargetOnce.stderr
+      fake.failAddTargetOnce = null
+      return { exitCode: 1, timedOut: false, stdout: '', stderr, cancelled: false }
+    }
     if (fake.profileBundleOnNextAdd !== null) {
       appendProfileBundle(fake.profileBundleOnNextAdd)
       fake.profileBundleOnNextAdd = null
@@ -472,6 +488,8 @@ beforeEach(() => {
   fake.buildScriptOutputOnce = ''
   fake.failNextAddStderrOnce = ''
   fake.failAfterWriteStderrOnce = ''
+  fake.preserveManifestOnNextAdd = false
+  fake.failAddTargetOnce = null
   fake.profileBundleOnNextAdd = null
   fake.failInstallOnce = false
   fake.captureBundlesOnNextAdd = false
@@ -627,7 +645,10 @@ describe('host-provided profile and package-operation seams', () => {
     fake.profileDir = explicitDir
     fake.npm['dsh-loop'] = {
       latest: '1.2.0',
-      versions: { '1.2.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } },
+      versions: {
+        '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] },
+        '1.2.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] },
+      },
     }
     fake.failAfterWriteStderrOnce = '[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/ghost: Not Found - 404'
     vi.stubGlobal('fetch', () => Promise.resolve(new Response(JSON.stringify({ version: '1.2.0' }), { status: 200 })))
@@ -637,6 +658,8 @@ describe('host-provided profile and package-operation seams', () => {
     expect(result.status).toBe(502)
     const desktopManifest = JSON.parse(readFileSync(join(explicitDir, 'package.json'), 'utf8'))
     expect(desktopManifest.dependencies).toEqual({ 'dsh-loop': '^1.0.0' })
+    const installed = JSON.parse(readFileSync(join(explicitDir, 'node_modules', 'dsh-loop', 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.0.0')
     const ordinaryManifest = JSON.parse(readFileSync(join(profileDir('web'), 'package.json'), 'utf8'))
     expect(ordinaryManifest.dependencies).toEqual({})
   })
@@ -1711,14 +1734,135 @@ describe('update flow — no npm publishing required', () => {
     expect(lastAdd).toContain('--config.minimumReleaseAge=0')
   })
 
-  it('restores the previous pin when an update fails after pnpm wrote the bumped spec (#65)', async () => {
+  it('restores the previous build when an update fails after pnpm wrote new files (#65 follow-up)', async () => {
     advanceNpmLatest('1.2.0')
     fake.failAfterWriteStderrOnce = '[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/some-ghost-dep: Not Found - 404'
     const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
     expect(r.status).toBe(502)
-    // pnpm had already bumped the spec to ^1.2.0 before failing; the
-    // rollback restores the pre-update pin.
+    // pnpm had already bumped the spec and replaced the package files before
+    // failing. A rollback is only complete when both return to the previous
+    // build; otherwise the rejected release still runs after restart.
     expect(installedSpec('dsh-loop')).toBe('^1.0.0')
+    const installed = JSON.parse(readFileSync(join(fake.profileDir, 'node_modules', 'dsh-loop', 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.0.0')
+    expect(fake.calls.some(call => call.includes('dsh-loop@1.0.0'))).toBe(true)
+    expect(String(r.json.stderr)).toContain('some-ghost-dep')
+  })
+
+  it('restores prior bytes even when the failed update did not change the manifest range', async () => {
+    advanceNpmLatest('1.2.0')
+    fake.preserveManifestOnNextAdd = true
+    fake.failAfterWriteStderrOnce = 'ELIFECYCLE: postinstall failed after replacing the package directory'
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(502)
+    expect(installedSpec('dsh-loop')).toBe('^1.0.0')
+    const installed = JSON.parse(readFileSync(join(fake.profileDir, 'node_modules', 'dsh-loop', 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.0.0')
+    expect(fake.calls.some(call => call.includes('dsh-loop@1.0.0'))).toBe(true)
+  })
+
+  it('reports a failed byte rollback without claiming the previous build was restored', async () => {
+    advanceNpmLatest('1.2.0')
+    const manifestPath = join(fake.profileDir, 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    manifest.dependencies['dsh-loop'] = '~1.0.0'
+    writeFileSync(manifestPath, JSON.stringify(manifest))
+    fake.failAfterWriteStderrOnce = 'ELIFECYCLE: update build failed after writing files'
+    fake.failAddTargetOnce = { target: 'dsh-loop@1.0.0', stderr: 'ELIFECYCLE: rollback build failed' }
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(502)
+    expect(String(r.json.error)).toMatch(/未能验证|could not be verified/)
+    expect(String(r.json.error)).not.toMatch(/已自动回滚并恢复原版本文件|previous build was restored/)
+    // The failed recovery command rewrites the manifest before exiting. The
+    // route's finally block must still put the user's exact durable spelling
+    // back, even though it cannot claim the recovery was verified.
+    expect(installedSpec('dsh-loop')).toBe('~1.0.0')
+    const installed = JSON.parse(readFileSync(join(fake.profileDir, 'node_modules', 'dsh-loop', 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.0.0')
+  })
+
+  it('restores the captured GitHub commit after an update command fails post-write', async () => {
+    const OLD = 'a'.repeat(40)
+    const NEW = 'b'.repeat(40)
+    await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'dsh-loop' })
+    fake.repos['github:owner/dsh-loop'] = {
+      name: 'dsh-loop',
+      manifest: { name: 'dsh-loop', version: '2.0.0', dsh: {}, main: 'lib/index.js' },
+      artifacts: ['lib/index.js'],
+      lockCommit: NEW,
+      byCommit: {
+        [OLD]: { manifest: { name: 'dsh-loop', version: '1.0.0', dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] },
+      },
+    }
+    const manifestPath = join(fake.profileDir, 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    manifest.dependencies = { 'dsh-loop': 'github:owner/dsh-loop' }
+    writeFileSync(manifestPath, JSON.stringify(manifest))
+    const pkgDir = join(fake.profileDir, 'node_modules', 'dsh-loop')
+    mkdirSync(join(pkgDir, 'lib'), { recursive: true })
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'dsh-loop', version: '1.0.0', dsh: {}, main: 'lib/index.js' }))
+    writeFileSync(join(pkgDir, 'lib', 'index.js'), '')
+    writeFileSync(join(fake.profileDir, 'pnpm-lock.yaml'), `lockfileVersion: 9\n  resolution: {tarball: https://codeload.github.com/owner/dsh-loop/tar.gz/${OLD}}\n`)
+    fake.failAfterWriteStderrOnce = 'ELIFECYCLE: git update failed after replacing files'
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(502)
+    expect(r.json.error).toBeUndefined()
+    expect(String(r.json.stderr)).toContain('git update failed')
+    expect(installedSpec('dsh-loop')).toBe('github:owner/dsh-loop')
+    expect(fake.calls.some(call => call.includes(`github:owner/dsh-loop#${OLD}`))).toBe(true)
+    const lockfile = readFileSync(join(fake.profileDir, 'pnpm-lock.yaml'), 'utf8')
+    expect(lockfile).toContain(OLD)
+    expect(lockfile).not.toContain(NEW)
+    const installed = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.0.0')
+  })
+
+  it('does not launch recovery when Desktop rejects the update as busy', async () => {
+    advanceNpmLatest('1.2.0')
+    bed.dispose()
+    const runPlugin = vi.fn(() => Promise.resolve({
+      exitCode: 127,
+      timedOut: false,
+      stdout: '',
+      stderr: 'another desktop pnpm operation is already running',
+      cancelled: false,
+      busy: true,
+    }))
+    bed = createTestbed({}, {
+      runPlugin,
+      probePnpm: () => Promise.resolve(true),
+      provisionPnpm: () => Promise.resolve({ ok: true }),
+      cancelActive: () => false,
+    })
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(409)
+    expect(r.json).toMatchObject({ ok: false, busy: true })
+    expect(runPlugin.mock.calls).toEqual([
+      ['web', ['add', 'dsh-loop@latest']],
+      ['web', ['store', 'path']],
+    ])
+    expect(installedSpec('dsh-loop')).toBe('^1.0.0')
+  })
+
+  it('does not launch automatic recovery for a user-cancelled update', async () => {
+    advanceNpmLatest('1.2.0')
+    fake.cancelNext = true
+    const callsBefore = fake.calls.length
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(200)
+    expect(r.json).toMatchObject({ ok: false, cancelled: true })
+    expect(fake.calls.slice(callsBefore)).toHaveLength(1)
+    expect(fake.calls.slice(callsBefore).flat()).not.toContain('dsh-loop@1.0.0')
   })
 
   it('surfaces blocked build scripts during an update so the approve banner can retry it (#69)', async () => {


### PR DESCRIPTION
## Summary

- rematerialize the exact previous npm version or captured GitHub commit after an update command hard-fails or times out
- preserve the user's original dependency spelling and verify the restored source identity and loadable entry
- force restored-manifest installs when package bytes changed without a manifest diff, while leaving busy and user-cancelled runs alone

## Why

`pnpm add` can replace both `package.json` and the installed package directory before returning a non-zero result. The existing failure path restored only the manifest, so a rejected or partially written build could remain on disk and run after restart.

The regression reproduced that state on current `main`: the response reported a failed update and the manifest returned to `^1.0.0`, but the installed package bytes remained at `1.2.0`.

## Verification

- focused failure/recovery regressions: 6/6
- complete flow suite: 134/134
- full suite on Node 22.22.2 and Node 24.19.0: 1,113 passed, 1 skipped on each
- typecheck, build, restart smoke, preflight, registry validation, and diff check passed
- independent patch review found no remaining blocking or material issues
