### PR TITLE
fix: declare support for the dsh 0.1.2 settings peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-settings": "^0.1.0-rc.7 || ^0.1.1-rc.2",
+    "@deepseek-ai/dsh-settings": "^0.1.0-rc.7 || ^0.1.1-rc.2 || ^0.1.2-alpha.2",
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "dsh": {


### PR DESCRIPTION
Follow-up to #437 / 1.38.1, from #445 by @a903067276-rgb.

They filed the same break independently and reached the same diagnosis — including that `settingsNamespace` was only a validator returning its argument. 1.38.1 already fixed the crash. This covers the second half of their report, which that fix did not: **the declared peer range still stopped at 0.1.1.**

Since #437, CI runs the real-host lane against `0.1.2-alpha.2`. So the market is tested against a host its own manifest said nothing about. The range now covers the line it is actually verified on:

```
^0.1.0-rc.7 || ^0.1.1-rc.2 || ^0.1.2-alpha.2
```

| version | in range |
|---|---|
| 0.1.0-rc.7 / rc.8 | yes |
| 0.1.1-rc.2 | yes |
| 0.1.2-alpha.2 | **yes (new)** |
| 0.1.2 (once released) | **yes (new)** |
| 0.2.0 | no — deliberately |

## On their suggested fix, for the record

They propose `ctx.settings.installSection(...)`. That method is real — it is on the alpha's `SettingsProvider`. But it is **alpha-only**:

```
0.1.2-alpha.2  → installSection present
0.1.0-rc.7     → installSection ABSENT
```

`register` is on both, which is why #437 used it. Adopting `installSection` would fix the alpha and break every host people are actually running today. Worth stating plainly since the suggestion is otherwise well-researched.

## Not reproduced

Their report also says pnpm flags a peer conflict on install. I could not reproduce it: installing `dshmarket` beside `dsh-settings@0.1.2-alpha.2` resolved a **single** copy against the alpha with no warning, and `--strict-peer-dependencies` passed as well — pnpm applies `includePrerelease` semantics here that a bare `semver` check does not.

Widening is still right, because the old range was a false statement about what this package supports. But nobody should expect a warning to vanish from their terminal as a result, and I would rather say so than let this look like a fix for something I never saw.
