### PR TITLE
fix: the exported log says which clock its timestamps are on

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -140,12 +140,53 @@ export function readPersistentLog(file: string, maxLines = 80): string[] {
 }
 
 /**
+ * How to read the `at` fields, said once at the top.
+ *
+ * Every line is stamped in UTC and stays that way: this file is written to
+ * be attached to an issue, and a maintainer comparing two reporters' logs
+ * needs one clock, not each machine's. Localizing the lines would make the
+ * artifact worse at the only job it has.
+ *
+ * But the reader is looking at their own wall clock, and #449 is what that
+ * costs when nobody says so — a UTC+8 user saw `07:32` for something they
+ * watched happen at `15:32` and could not tell whether the log was skewed
+ * or their own machine was. So the offset is stated, with the arithmetic
+ * already done: "add 8h" is a fact they can use without converting
+ * anything, and it is the one line that turns the timestamps from
+ * suspicious into usable.
+ * @returns the note, or null when this machine is already on UTC.
+ */
+function timezoneNote(now = new Date()): string | null {
+  // getTimezoneOffset is minutes to ADD to local to reach UTC, so it is
+  // positive west of Greenwich — the opposite sign from how offsets are
+  // written. Negate it once here rather than at each use.
+  const minutes = -now.getTimezoneOffset()
+  if (minutes === 0) return null
+  const sign = minutes < 0 ? '-' : '+'
+  const abs = Math.abs(minutes)
+  const hh = String(Math.floor(abs / 60)).padStart(2, '0')
+  const mm = String(abs % 60).padStart(2, '0')
+  let zone = ''
+  try {
+    const named = Intl.DateTimeFormat().resolvedOptions().timeZone
+    zone = typeof named === 'string' && named !== '' ? ` (${named})` : ''
+  } catch { /* a runtime without full ICU still gets the offset */ }
+  const shift = mm === '00' ? `${String(Math.floor(abs / 60))}h` : `${String(Math.floor(abs / 60))}h${mm}m`
+  const direction = minutes < 0 ? 'subtract' : 'add'
+  return `timestamps: UTC — this machine is UTC${sign}${hh}:${mm}${zone}, so ${direction} ${shift} for local time`
+}
+
+/**
  * The export document for bug reports.
  * @param header - environment lines to prepend (version, platform — no paths).
  * @returns plain text, newest entry last.
  */
 export function exportLogs(header: Record<string, string>, snapshot: string[] = [], priorSessions: string[] = []): string {
-  const head = Object.entries(header).map(([key, value]) => `${key}: ${sanitize(value)}`)
+  const note = timezoneNote()
+  const head = [
+    ...Object.entries(header).map(([key, value]) => `${key}: ${sanitize(value)}`),
+    ...(note === null ? [] : [note]),
+  ]
   const lines = entries.map(e => `${e.at} [${e.level}] ${e.event}: ${e.detail}`)
   return [
     '# dsh-market log export',

--- a/tests/log-persistence.spec.ts
+++ b/tests/log-persistence.spec.ts
@@ -72,3 +72,48 @@ describe('persistent log sink', () => {
     expect(exportLogs({}, [], readPersistentLog(join(home, 'absent.ndjson')))).not.toContain('previous sessions')
   })
 })
+
+describe('exported timestamps say which clock they are on (#449)', () => {
+  const withOffset = async (minutes: number, zone: string): Promise<string> => {
+    const realOffset = Date.prototype.getTimezoneOffset
+    const realFormat = Intl.DateTimeFormat
+    // getTimezoneOffset is minutes to ADD to local to reach UTC, so UTC+8
+    // reports -480. Stub the platform rather than the module: the note is
+    // computed from the runtime's own clock, which is the thing under test.
+    Date.prototype.getTimezoneOffset = function () { return -minutes }
+    Intl.DateTimeFormat = function () {
+      return { resolvedOptions: () => ({ timeZone: zone }) }
+    } as unknown as typeof Intl.DateTimeFormat
+    try {
+      return exportLogs({ 'dsh-market': 'test' })
+    } finally {
+      Date.prototype.getTimezoneOffset = realOffset
+      Intl.DateTimeFormat = realFormat
+    }
+  }
+
+  it('does the arithmetic for the reader instead of leaving a bare Z', async () => {
+    // #449: a UTC+8 reporter saw 07:32 for something they watched happen at
+    // 15:32 and could not tell whether the log was skewed or their machine
+    // was. Lines stay UTC on purpose — one clock across reporters — so the
+    // header has to be what closes that gap.
+    const text = await withOffset(480, 'Asia/Shanghai')
+    expect(text).toContain('timestamps: UTC')
+    expect(text).toContain('UTC+08:00')
+    expect(text).toContain('Asia/Shanghai')
+    expect(text).toContain('add 8h for local time')
+  })
+
+  it('points the other way west of Greenwich, and keeps half-hour zones exact', async () => {
+    expect(await withOffset(-300, 'America/New_York')).toContain('UTC-05:00')
+    expect(await withOffset(-300, 'America/New_York')).toContain('subtract 5h for local time')
+    // A whole-hour shift would be wrong for the zones that are not on one.
+    expect(await withOffset(330, 'Asia/Kolkata')).toContain('add 5h30m for local time')
+  })
+
+  it('says nothing at all when the machine is already on UTC', async () => {
+    // A note that reduces to "add 0h" is noise in an artifact people read
+    // under pressure.
+    expect(await withOffset(0, 'UTC')).not.toContain('timestamps: UTC —')
+  })
+})


### PR DESCRIPTION
Closes #449.

A UTC+8 reporter watched an update fail at **15:32**, opened the log, and read **07:32**. Nothing was wrong — the stamps are UTC — but from inside the file there was no way to distinguish that from a skewed clock.

## The lines stay UTC

Deliberately. This file exists to be attached to an issue, and comparing two reporters' logs needs one clock, not each machine's. Localizing the lines would make the artifact worse at its only job.

The reporter framed this correctly themselves — storage in UTC is right, the display layer is what's missing — so the fix goes in the header:

```
# dsh-market log export
dsh-market: 1.38.1
platform: darwin arm64
timestamps: UTC — this machine is UTC+08:00 (Asia/Shanghai), so add 8h for local time
```

`add 8h` is usable without converting anything, which is the entire gap.

## Edges covered

| machine | header |
|---|---|
| UTC+08:00 | `add 8h for local time` |
| UTC-05:00 | `subtract 5h for local time` |
| UTC+05:30 | `add 5h30m for local time` — not rounded |
| UTC | *no line* — "add 0h" is noise |

## Verification

- 3 new tests stub `getTimezoneOffset` and `Intl` rather than the module: the note is computed from the runtime's own clock, so that is the thing worth exercising.
- `npm test` 1131 passed; `npm run check` passed.

## Not in scope

#449 also links #448 (update failures are silent in the UI, details only reach `log.ndjson`). That one is a separate defect in the update flow — I'm treating it on its own issue rather than folding two unrelated fixes together.