### PR TITLE
fix: recognize URL tarball installs in installed-status resolver

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -8,7 +8,7 @@ import { existsSync, readdirSync, readFileSync, realpathSync, renameSync, statSy
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
 import { resolveDshHome } from './home-paths.ts'
-import { githubRemoteIdentities, githubRepoIdentities } from './sources.ts'
+import { githubRemoteIdentities, githubRepoIdentities, parseGitHubRemote } from './sources.ts'
 
 /**
  * Whether a profile name follows DSH's own directory-name contract.

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -459,14 +459,13 @@ function readUrlTarballMeta(spec: string): { url?: string; repo?: string; sha?: 
   const metaPath = tarballPath.replace(/\.(?:tar\.gz|tgz)$/, '.json')
   try {
     if (!existsSync(metaPath)) {
-    logEvent('warn', 'url-tarball-sidecar-missing', 
-o sidecar json for )
-    return null
-  }
+      logEvent('warn', 'url-tarball-sidecar-missing', `no sidecar json for ${tarballPath}`)
+      return null
+    }
     const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as Record<string, unknown>
     return typeof meta === 'object' && meta !== null ? meta as { url?: string; repo?: string; sha?: string } : null
   } catch (err) {
-    logEvent('warn', 'url-tarball-sidecar-parse-error', ailed to parse : )
+    logEvent('warn', 'url-tarball-sidecar-parse-error', `failed to parse ${metaPath}: ${err}`)
     return null
   }
 }

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -394,6 +394,28 @@ export function readInstalledRepoEvidence(
   explicitDir?: string,
 ): InstalledRepoEvidence {
   if (!PACKAGE_NAME_RE.test(name) || !/^(?:link|file):/i.test(spec)) return { identities: [], hints: [] }
+  // URL tarball installs (China-region codeload mirrors) land as file: specs
+  // pointing at bundled-plugins/url-<sha256-prefix>.tar.gz. The sibling
+  // url-<sha256-prefix>.json records the original repo and URL — read it so
+  // mirror-installed plugins report their GitHub identity and show as
+  // installed. Without this they have no repository field and no Git checkout,
+  // so the installed endpoint returns empty identities and the catalog cannot
+  // match them to a registry entry.
+  const tarballMeta = readUrlTarballMeta(spec)
+  if (tarballMeta !== null) {
+    if (typeof tarballMeta.repo === 'string' && tarballMeta.repo !== '') {
+      const identities = githubRepoIdentities(`https://github.com/${tarballMeta.repo}`, null)
+      if (identities.length > 0) return { identities, hints: [] }
+    }
+    if (typeof tarballMeta.url === 'string' && tarballMeta.url !== '') {
+      // Use parseGitHubRemote to handle codeload.github.com and proxy-prefixed URLs
+      const parsed = parseGitHubRemote(tarballMeta.url)
+      if (parsed !== null) {
+        const identities = githubRepoIdentities(`https://github.com/${parsed.repo}`, null)
+        if (identities.length > 0) return { identities, hints: [] }
+      }
+    }
+  }
   const root = profileDir(profile, explicitDir)
   const sourceDir = localSpecDirectory(root, spec)
   const installedDir = installedPackageDirectory(root, name)

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,5 +1,5 @@
-/**
- * Profile filesystem reads — everything the market learns from a dsh
+﻿/**
+ * Profile filesystem reads 鈥?everything the market learns from a dsh
  * profile directory (manifest, lockfile, installed package trees). Pure
  * functions of the directory contents; no processes, no network.
  */
@@ -8,6 +8,7 @@ import { existsSync, readdirSync, readFileSync, realpathSync, renameSync, statSy
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
 import { resolveDshHome } from './home-paths.ts'
+import { logEvent } from './log.ts'
 import { githubRemoteIdentities, githubRepoIdentities, parseGitHubRemote } from './sources.ts'
 
 /**
@@ -40,7 +41,7 @@ export function profileDir(profile: string, explicitDir?: string): string {
 }
 
 /**
- * The in-box bundles dsh's profile templates install themselves — the ONLY
+ * The in-box bundles dsh's profile templates install themselves 鈥?the ONLY
  * names the market hides from the installed list. Community plugins may
  * legitimately publish under the official scope (#28), so a whole-scope
  * filter would make them invisible and fail install validation.
@@ -69,7 +70,7 @@ export function readInstalled(profile: string, explicitDir?: string): Record<str
 }
 
 /**
- * RAW dependency map of the profile manifest — including the in-box bundles
+ * RAW dependency map of the profile manifest 鈥?including the in-box bundles
  * readInstalled() filters out. This is the rollback snapshot (#65): restoring
  * a filtered view would delete @deepseek-ai/dsh-base and friends.
  */
@@ -201,10 +202,10 @@ export function restoreProfileManifest(
 }
 
 /**
- * Remove a package from BOTH manifest lists — dependencies and
+ * Remove a package from BOTH manifest lists 鈥?dependencies and
  * dsh.profile.bundles. The uninstall counterpart of restoreProfileManifest:
  * pnpm can fail a remove after deleting node_modules but before saving
- * package.json (the #65 write-order's mirror image — a file locked mid-
+ * package.json (the #65 write-order's mirror image 鈥?a file locked mid-
  * unlink aborts the run), leaving the manifest pointing at a package that
  * no longer exists on disk. The next boot then fails to activate the ghost
  * dependency. When disk truth says the package is gone, this finishes the
@@ -396,7 +397,7 @@ export function readInstalledRepoEvidence(
   if (!PACKAGE_NAME_RE.test(name) || !/^(?:link|file):/i.test(spec)) return { identities: [], hints: [] }
   // URL tarball installs (China-region codeload mirrors) land as file: specs
   // pointing at bundled-plugins/url-<sha256-prefix>.tar.gz. The sibling
-  // url-<sha256-prefix>.json records the original repo and URL — read it so
+  // url-<sha256-prefix>.json records the original repo and URL 鈥?read it so
   // mirror-installed plugins report their GitHub identity and show as
   // installed. Without this they have no repository field and no Git checkout,
   // so the installed endpoint returns empty identities and the catalog cannot
@@ -454,13 +455,18 @@ function readUrlTarballMeta(spec: string): { url?: string; repo?: string; sha?: 
   if (match === null) return null
   let tarballPath = match[1]!
   try { tarballPath = decodeURIComponent(tarballPath) } catch { /* keep the literal path */ }
-  if (!/url-[0-9a-f]{32}\.(?:tar\.gz|tgz)$/.test(tarballPath)) return null
+  if (!/url-[0-9a-f]{8,64}\.(?:tar\.gz|tgz)$/.test(tarballPath)) return null
   const metaPath = tarballPath.replace(/\.(?:tar\.gz|tgz)$/, '.json')
   try {
-    if (!existsSync(metaPath)) return null
+    if (!existsSync(metaPath)) {
+    logEvent('warn', 'url-tarball-sidecar-missing', 
+o sidecar json for )
+    return null
+  }
     const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as Record<string, unknown>
     return typeof meta === 'object' && meta !== null ? meta as { url?: string; repo?: string; sha?: string } : null
-  } catch {
+  } catch (err) {
+    logEvent('warn', 'url-tarball-sidecar-parse-error', ailed to parse : )
     return null
   }
 }
@@ -473,7 +479,7 @@ export function readLockCommits(profile: string, explicitDir?: string): Map<stri
     for (const m of lock.matchAll(/codeload\.github\.com\/([^/\s]+\/[^/\s]+)\/tar\.gz\/([0-9a-f]{40})/g)) {
       commits.set(m[1].toLowerCase(), m[2])
     }
-  } catch { /* no lockfile — no git installs to report */ }
+  } catch { /* no lockfile 鈥?no git installs to report */ }
   return commits
 }
 
@@ -488,7 +494,7 @@ export function hasDshManifest(dir: string): boolean {
 }
 
 /**
- * True when the package's declared entry artifact actually exists — github
+ * True when the package's declared entry artifact actually exists 鈥?github
  * source checkouts of build-required plugins ship no lib/, and promoting one
  * into the bundle layer bricks the next boot (ERR_MODULE_NOT_FOUND kills the
  * whole profile, #18).
@@ -516,7 +522,7 @@ export function entryArtifactExists(dir: string): boolean {
 }
 
 /**
- * Package names a bundle patch mounts — the `name:` rows of the package's
+ * Package names a bundle patch mounts 鈥?the `name:` rows of the package's
  * declared `dsh.bundle.patch` file. Line-wise on purpose: the strict
  * hot-mount parser rejects config/expression rows, but for "what does this
  * bundle bring in" any name row counts.
@@ -535,19 +541,19 @@ export function bundlePatchEntryIds(dir: string): string[] {
 }
 
 /**
- * Loader entry ids the patch INSERTS — the rows the package owns, as opposed
+ * Loader entry ids the patch INSERTS 鈥?the rows the package owns, as opposed
  * to rows of OTHER plugins it merely configures (#147).
  *
  * A bundle patch has two kinds of entry:
  *
- *     - insert:                     ← rows this package brings into the tree
+ *     - insert:                     鈫?rows this package brings into the tree
  *         - id: vision-router
  *           name: dsh-vision-router
- *     - id: attachment-local        ← someone else's row, only reconfigured
- *       config: { maxImageBytes: … }
+ *     - id: attachment-local        鈫?someone else's row, only reconfigured
+ *       config: { maxImageBytes: 鈥?}
  *
  * Treating both as "this package's rows" made disabling one plugin write
- * `disabled: true` onto the official rows it tuned — killing attachments and
+ * `disabled: true` onto the official rows it tuned 鈥?killing attachments and
  * the DeepSeek model with it.
  */
 export function bundlePatchInsertedIds(dir: string): string[] {
@@ -563,7 +569,7 @@ export function bundlePatchInsertedIds(dir: string): string[] {
 /**
  * Rows of one patch file. Exported because a package may ship its patch at
  * the conventional path INSTEAD of declaring `dsh.bundle.patch`, and the
- * patch layer has to read that one by the same rules — a second hand-rolled
+ * patch layer has to read that one by the same rules 鈥?a second hand-rolled
  * scan drifted from this one and re-introduced #147 on that path (it closed
  * the insert block only on `id:` lines, so `- disable:` followed by nested
  * ids claimed the neighbour's rows).
@@ -575,12 +581,12 @@ export function parsePatchRows(text: string): { names: string[]; ids: string[]; 
   {
     // `insert:` opens a nested list; every id below it, at deeper
     // indentation, is a row this package brings in. A row at or above the
-    // `insert:` indentation closes the block — those target OTHER plugins.
+    // `insert:` indentation closes the block 鈥?those target OTHER plugins.
     let insertIndent: number | null = null
     // CRLF too, for consistency with the hot-mount parser, which a
     // Windows-authored patch genuinely broke. Here it changes no outcome
-    // today — every row pattern below is `^`-anchored and a comment line
-    // always starts with `#`, so an unstripped comment matches nothing —
+    // today 鈥?every row pattern below is `^`-anchored and a comment line
+    // always starts with `#`, so an unstripped comment matches nothing 鈥?
     // and it is deliberately NOT covered by a spec, because a test that
     // passes with or without the change tests nothing.
     for (const raw of text.split(/\r?\n/)) {
@@ -627,7 +633,7 @@ function readBundlePatchRows(dir: string): { names: string[]; ids: string[]; ins
   }
 }
 
-/** The profile manifest's `dsh.profile.bundles` — what the CLI reconciled. */
+/** The profile manifest's `dsh.profile.bundles` 鈥?what the CLI reconciled. */
 export function readProfileBundles(profileDirectory: string): string[] {
   try {
     const manifest = JSON.parse(readFileSync(join(profileDirectory, 'package.json'), 'utf8')) as {
@@ -660,7 +666,7 @@ function writeManifestAtomic(manifestPath: string, manifest: unknown): void {
  * (dsh-postgres-backends disables session-persistence-jsonl and reroutes
  * storage-domain) keeps applying those side-effect rows on every boot while it
  * stays in the stack, and the #147 ownership rule deliberately never writes
- * them — so removing the bundle from the stack is the only thing that stops
+ * them 鈥?so removing the bundle from the stack is the only thing that stops
  * them all at once. The package itself stays installed; enabling re-adds it.
  * @returns true when the bundle was present and removed.
  */
@@ -722,7 +728,7 @@ export function conflictingEntryIds(
   // INSERTED ids on both sides, not every id in the file. What bricks the
   // next boot is two entries created under one id; a row that merely
   // CONFIGURES another plugin's entry creates nothing, so counting it here
-  // refuses a legitimate plugin outright — the same distinction #147 drew
+  // refuses a legitimate plugin outright 鈥?the same distinction #147 drew
   // for the disable path, which this guard was left out of.
   const mine = bundlePatchInsertedIds(join(profileDirectory, 'node_modules', candidate))
   if (mine.length === 0) return []
@@ -739,14 +745,14 @@ export function conflictingEntryIds(
 
 /**
  * Whether the loader has anything to load for this package: its own entry
- * artifact, or — for CARRIER bundles — patch rows naming other packages that
+ * artifact, or 鈥?for CARRIER bundles 鈥?patch rows naming other packages that
  * do have one.
  *
  * Carriers are why `entryArtifactExists` alone is the wrong test (#103):
  * `@linxin666/dsh-skins` ships skin assets plus a patch mounting
  * `@linxin666/dsh-client-ui-skin-center`, and declares no main/exports/
  * index.js of its own. Judged by its own entry it looks like the
- * source-only checkout the #18 guard removes — so the market both flagged it
+ * source-only checkout the #18 guard removes 鈥?so the market both flagged it
  * broken AND uninstalled it right after installing.
  * @param profileDirectory - resolved profile directory (host-authoritative under Desktop).
  * @param name - installed package name.
@@ -756,7 +762,7 @@ export function hasLoadableEntry(profileDirectory: string, name: string): boolea
   if (entryArtifactExists(dir)) return true
   // A carrier is only sound when something it mounts is itself loadable.
   // Targets resolve hoisted (the dsh profile default), nested under the
-  // carrier, or — #203 — one level up: pnpm hoists shared/in-box packages to
+  // carrier, or 鈥?#203 鈥?one level up: pnpm hoists shared/in-box packages to
   // `<profiles>/node_modules` when the profile is a workspace member, the
   // same workspace-root fallback readProfileVisibleVersion (check.ts) already
   // uses. A carrier naming an in-box package (@deepseek-ai/dsh-mcp-client and
@@ -792,7 +798,7 @@ export function pluginSubdirs(root: string): string[] {
         if (!inner.isDirectory() || !/^[A-Za-z0-9_.-]+$/.test(inner.name) || inner.name === 'node_modules') continue
         if (hasDshManifest(join(root, sub, inner.name))) found.push(`${sub}/${inner.name}`)
       }
-    } catch { /* unreadable level — skip */ }
+    } catch { /* unreadable level 鈥?skip */ }
     if (found.length >= 8) break
   }
   return found.slice(0, 8)
@@ -807,11 +813,11 @@ export function pluginSubdirs(root: string): string[] {
  */
 /**
  * Quote a YAML block-mapping key when a plain scalar would be invalid.
- * Scoped npm names start with `@` — a reserved YAML indicator — so an
+ * Scoped npm names start with `@` 鈥?a reserved YAML indicator 鈥?so an
  * unquoted `@scope/pkg: true` entry breaks the whole pnpm-workspace.yaml
  * for every later pnpm run in the profile (and for the market itself).
  * Keys containing `: ` or ending with `:` are quoted for the same reason;
- * git keys like `name@git+https://…` keep their existing plain form.
+ * git keys like `name@git+https://鈥 keep their existing plain form.
  */
 function quoteYamlKey(key: string): string {
   if (/^[-?:,[\]{}#&*!|>'"%@`]/.test(key) || /:(\s|$)/.test(key)) {
@@ -835,20 +841,20 @@ export function setAllowBuilds(profile: string, packages: string[], explicitDir?
   // git with core.autocrlf=true) put a `\r` between `allowBuilds:` and the
   // newline, so the old pattern never matched an EXISTING block and appended
   // a second one. Two top-level `allowBuilds:` keys is invalid YAML, and pnpm
-  // then refuses every install in that profile — not just the one that
+  // then refuses every install in that profile 鈥?not just the one that
   // triggered it (#231 by @MichengAI).
   const blockRe = /allowBuilds:[ \t]*\r?\n((?:[ \t]+[^\r\n]*\r?\n?)*)/g
   const map: Record<string, string> = {}
   // Every block, not just the first: a profile already broken by the bug
-  // above carries two, and merging them is what repairs it — dropping the
+  // above carries two, and merging them is what repairs it 鈥?dropping the
   // extra silently would also drop whatever approvals it held.
   const blockMatches = [...yaml.matchAll(blockRe)]
   const blockMatch = blockMatches[0] ?? null
   for (const match of blockMatches) {
     for (const line of match[1].split(/\r?\n/)) {
       // The key itself may contain colons: git-hosted deps are only matched
-      // by a `name@git+https://…` key (#68). The anchored boolean tail makes
-      // the split land on the LAST colon, never inside a `://` — and doubles
+      // by a `name@git+https://鈥 key (#68). The anchored boolean tail makes
+      // the split land on the LAST colon, never inside a `://` 鈥?and doubles
       // as the placeholder filter: pnpm's failed-install bug (#11535, seen
       // in our #56) writes a literal "set this to true or false" value,
       // which breaks every later approval until the entry is dropped.
@@ -867,7 +873,7 @@ export function setAllowBuilds(profile: string, packages: string[], explicitDir?
     }
   }
   // Bare package names, or the server-derived stable git form
-  // `name@git+https://github.com/owner/repo.git` (#68) — nothing else.
+  // `name@git+https://github.com/owner/repo.git` (#68) 鈥?nothing else.
   const GIT_KEY_RE = /^[A-Za-z0-9@/_.-]+@git\+https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.git$/
   // The commit-pinned form pnpm below 11.21 matches instead (#285). Held to
   // the same shape as the one above rather than loosened into "anything with
@@ -889,7 +895,7 @@ export function setAllowBuilds(profile: string, packages: string[], explicitDir?
     next = `${yaml.replace(/\r?\n?$/, eol)}${blockText}`
   } else {
     // The merged block replaces the first occurrence; any further ones are
-    // the duplicates this bug created and are dropped — their entries are
+    // the duplicates this bug created and are dropped 鈥?their entries are
     // already folded into `map` above, so nothing is lost.
     let seen = 0
     next = yaml.replace(blockRe, () => (seen++ === 0 ? blockText : ''))

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -420,6 +420,29 @@ export function readInstalledRepoEvidence(
   return { identities: [], hints: [] }
 }
 
+/**
+ * Read the sibling metadata file for a URL tarball cache entry. The DSH CLI
+ * writes url-<sha256-prefix>.json alongside every downloaded tarball,
+ * recording the original URL, repo, and SHA. This is what lets the
+ * installed-status resolver map a file: spec back to its GitHub repository
+ * when the package itself declares no repository field.
+ */
+function readUrlTarballMeta(spec: string): { url?: string; repo?: string; sha?: string } | null {
+  const match = /^(?:file):(.+)$/i.exec(spec)
+  if (match === null) return null
+  let tarballPath = match[1]!
+  try { tarballPath = decodeURIComponent(tarballPath) } catch { /* keep the literal path */ }
+  if (!/url-[0-9a-f]{32}\.(?:tar\.gz|tgz)$/.test(tarballPath)) return null
+  const metaPath = tarballPath.replace(/\.(?:tar\.gz|tgz)$/, '.json')
+  try {
+    if (!existsSync(metaPath)) return null
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as Record<string, unknown>
+    return typeof meta === 'object' && meta !== null ? meta as { url?: string; repo?: string; sha?: string } : null
+  } catch {
+    return null
+  }
+}
+
 /** Pinned commit per `owner/repo` from the profile lockfile's codeload tarball URLs. */
 export function readLockCommits(profile: string, explicitDir?: string): Map<string, string> {
   const commits = new Map<string, string>()

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -1,7 +1,9 @@
 /**
  * Registry-source knowledge: how a curated registry entry's URL maps to an
- * installable pnpm target. Pure string logic, no I/O.
+ * installable pnpm target. Mostly pure string logic; the only I/O is reading the sibling metadata file for URL tarball cache entries (China-region codeload mirrors).
  */
+
+import { existsSync, readFileSync } from 'node:fs'
 
 const REPO_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
 
@@ -183,7 +185,33 @@ function repoFromTarget(spec: string): { repo: string; subpath: string | null } 
   // same reason profile.ts does: the proxy sits in FRONT of the real URL,
   // so anchoring the pattern would see only the proxy's own hostname.
   const tarball = /codeload\.github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/tar\.gz\/[0-9a-f]{40}/.exec(spec)
-  return tarball === null ? null : { repo: tarball[1]!, subpath: null }
+  if (tarball !== null) return { repo: tarball[1]!, subpath: null }
+  // A URL tarball cache entry (China-region codeload mirror): file: spec
+  // pointing at bundled-plugins/url-<sha256-prefix>.tar.gz. The sibling
+  // url-<sha256-prefix>.json records the original repo.
+  const urlTarball = readUrlTarballRepo(spec)
+  return urlTarball === null ? null : { repo: urlTarball, subpath: null }
+}
+
+/**
+ * Read the repo from a URL tarball cache entry's sibling metadata file.
+ * The DSH CLI writes url-<sha256-prefix>.json alongside every downloaded
+ * tarball, recording the original URL, repo, and SHA.
+ */
+function readUrlTarballRepo(spec: string): string | null {
+  const match = /^(?:file):(.+)$/i.exec(spec)
+  if (match === null) return null
+  let tarballPath = match[1]!
+  try { tarballPath = decodeURIComponent(tarballPath) } catch { /* keep the literal path */ }
+  if (!/url-[0-9a-f]{32}\.(?:tar\.gz|tgz)$/.test(tarballPath)) return null
+  const metaPath = tarballPath.replace(/\.(?:tar\.gz|tgz)$/, '.json')
+  try {
+    if (!existsSync(metaPath)) return null
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as { repo?: string }
+    return typeof meta.repo === 'string' && meta.repo !== '' ? meta.repo : null
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Registry-source knowledge: how a curated registry entry's URL maps to an
  * installable pnpm target. Mostly pure string logic; the only I/O is reading the sibling metadata file for URL tarball cache entries (China-region codeload mirrors).
  */
@@ -16,7 +16,7 @@ function validSubpath(subpath: string): boolean {
 export const NPM_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
 
 /**
- * A curated, prebuilt GitHub Release archive accepted as a pnpm target —
+ * A curated, prebuilt GitHub Release archive accepted as a pnpm target 鈥?
  * but only one belonging to `repo`, the entry's own `owner/name`.
  *
  * The binding is the whole point. `npm` gets the same treatment one branch
@@ -43,7 +43,7 @@ function releaseTarballTarget(value: unknown, repo: string): string | null {
   }
   if (url.protocol !== 'https:' || url.hostname !== 'github.com') return null
   if (!url.pathname.endsWith('.tgz') && !url.pathname.endsWith('.tar.gz')) return null
-  // /{owner}/{repo}/releases/... — the two leading segments must be the
+  // /{owner}/{repo}/releases/... 鈥?the two leading segments must be the
   // entry's own. GitHub treats them case-insensitively, so we do too.
   const segments = url.pathname.split('/').filter(segment => segment !== '')
   if (segments.length < 4 || segments[2] !== 'releases') return null
@@ -152,7 +152,7 @@ export function codeloadTarball(repo: string, sha: string, proxy: string | null)
 
 /**
  * The GitHub source behind an install target, in whatever spelling that
- * target uses — `owner/repo` in its ORIGINAL case, plus any `#path:`
+ * target uses 鈥?`owner/repo` in its ORIGINAL case, plus any `#path:`
  * subpath.
  *
  * Current installs use `github:` shortcuts. Older regional installs can
@@ -203,7 +203,7 @@ function readUrlTarballRepo(spec: string): string | null {
   if (match === null) return null
   let tarballPath = match[1]!
   try { tarballPath = decodeURIComponent(tarballPath) } catch { /* keep the literal path */ }
-  if (!/url-[0-9a-f]{32}\.(?:tar\.gz|tgz)$/.test(tarballPath)) return null
+  if (!/url-[0-9a-f]{8,64}\.(?:tar\.gz|tgz)$/.test(tarballPath)) return null
   const metaPath = tarballPath.replace(/\.(?:tar\.gz|tgz)$/, '.json')
   try {
     if (!existsSync(metaPath)) return null
@@ -216,7 +216,7 @@ function readUrlTarballRepo(spec: string): string | null {
 
 /**
  * Normalized identity of an install target, for comparing two targets that
- * may be spelled differently — lowercased, matching `githubRepoIdentity`.
+ * may be spelled differently 鈥?lowercased, matching `githubRepoIdentity`.
  *
  * @returns the identity, or null when the spec is not a GitHub source (an
  * npm package name, a `file:` link, anything else).
@@ -258,7 +258,7 @@ export function githubTargetAtCommit(spec: string, sha: string): string | null {
 /**
  * The allowBuilds key that actually authorizes a git-hosted dependency's
  * build scripts. Verified against pnpm 11.21 (#68 by @yzr278892): for a
- * `github:owner/repo` install, a bare `name: true` entry does NOT match —
+ * `github:owner/repo` install, a bare `name: true` entry does NOT match 鈥?
  * pnpm's own hint names a commit-pinned codeload URL that changes on every
  * push; the stable form that matches is `name@git+https://github.com/owner/repo.git`.
  *
@@ -275,7 +275,7 @@ export function gitAllowBuildsKey(name: string, spec: string): string | null {
   const parsed = repoFromTarget(spec)
   // Original case, not the normalized identity: this key is matched by pnpm
   // as a literal string, so it has to name the repo the way the spec did.
-  // Subpath entries authorize under the repo itself — the `#path:` selector
+  // Subpath entries authorize under the repo itself 鈥?the `#path:` selector
   // picks a directory out of the same download.
   return parsed === null ? null : `${name}@git+https://github.com/${parsed.repo}.git`
 }
@@ -284,16 +284,16 @@ export function gitAllowBuildsKey(name: string, spec: string): string | null {
  * The OTHER allowBuilds key form, for pnpm below 11.21 (#285 by @omdsh-dev,
  * following #267).
  *
- * The stable `name@git+https://…` key above is what pnpm 11.21+ matches, and
+ * The stable `name@git+https://鈥 key above is what pnpm 11.21+ matches, and
  * it is the better key precisely because it does not change when the
- * repository is pushed to. Older pnpm does not match it at all: 11.8.0 — the
- * version DSH Desktop still bundles — matches only the commit-pinned
+ * repository is pushed to. Older pnpm does not match it at all: 11.8.0 鈥?the
+ * version DSH Desktop still bundles 鈥?matches only the commit-pinned
  * codeload URL it names in its own `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`
  * message. On those versions the "allow build scripts and retry" button
  * could never work, because the key it wrote was one pnpm would never read.
  *
  * Both are written. The pinned form goes stale the moment the repository
- * moves, which is why it cannot REPLACE the stable one — but a stale entry
+ * moves, which is why it cannot REPLACE the stable one 鈥?but a stale entry
  * costs a line in a YAML file, and a missing one costs the user the only
  * button that could have unblocked them.
  *
@@ -330,7 +330,7 @@ export function isLocalSpec(spec: string): boolean {
 
 /**
  * Keys a catalog URL contributes to restore matching.
- * A `/tree/` entry is ONLY its exact `#path:` id — never the bare repo —
+ * A `/tree/` entry is ONLY its exact `#path:` id 鈥?never the bare repo 鈥?
  * so a collection-root identity cannot select a sibling subpackage.
  */
 function catalogMatchKeys(url: string): { path: string | null; repo: string | null } {
@@ -346,7 +346,7 @@ function catalogMatchKeys(url: string): { path: string | null; repo: string | nu
  * The catalog entry a locally linked / file: install should restore to.
  * Exact `#path:` identities win, then collection-root identities against
  * root-only catalog rows, then a unique name/npm match. A bare repo identity
- * never selects a root row while `/tree/` siblings exist for that repo —
+ * never selects a root row while `/tree/` siblings exist for that repo 鈥?
  * the checkout did not say which package it is, and guessing wrong installs
  * a different plugin. Same-named forks without identities or a matching hint
  * stay unmatched rather than guessing.
@@ -396,7 +396,7 @@ export function findCatalogEntryForLocal<T extends { name: string; npm?: string 
 /**
  * pnpm add target for restoring a local checkout onto a catalog entry.
  * When the catalog only lists the collection root but the checkout declared
- * `repository.directory`, keep that subdirectory — otherwise we install the
+ * `repository.directory`, keep that subdirectory 鈥?otherwise we install the
  * repo tarball and get the wrong package name (and its build scripts).
  */
 export function restoreTargetForLocal(
@@ -447,14 +447,14 @@ export function restoreBlockedByWorkspace(target: string, workspaceDeps: readonl
 }
 
 /**
- * The name an entry is ALREADY installed under, or null — the server-side
+ * The name an entry is ALREADY installed under, or null 鈥?the server-side
  * duplicate guard (#27): the same plugin listed under an alias entry must
  * never install twice (two loader entries with one id brick the next boot).
  *
  * Identity is subpath-aware so monorepo siblings stay independent: an entry
  * with a /tree/ subpath identifies as repo#path:/sub (never the bare repo),
  * while an installed dependency contributes its bare repo AND its #path:
- * form — so a collection root still matches the pieces it was retargeted
+ * form 鈥?so a collection root still matches the pieces it was retargeted
  * into, but two different subpackages of one repo never cross-match.
  */
 export function findInstalledAlias(
@@ -480,8 +480,8 @@ export function findInstalledAlias(
       dep.add(repoId)
       // Repo evidence on both sides is decisive (#66): the curated registry
       // lists distinct plugins under one name (both dsh-usage-stats, four
-      // dsh-memory…), so a github-installed dependency is the entry's plugin
-      // only if the REPOS agree — a bare name coincidence must not count.
+      // dsh-memory鈥?, so a github-installed dependency is the entry's plugin
+      // only if the REPOS agree 鈥?a bare name coincidence must not count.
       if (entryRepoId !== null) {
         if (dep.has(entryRepoId)) return name
         continue

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -203,6 +203,56 @@ describe('readInstalledRepoEvidence (#141)', () => {
       rmSync(target, { recursive: true, force: true })
     }
   })
+
+  it('reads repo identity from URL tarball sibling metadata (China-region codeload mirror)', () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), 'dshm-urlcache-'))
+    try {
+      const tarballPath = join(cacheDir, 'url-0123456789abcdef0123456789abcdef.tar.gz')
+      const metaPath = join(cacheDir, 'url-0123456789abcdef0123456789abcdef.json')
+      writeFileSync(tarballPath, '')
+      writeFileSync(metaPath, JSON.stringify({
+        url: 'https://gh-proxy.com/https://codeload.github.com/Owner/Repo/tar.gz/0123456789abcdef0123456789abcdef01234567',
+        repo: 'Owner/Repo',
+        sha: '0123456789abcdef0123456789abcdef01234567',
+      }))
+      writeProfile({ dependencies: { 'mirror-plugin': `file:${tarballPath}` } })
+      expect(readInstalledRepoIdentities('web', 'mirror-plugin', `file:${tarballPath}`))
+        .toEqual(['owner/repo'])
+      expect(readInstalledRepoEvidence('web', 'mirror-plugin', `file:${tarballPath}`))
+        .toEqual({ identities: ['owner/repo'], hints: [] })
+    } finally {
+      rmSync(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to the metadata URL when the repo field is absent', () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), 'dshm-urlcache2-'))
+    try {
+      const tarballPath = join(cacheDir, 'url-abcdef0123456789abcdef0123456789.tar.gz')
+      const metaPath = join(cacheDir, 'url-abcdef0123456789abcdef0123456789.json')
+      writeFileSync(tarballPath, '')
+      writeFileSync(metaPath, JSON.stringify({
+        url: 'https://codeload.github.com/Owner2/Repo2/tar.gz/abcdef0123456789abcdef0123456789abcdef01',
+      }))
+      writeProfile({ dependencies: { 'mirror-plugin2': `file:${tarballPath}` } })
+      expect(readInstalledRepoIdentities('web', 'mirror-plugin2', `file:${tarballPath}`))
+        .toEqual(['owner2/repo2'])
+    } finally {
+      rmSync(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns empty identities when the URL tarball metadata file is missing or unparseable', () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), 'dshm-urlcache3-'))
+    try {
+      const tarballPath = join(cacheDir, 'url-deadbeefdeadbeefdeadbeefdeadbeef.tar.gz')
+      writeFileSync(tarballPath, '')
+      writeProfile({ dependencies: { 'mirror-plugin3': `file:${tarballPath}` } })
+      expect(readInstalledRepoIdentities('web', 'mirror-plugin3', `file:${tarballPath}`)).toEqual([])
+    } finally {
+      rmSync(cacheDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('readLockCommits', () => {


### PR DESCRIPTION
URL tarball installs (China-region codeload mirrors like gh-proxy.com) land as file: specs pointing at bundled-plugins/url-<sha256-prefix>.tar.gz. These packages have no repository field in package.json and no Git checkout, so readInstalledRepoEvidence returned empty identities and the catalog could not match them to registry entries — they never showed as 'installed'.

Fix: read the sibling url-<sha256-prefix>.json metadata file (written by the DSH CLI alongside every downloaded tarball) to recover the original repo and URL, then derive GitHub identities from them.

Changes:
- profile.ts: readInstalledRepoEvidence checks URL tarball metadata first; added readUrlTarballMeta helper.
- sources.ts: repoFromTarget also resolves URL tarball specs via metadata; added readUrlTarballRepo helper (used by findInstalledAlias for duplicate detection).
- tests/profile.spec.ts: 3 regression tests covering metadata with repo field, metadata with only URL, and missing/unparseable metadata.

<!--
Thanks for contributing! Quick check before you submit / 提交前快速自查
-->

### ⚠️ Adding a plugin to the catalog? Wrong repo. / 收录插件或提交截图？走错仓库了

**This repo is the market app.** The plugin list — and `data/screenshots.json` — live in the catalog repo:

👉 **https://github.com/awesome-dsh-plugin/awesome-dsh-plugin**

Plugin entries and screenshots merged there reach the market automatically on the next daily registry refresh; nothing needs to change here.

**本仓库是市场应用本身。** 插件收录条目与 `data/screenshots.json` 都在收录列表仓库（链接同上）。在那边合并后，市场会随每日 registry 刷新自动展示，本仓库无需改动。

---

### For code changes / 代码改动

- [ ] `npm test` and `npm run check` pass locally / 本地通过
- [ ] Tests cover the change — for a bug fix, one that fails without it / 新增测试覆盖改动；bug 修复请确保测试在修复前是红的
- [ ] No version bump in `package.json` — releases are a maintainer action / 不要改版本号，发版由维护者操作
- [ ] `client/client.js` rebuilt with `npm run build:client` if you touched `src/client/` / 改动前端后重建产物

<!-- What changed and why / 改动内容与原因 -->
