### PR TITLE
fix: installing the market no longer stops dsh 0.1.2-alpha from booting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        # The released line is what users run today; the alpha is what they
+        # will run next, and it is where the market breaks first. dsh
+        # 0.1.2-alpha.1 removed two exports this plugin imported by name, and
+        # the result was the HOST FAILING TO BOOT with the market installed —
+        # nothing in CI could see it, because CI only ever ran the released
+        # line. A plugin that can stop the host from starting has to be
+        # caught before the alpha becomes `latest`.
+        dsh: ['0.1.0-rc.8', '0.1.2-alpha.2']
+        exclude:
+          # Host-API breakage is platform-independent, and Windows web-e2e is
+          # the slowest job in the matrix (~8 min). Running the alpha on Linux
+          # alone catches the class without doubling the critical path.
+          - os: windows-latest
+            dsh: '0.1.2-alpha.2'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +106,7 @@ jobs:
       # flaky "dsh boot timeout" (and, on longer specs, an hours-long stuck
       # job) with nothing wrong in this repo's own code. rc.8 added
       # `--no-open`, which tests/web/scaffold.ts now passes.
-      - run: npm install -g @deepseek-ai/dsh@0.1.0-rc.8
+      - run: npm install -g @deepseek-ai/dsh@${{ matrix.dsh }}
       # --with-deps installs system libraries and is Linux-only.
       - run: npx playwright install --with-deps chromium
         if: runner.os == 'Linux'

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,19 +27,67 @@
  * plugin configuration page, so a second door bought nothing and cost the
  * setting its memory.
  *
- * installSettingsSection rides the scoped fiber, so a host with no settings
- * service — every dsh before 0.1.0-rc.7 — simply never runs any of this and
- * the entry configuration stands as composed. That is why this needs no
- * version check of its own.
+ * The wiring rides the scoped fiber, so a host with no settings service —
+ * every dsh before 0.1.0-rc.7 — simply never runs any of this and the entry
+ * configuration stands as composed. That is why this needs no version check
+ * of its own.
+ *
+ * It depends on the SERVICE and nothing else, which is the whole point of
+ * the shape below. This module used to import two convenience helpers,
+ * `installSettingsSection` and `settingsNamespace`, from
+ * `@deepseek-ai/dsh-settings`. dsh 0.1.2-alpha.1 deleted both — and a
+ * missing NAMED EXPORT is not a missing service. `ctx.inject` degrades
+ * quietly; an ESM named import that resolves to nothing is a SyntaxError at
+ * module evaluation, which cordis's loader reports as a failed entry and the
+ * host exits 1. Installing the market stopped the host from booting at all:
+ *
+ *   SyntaxError: The requested module '@deepseek-ai/dsh-settings' does not
+ *   provide an export named 'installSettingsSection'
+ *
+ * The service itself never changed — `sctx.settings.register(ns, schema,
+ * { base })` is identical in 0.1.0-rc.7 and 0.1.2-alpha.2. Only the two
+ * wrappers went away. So this inlines what the wrapper did (verified against
+ * its source: an inject, a register, a watch, and an unload effect) and
+ * validates the namespace here. Nothing about the graceful-degradation story
+ * changes; it just stops being conditional on an export that upstream is
+ * free to move.
  */
 
 import type { Context } from '@deepseek-ai/cordis'
-import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import z from '@deepseek-ai/schemastery'
 import { restartAllowed } from './restart.ts'
 
+/**
+ * The namespace pattern `settingsNamespace` enforced before it was removed.
+ * Kept as a literal check rather than an import for the reason above.
+ */
+const NAMESPACE_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
+
 /** Namespace the card on the browser side keys itself to. */
-export const MARKET_SETTINGS_NS = settingsNamespace('dsh-market')
+export const MARKET_SETTINGS_NS = 'dsh-market'
+
+if (!NAMESPACE_PATTERN.test(MARKET_SETTINGS_NS)) {
+  throw new TypeError(`settings namespace "${MARKET_SETTINGS_NS}" must match ${String(NAMESPACE_PATTERN)}`)
+}
+
+/**
+ * The slice of the host's `settings` service this module uses.
+ *
+ * Declared structurally rather than imported: the package no longer exports
+ * a type for it on every supported host, and naming only what is called
+ * keeps this from breaking again when a neighbouring field moves.
+ */
+interface SettingsScope {
+  get: () => MarketSettings
+  watch: (listener: () => void) => void
+}
+interface SettingsService {
+  register: (
+    ns: string,
+    schema: z<MarketSettings>,
+    options: { base: MarketSettings },
+  ) => SettingsScope
+}
 
 /** The market settings a user may edit at runtime. */
 export interface MarketSettings {
@@ -71,16 +119,23 @@ export function installMarketSettings(ctx: Context, resolved: { allowRestart?: b
   // class of confusion the detection exists to end.
   const entry = { allowRestart: restartAllowed(resolved) }
   let source = (): MarketSettings => entry
-  installSettingsSection(
-    ctx,
-    MARKET_SETTINGS_NS,
-    MarketSettings,
-    entry,
-    {
-      setSource: (current) => { source = current },
-      // Assigns ONLY what this namespace owns. Writing back a field the
-      // market stores elsewhere is how the channel lost its memory.
-      onChange: () => { resolved.allowRestart = source().allowRestart },
-    },
-  )
+  // Assigns ONLY what this namespace owns. Writing back a field the market
+  // stores elsewhere is how the channel lost its memory.
+  const apply = (): void => { resolved.allowRestart = source().allowRestart }
+
+  // `inject` is the graceful-degradation boundary: on a host with no
+  // settings service the callback never runs and the composed entry stands.
+  ctx.inject(['settings'], (scopedCtx: Context) => {
+    const scoped = scopedCtx as unknown as Context & { settings: SettingsService }
+    const scope = scoped.settings.register(MARKET_SETTINGS_NS, MarketSettings, { base: entry })
+    source = () => scope.get()
+    // Unload restores the composed entry, so a disabled section cannot leave
+    // the routes reading a value nobody can see or change any more.
+    scoped.effect(() => () => {
+      source = () => entry
+      apply()
+    })
+    apply()
+    scope.watch(apply)
+  })
 }

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -12,6 +12,8 @@
  * contract I did not write.
  */
 
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { installMarketSettings, MarketSettings } from '../src/settings.ts'
 
@@ -65,5 +67,32 @@ describe('installMarketSettings', () => {
     // registration rides its own scoped fiber.
     expect(ctx.injected.flat()).toContain('settings')
     expect(ctx.injected.flat()).not.toContain('webServer')
+  })
+
+  it('takes nothing from @deepseek-ai/dsh-settings at runtime', () => {
+    // dsh 0.1.2-alpha.1 deleted `installSettingsSection` and moved
+    // `settingsNamespace` elsewhere. This module imported both, and the
+    // result was not a missing feature — it was the HOST FAILING TO BOOT:
+    //
+    //   SyntaxError: The requested module '@deepseek-ai/dsh-settings' does
+    //   not provide an export named 'installSettingsSection'
+    //
+    // That is the distinction this guard exists for. `ctx.inject` degrades
+    // quietly when a SERVICE is absent, which is the graceful path this file
+    // already tests above. An ESM import of a missing EXPORT cannot degrade
+    // at all: it throws while the module is being evaluated, cordis reports
+    // a failed entry, and dsh exits 1 with the market installed. A plugin
+    // must never be able to stop the host from starting.
+    //
+    // The service is the stable surface — `settings.register(ns, schema,
+    // { base })` is byte-identical in 0.1.0-rc.7 and 0.1.2-alpha.2 — so the
+    // rule is simply: reach the settings service through injection, never
+    // through this package's exports. Scanned rather than mocked, because
+    // this is a fact about our own source, not a claim about their contract
+    // (see the note at the top of this file).
+    const source = readFileSync(resolve('src/settings.ts'), 'utf8')
+    const runtimeImports = [...source.matchAll(/^import\s+(?!type\b)(.+?)\s+from\s+'([^']+)'/gmu)]
+      .filter(match => match[2]!.startsWith('@deepseek-ai/dsh-settings'))
+    expect(runtimeImports.map(match => match[0]), 'import the settings SERVICE via ctx.inject instead').toEqual([])
   })
 })


### PR DESCRIPTION
`@deepseek-ai/dsh@0.1.2-alpha.2` was published to npm today (2026-08-30T14:10Z, tagged `alpha`). **With the market installed, the host does not start on it.**

```
SyntaxError: The requested module '@deepseek-ai/dsh-settings' does not
provide an export named 'installSettingsSection'
  at Entry._init (@deepseek-ai/cordis-plugin-loader)
  ... dsh exited 1
```

`0.1.2-alpha.1` deleted `installSettingsSection` and moved `settingsNamespace` into `@deepseek-ai/dsh-api-settings-controller`. `src/settings.ts` imported both by name.

## Missing service vs missing export

This module was written for the first case, and says so:

> `installSettingsSection` rides the scoped fiber, so a host with no settings service — every dsh before 0.1.0-rc.7 — simply never runs any of this.

That reasoning is still correct, and `ctx.inject` still behaves that way. But an ESM **named import** of an export that no longer exists cannot degrade: it throws during module evaluation, cordis records a failed entry, and the host exits 1. The graceful path never got a chance to run.

A plugin must not be able to stop the host from booting. That is the actual defect here — not the missing feature.

## The service never changed

`settings.register(ns, schema, { base })` is identical in `0.1.0-rc.7` and `0.1.2-alpha.2`; only the two convenience wrappers went away. So this inlines what the wrapper did — read out of its source: an `inject`, a `register`, a `watch`, and an unload effect restoring the composed entry — and validates the namespace with the same pattern the removed helper used (`/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/`).

The dependency is now the **service** and nothing else, which is what the original comment intended all along.

## Verified on both hosts

Real-host lane (`npm run test:web`), not a mock:

| host | before | after |
|---|---|---|
| `dsh@0.1.0-rc.8` (CI pin) | 29/29 | **29/29** |
| `dsh@0.1.2-alpha.2` | **0/29 — every spec failed at boot** | **29/29** |

## Why CI missed it

CI only ever installed the released line. The matrix now runs the alpha too, **Linux only**: host-API breakage is platform-independent, and Windows web-e2e is the slowest job (~8 min), so this buys the coverage without doubling the critical path. Three jobs instead of two.

## Guard

The unit test scans this file for runtime imports from `dsh-settings` rather than mocking the service — that is a fact about our own source, and the file's existing note explains why a hand-written stand-in for someone else's contract would prove nothing. Confirmed it fails when violated (added a `redactSecrets` import → red).

## Blast radius today

`latest` is still `0.1.1-rc.2`, and every Desktop build predates the alpha, so nobody on a default install is affected yet. This lands before `0.1.2` goes stable rather than after.

## Also checked while I was in there

- **peer ranges**: `dsh-settings@0.1.2-alpha.2` does not satisfy our declared `^0.1.0-rc.7 || ^0.1.1-rc.2` by strict semver, but pnpm accepts it — `--strict-peer-dependencies` passes and resolves a single copy against the alpha. No action needed.
- **`@deepseek-ai/cordis`**: `4.0.2` satisfies `^4.0.1`. Fine.
- **alpha.1's other two breaking changes** (APIProxy removed → `@Remote`; one-time token auth on `dsh web`) were already handled by #421.
