### PR TITLE
fix: a plugin toggle no longer erases notes, channel and region

### DIFF
--- a/src/hot.ts
+++ b/src/hot.ts
@@ -284,24 +284,55 @@ export function readMarketState(profileDir: string): MarketState {
   }
 }
 
-/** Persist the whole market state; `disabled` is the single written key. */
+/**
+ * Persist the whole market state.
+ *
+ * Every field a caller does not carry forward is taken from disk rather than
+ * dropped. Several callers legitimately know about only one part of the
+ * state — `writeMarketState(dir, { disabled, groups, groupOrder })` appears
+ * at five call sites in routes.ts — and before #435 that shape silently
+ * erased whatever else the user had chosen:
+ *
+ * - `channel` and `region` had no fallback at all, so toggling any plugin
+ *   threw away the user's update channel and download region. Both are
+ *   deliberate choices made through the settings card, and neither has a
+ *   "clear it" path: once picked they only ever move to another value. So
+ *   an absent one always means "the caller has nothing to say", never
+ *   "the user unchose it".
+ * `notes` keeps its original rule — an explicit object wins, including an
+ * empty one, because deleting the last note has to be expressible. What made
+ * #435 lose notes was not this function but a caller: the note route wrote
+ * through a fresh read while the long-lived `marketState` in routes.ts still
+ * carried `notes: {}` from boot, and the next write from that object put the
+ * empty one back. The fix for that belongs at the call site, where the two
+ * copies are, not here — see the note route.
+ *
+ * Reading before writing costs one small JSON parse on an operation that is
+ * already doing filesystem work, and it is what makes "this function writes
+ * the whole document" safe for callers that only hold part of it.
+ */
 export function writeMarketState(profileDir: string, state: MarketState): void {
   mkdirSync(join(profileDir, HOT_DIR), { recursive: true, mode: 0o700 })
-  // Absent means "keep what is on disk", not "clear it". Only an explicit
-  // empty object erases every note.
-  const notes = state.notes ?? readMarketState(profileDir).notes ?? {}
+  const onDisk = readMarketState(profileDir)
+  // `?? {}` only for the type: MarketState declares notes optional, while
+  // readMarketState always returns an object.
+  const notes = state.notes ?? onDisk.notes ?? {}
+  const channel = state.channel ?? onDisk.channel
+  const region = state.region ?? onDisk.region
+  const regionAuto = state.regionAuto ?? onDisk.regionAuto
   writeFileSync(stateFile(profileDir), JSON.stringify({
     disabled: [...state.disabled],
     groups: state.groups,
     groupOrder: state.groupOrder,
     ...(Object.keys(notes).length > 0 ? { notes } : {}),
     // Omitted while unchosen, so "never picked" survives a round trip and
-    // keeps deriving from the running build.
-    ...(state.channel === undefined ? {} : { channel: state.channel }),
+    // keeps deriving from the running build — but only when disk has not
+    // recorded a choice either.
+    ...(channel === undefined ? {} : { channel }),
     // Same reasoning, different consequence: an absent region is what makes
     // the probe run, so writing a default here would mean it never does.
-    ...(state.region === undefined ? {} : { region: state.region }),
-    ...(state.regionAuto === true ? { regionAuto: true } : {}),
+    ...(region === undefined ? {} : { region }),
+    ...(regionAuto === true ? { regionAuto: true } : {}),
   }))
 }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -328,6 +328,17 @@ export function mountMarketRoutes(
     Object.assign(groups, fresh.groups)
     groupOrder.length = 0
     groupOrder.push(...fresh.groupOrder)
+    // The three above are aliased objects other closures hold, so they are
+    // mutated in place. These three are read off `marketState` itself and
+    // were not being refreshed at all — which is #435: a note written
+    // through this route reached disk, but `marketState.notes` still held
+    // the empty object from boot, and the next write from that object put
+    // the empty one back. The note survived a page reload (disk was right)
+    // and vanished later, which is exactly what the reporter described.
+    marketState.notes = fresh.notes
+    marketState.channel = fresh.channel
+    marketState.region = fresh.region
+    marketState.regionAuto = fresh.regionAuto
   }
 
   // Client-only packages (dsh.client without dsh.bundle) are invisible to the

--- a/tests/state.spec.ts
+++ b/tests/state.spec.ts
@@ -166,6 +166,57 @@ describe('market state.json (#60)', () => {
   })
 })
 
+describe('a partial write must not erase the rest of the state (#435)', () => {
+  it('keeps the channel and region a plugin toggle knows nothing about', () => {
+    // Five call sites in routes.ts write `{ disabled, groups, groupOrder }`
+    // — everything a toggle knows. Before this, that shape silently threw
+    // away the update channel and download region, both of which the user
+    // picked deliberately in the settings card. Neither has an "unchoose"
+    // path: once set they only move to another value, so an absent one is
+    // always the caller having nothing to say.
+    const dir = stateDir()
+    writeMarketState(dir, {
+      disabled: new Set(), groups: {}, groupOrder: [],
+      notes: { alpha: 'my note' }, channel: 'beta', region: 'china',
+    })
+
+    const before = readMarketState(dir)
+    writeMarketState(dir, { disabled: new Set(['x']), groups: before.groups, groupOrder: before.groupOrder })
+
+    const after = readMarketState(dir)
+    expect(after.channel).toBe('beta')
+    expect(after.region).toBe('china')
+    expect(after.notes).toEqual({ alpha: 'my note' })
+    expect([...after.disabled]).toEqual(['x'])
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('still lets the last note be deleted', () => {
+    // The preserve rule must not become "notes can never be cleared". The
+    // note route re-reads first, so its empty object is a real statement
+    // about the world rather than a stale one.
+    const dir = stateDir()
+    writeMarketState(dir, { disabled: new Set(), groups: {}, groupOrder: [], notes: { only: 'note' } })
+    const current = readMarketState(dir)
+    writeMarketState(dir, { ...current, notes: {} })
+
+    expect(readMarketState(dir).notes).toEqual({})
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('leaves an unchosen channel and region unset rather than inventing one', () => {
+    // An absent region is what makes the probe run at boot; writing a
+    // default here would mean it never does.
+    const dir = stateDir()
+    writeMarketState(dir, { disabled: new Set(['a']), groups: {}, groupOrder: [] })
+
+    const written = JSON.parse(readFileSync(join(dir, '.dsh-market', 'state.json'), 'utf8')) as Record<string, unknown>
+    expect('channel' in written).toBe(false)
+    expect('region' in written).toBe(false)
+    rmSync(dir, { recursive: true, force: true })
+  })
+})
+
 describe('group CRUD (groups.ts)', () => {
   it('create/rename/delete keep groups and order consistent', () => {
     const state = { groups: {}, groupOrder: [] }


### PR DESCRIPTION
Closes #435. Reproduced, and it turned out to be **two** defects sharing one cause: `writeMarketState` could not tell *"the caller has nothing to say about this field"* from *"the caller wants it empty"*.

## The reported one: notes vanish after a restart

@KJinxxx described it precisely — the note survives a page refresh and is gone after restarting DSH. That shape is the whole clue: the note **did** reach disk.

The note route writes through a fresh read. But `routes.ts` also holds a long-lived `marketState` read once at boot, and `refreshMarketState()` synced only `disabled` / `groups` / `groupOrder` onto it — so `marketState.notes` stayed `{}` from boot forever.

The preserve rule was:

```ts
const notes = state.notes ?? readMarketState(profileDir).notes ?? {}
```

`??` does not fire on `{}` — it is not nullish. So the next write from that stale object put the empty object back.

## The one found next to it: **any plugin toggle erased the channel and region**

Five call sites in `routes.ts` write `{ disabled, groups, groupOrder }` — everything a toggle knows about. `channel` and `region` had **no fallback at all**:

```ts
...(state.channel === undefined ? {} : { channel: state.channel }),
```

So enabling or disabling any plugin silently discarded the user's update channel and download region — both deliberate choices made in the settings card. Measured before the fix:

```
notes  : {"p":"备注"}  ✅ 保住了     ← the reported bug needs the stale object
channel: undefined     ❌ 丢了
region : undefined     ❌ 丢了
```

## Fixes, each where the confusion actually is

- **`writeMarketState`** now reads the current document and falls back to it for `channel` / `region` / `regionAuto`. Neither has an "unchoose" path — once picked they only move to another value — so an absent one always means the caller had nothing to say. An unchosen region still writes nothing, because its absence is exactly what makes the boot probe run.
- **`notes` keeps the explicit-object-wins rule**, because deleting the last note has to stay expressible. The stale copy is fixed at its source instead: `refreshMarketState` now also syncs `notes`, `channel` and `region`, so there is one story instead of two.

I deliberately did *not* make emptiness mean "preserve" — that would have fixed #435 by making notes undeletable.

## Verification

- 3 regressions in `tests/state.spec.ts`: partial write preserves everything; the last note can still be deleted; an unchosen channel/region is still written as absent rather than invented.
- **Confirmed they fail without the fix** — reverted the fallbacks and got `AssertionError: expected undefined to be 'beta'`.
- `npm test` 1153 passed; `npm run check` passed.
