### PR TITLE
fix: classify git prepare failures and tarball URL mismatch

### DIFF
--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -45,7 +45,8 @@ export const HOST_NAMESPACE_RE = /^@deepseek-ai\//
 
 export interface PnpmFailure {
   code: 'adding-to-root' | 'not-a-workspace' | 'hoist-pattern-diff' | 'pnpm-missing' | 'release-age-violation'
-    | 'ignored-builds' | 'git-prepare-not-allowed' | 'fetch-404' | 'transient-network' | 'fetch-timeout'
+    | 'ignored-builds' | 'git-prepare-not-allowed' | 'git-prepare-failed' | 'tarball-url-mismatch'
+    | 'fetch-404' | 'transient-network' | 'fetch-timeout'
     | 'unexpected-store' | 'patch-failed' | 'missing-tarball-integrity' | 'windows-file-locked'
   /** Bilingual, actionable message shown to the user instead of the raw wall of text. */
   message: string
@@ -227,6 +228,30 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
       message: `profile 的 pnpm-lock.yaml 里有 tarball 依赖${zh}缺少 integrity，pnpm 因此拒绝这个 profile 里的所有安装和卸载——包括卸载它自己，所以装不回来也删不掉。这种条目通常是旧版市场留下的：它把 GitHub 插件写成了带镜像前缀的 tarball 地址，pnpm 认不出那是 GitHub，就要求一个它自己从不为 GitHub 源写入的校验值。新版市场改为交给 pnpm 原生的 GitHub 地址，不会再产生这种条目（#385）。请在 pnpm-lock.yaml 里删掉上面点名的那条依赖记录后重试，市场会用当前方式把它重新装回来；不要删整个 pnpm-lock.yaml，那会让其余插件全部重新解析版本。市场不会自动为未经验证的字节生成校验值 / a tarball dependency${en} in this profile's pnpm-lock.yaml has no integrity, so pnpm refuses every install and uninstall in this profile — including uninstalling that dependency itself, so it can be neither repaired nor removed. Entries like this usually come from an older market version, which installed GitHub plugins from a mirror-prefixed tarball URL: pnpm cannot tell that is GitHub, so it demands a checksum it never writes for GitHub sources. Current versions hand pnpm its own native GitHub target instead and no longer produce such entries (#385). Delete the named dependency's entry from pnpm-lock.yaml and retry — the market will reinstall it the current way. Do not delete the whole pnpm-lock.yaml; that re-resolves the versions of every other plugin too. The market will not generate a checksum for unverified bytes automatically`,
     }
   }
+  // #…: pnpm 11's supply-chain check compares every lockfile tarball URL
+  // against the registry's published metadata. A lockfile generated against
+  // registry.npmjs.org fails wholesale when the profile resolves a mirror
+  // registry (npmmirror), because the mirror's metadata names its own
+  // tarball host. pnpm refuses every operation while the mismatch stands,
+  // and the same check runs inside a git-hosted package's own build — which
+  // is how a floating github: dependency can break updates of unrelated
+  // plugins (the inner failure surfaces as ERR_PNPM_PREPARE_PACKAGE).
+  if (output.includes('ERR_PNPM_TARBALL_URL_MISMATCH')) {
+    const diagnostic = withDecodedPnpmDiagnostics(output)
+    const NAME = String.raw`(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*`
+    const named = [...diagnostic.matchAll(new RegExp(String.raw`(?<![\w./:@-])(${NAME})@[A-Za-z0-9._+-]+ has a tarball URL`, 'gi'))]
+      .map(match => match[1])
+      .filter((name, index, all) => all.indexOf(name) === index)
+    const pkg = named.length === 1 ? named[0] : undefined
+    const zh = named.length === 0 ? '' : `（${named.join('、')}）`
+    const en = named.length === 0 ? '' : ` (${named.join(', ')})`
+    return {
+      code: 'tarball-url-mismatch',
+      recoverable: false,
+      ...(pkg === undefined ? {} : { pkg }),
+      message: `pnpm-lock.yaml 里有一些条目的 tarball 地址与当前 registry 发布的元数据不一致${zh}，pnpm 11 的供应链检查因此拒绝这个 profile 里的所有操作。这通常发生在镜像 registry（如 npmmirror）与用 npmjs.org 生成的 lockfile 相遇时——例如某个 git 插件仓库自带的 lockfile。可以按 pnpm 的提示执行 pnpm clean --lockfile 后重新安装，或把 registry 切回生成该 lockfile 的源 / some entries in pnpm-lock.yaml have tarball URLs that do not match the current registry's published metadata${en}; pnpm 11's supply-chain check therefore refuses every operation in this profile. This usually happens when a mirror registry (e.g. npmmirror) meets a lockfile generated against npmjs.org — for example a git-hosted plugin repository's own lockfile. Run pnpm clean --lockfile and reinstall as pnpm suggests, or switch the registry back to the source the lockfile was generated against`,
+    }
+  }
   // #222 by @MicroMilo: a patch in the profile that no longer applies.
   //
   // pnpm exits 1 (verified against 10.29.3) but it has ALREADY written the
@@ -297,6 +322,29 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
       code: 'git-prepare-not-allowed',
       recoverable: false,
       message: '这个 git 插件需要在安装时执行构建脚本，被 pnpm 默认拦截。点击「允许构建脚本并重试」放行后重试即可 / this git-hosted plugin needs to run its build script at install time, which pnpm blocks by default — click "Allow build scripts and retry" to approve and retry',
+    }
+  }
+  // #…: a git-hosted package with a prepare/prepack script failed its own
+  // build. pnpm runs `pnpm install` inside the fetched repository and
+  // rethrows the inner failure as ERR_PNPM_PREPARE_PACKAGE with only a
+  // one-line summary — the inner diagnostics (which package, which registry)
+  // are not propagated, so the user sees "pnpm install Exit status 1" with no
+  // cause. The most common cause on pnpm 11 is the repository's own
+  // pnpm-lock.yaml failing the supply-chain check against a mirror registry
+  // (tarball URLs pointing at registry.npmjs.org while the profile resolves
+  // npmmirror); the repository's build script itself failing, or a network
+  // problem, are the other ones.
+  if (output.includes('ERR_PNPM_PREPARE_PACKAGE')) {
+    const diagnostic = withDecodedPnpmDiagnostics(output)
+    const named = /Failed to prepare git-hosted package fetched from "https:\/\/codeload\.github\.com\/[^"]+":\s*((?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*)@[A-Za-z0-9._+-]+/i
+      .exec(diagnostic)?.[1]
+    const zh = named === undefined ? '' : `（${named}）`
+    const en = named === undefined ? '' : ` (${named})`
+    return {
+      code: 'git-prepare-failed',
+      recoverable: false,
+      ...(named === undefined ? {} : { pkg: named }),
+      message: `git 插件${zh}在安装时需要执行它自己仓库里的构建脚本（pnpm install），但构建失败了。最常见的原因是仓库自带的 pnpm-lock.yaml 与你的 registry 不兼容：lockfile 里的 tarball 地址指向 registry.npmjs.org，而你的 registry 是镜像（如 npmmirror），pnpm 11 的供应链检查会拒绝整个 lockfile；也可能是仓库的构建脚本本身报错或网络问题。可以先把这个依赖固定到已知可用的 commit（github:owner/repo#<commit>）再更新其他插件，或临时把 registry 切到 npmjs.org 重试 / a git-hosted plugin${en} failed to run its own build (pnpm install) during install. The most common cause is the repository's pnpm-lock.yaml being incompatible with your registry: its tarball URLs point at registry.npmjs.org while your registry is a mirror (e.g. npmmirror), which pnpm 11's supply-chain check rejects; the repository's build script itself failing, or a network problem, are the other causes. Pin that dependency to a known-good commit (github:owner/repo#<commit>) before updating other plugins, or temporarily switch the registry to npmjs.org and retry`,
     }
   }
   // #65: a dependency that no longer resolves — an unpublished package left

--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -228,7 +228,7 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
       message: `profile 的 pnpm-lock.yaml 里有 tarball 依赖${zh}缺少 integrity，pnpm 因此拒绝这个 profile 里的所有安装和卸载——包括卸载它自己，所以装不回来也删不掉。这种条目通常是旧版市场留下的：它把 GitHub 插件写成了带镜像前缀的 tarball 地址，pnpm 认不出那是 GitHub，就要求一个它自己从不为 GitHub 源写入的校验值。新版市场改为交给 pnpm 原生的 GitHub 地址，不会再产生这种条目（#385）。请在 pnpm-lock.yaml 里删掉上面点名的那条依赖记录后重试，市场会用当前方式把它重新装回来；不要删整个 pnpm-lock.yaml，那会让其余插件全部重新解析版本。市场不会自动为未经验证的字节生成校验值 / a tarball dependency${en} in this profile's pnpm-lock.yaml has no integrity, so pnpm refuses every install and uninstall in this profile — including uninstalling that dependency itself, so it can be neither repaired nor removed. Entries like this usually come from an older market version, which installed GitHub plugins from a mirror-prefixed tarball URL: pnpm cannot tell that is GitHub, so it demands a checksum it never writes for GitHub sources. Current versions hand pnpm its own native GitHub target instead and no longer produce such entries (#385). Delete the named dependency's entry from pnpm-lock.yaml and retry — the market will reinstall it the current way. Do not delete the whole pnpm-lock.yaml; that re-resolves the versions of every other plugin too. The market will not generate a checksum for unverified bytes automatically`,
     }
   }
-  // #…: pnpm 11's supply-chain check compares every lockfile tarball URL
+  // #455 by @Asheblog: pnpm 11's supply-chain check compares every lockfile tarball URL
   // against the registry's published metadata. A lockfile generated against
   // registry.npmjs.org fails wholesale when the profile resolves a mirror
   // registry (npmmirror), because the mirror's metadata names its own
@@ -324,7 +324,7 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
       message: '这个 git 插件需要在安装时执行构建脚本，被 pnpm 默认拦截。点击「允许构建脚本并重试」放行后重试即可 / this git-hosted plugin needs to run its build script at install time, which pnpm blocks by default — click "Allow build scripts and retry" to approve and retry',
     }
   }
-  // #…: a git-hosted package with a prepare/prepack script failed its own
+  // #455 by @Asheblog: a git-hosted package with a prepare/prepack script failed its own
   // build. pnpm runs `pnpm install` inside the fetched repository and
   // rethrows the inner failure as ERR_PNPM_PREPARE_PACKAGE with only a
   // one-line summary — the inner diagnostics (which package, which registry)

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -235,6 +235,54 @@ The lockfile contains entries that the active policies reject.`)
     expect(prepare?.code).toBe('git-prepare-not-allowed')
     expect(prepare?.message).toContain('允许构建脚本并重试')
   })
+
+  it('recognizes a git-hosted package whose own build failed (ERR_PNPM_PREPARE_PACKAGE)', () => {
+    // Verbatim from a real profile: updating an unrelated npm plugin
+    // re-resolved a floating github: dependency to a new HEAD whose own
+    // pnpm-lock.yaml fails pnpm 11's supply-chain check against a mirror
+    // registry. pnpm rethrows the inner `pnpm install` failure with only a
+    // one-line summary, so the classifier must name the package from that.
+    const failed = classifyPnpmFailure('ERR_PNPM_PREPARE_PACKAGE: Failed to prepare git-hosted package fetched from "https://codeload.github.com/omdsh-dev/DSH-better-sidebar/tar.gz/d70db8fb026d002b22ae97efd893ff08ee9f0d10": dsh-better-sidebar@0.18.0-alpha.0 pnpm-install: `pnpm install`Exit status 1')
+    expect(failed?.code).toBe('git-prepare-failed')
+    expect(failed?.recoverable).toBe(false)
+    expect(failed?.pkg).toBe('dsh-better-sidebar')
+    expect(failed?.message).toContain('dsh-better-sidebar')
+    expect(failed?.message).toContain('registry')
+    expect(failed?.message).toContain('github:owner/repo#<commit>')
+    // The scoped form is read the same way.
+    const scoped = classifyPnpmFailure('ERR_PNPM_PREPARE_PACKAGE: Failed to prepare git-hosted package fetched from "https://codeload.github.com/o/r/tar.gz/abc": @scope/plugin@1.0.0 pnpm-install: `pnpm install`Exit status 1')
+    expect(scoped?.pkg).toBe('@scope/plugin')
+    // Unparseable prose still classifies, without inventing a package.
+    const generic = classifyPnpmFailure('ERR_PNPM_PREPARE_PACKAGE: something reworded upstream')
+    expect(generic?.code).toBe('git-prepare-failed')
+    expect(generic?.pkg).toBeUndefined()
+    expect(generic?.message).not.toContain('undefined')
+  })
+
+  it('recognizes the tarball URL mismatch supply-chain check (ERR_PNPM_TARBALL_URL_MISMATCH)', () => {
+    // Captured from pnpm 11.7.0 preparing a git-hosted package whose
+    // committed lockfile names registry.npmjs.org tarballs while the profile
+    // resolves registry.npmmirror.com.
+    const failed = classifyPnpmFailure(`[ERR_PNPM_TARBALL_URL_MISMATCH] 2 lockfile entries failed verification:
+  @deepseek-ai/dsh-util-crypto@0.1.2-alpha.2 has a tarball URL (https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.2-alpha.2.tgz) that does not match the registry's published metadata (https://registry.npmmirror.com/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.2-alpha.2.tgz)
+  @deepseek-ai/dsh-util-time@0.1.2-alpha.2 has a tarball URL (https://registry.npmjs.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.2-alpha.2.tgz) that does not match the registry's published metadata (https://registry.npmmirror.com/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.2-alpha.2.tgz)
+
+The lockfile contains entries that the active policies reject.`)
+    expect(failed?.code).toBe('tarball-url-mismatch')
+    expect(failed?.recoverable).toBe(false)
+    // Two violators: both named, `pkg` stays undefined.
+    expect(failed?.pkg).toBeUndefined()
+    expect(failed?.message).toContain('@deepseek-ai/dsh-util-crypto')
+    expect(failed?.message).toContain('@deepseek-ai/dsh-util-time')
+    expect(failed?.message).toContain('pnpm clean --lockfile')
+    // A single violator is exposed as `pkg`.
+    const single = classifyPnpmFailure(`[ERR_PNPM_TARBALL_URL_MISMATCH] 1 lockfile entries failed verification:
+  dsh-music-huazai@0.1.0 has a tarball URL (https://registry.npmjs.org/x.tgz) that does not match the registry's published metadata (https://registry.npmmirror.com/x.tgz)`)
+    expect(single?.pkg).toBe('dsh-music-huazai')
+    // The escaped NDJSON form used in production decodes the same way.
+    const ndjson = String.raw`{"name":"pnpm","level":"error","err":{"code":"ERR_PNPM_TARBALL_URL_MISMATCH","message":"1 lockfile entries failed verification:\n  dsh-music-huazai@0.1.0 has a tarball URL (https://registry.npmjs.org/x.tgz) that does not match the registry's published metadata (https://registry.npmmirror.com/x.tgz)"}}`
+    expect(classifyPnpmFailure(ndjson)?.pkg).toBe('dsh-music-huazai')
+  })
 })
 
 describe('provisionHint (#142 / #108 / #32)', () => {


### PR DESCRIPTION
## 改动内容 / What changed

`classifyPnpmFailure` 现在识别两个此前未覆盖的 pnpm 11 失败形态，并给出可操作的双语提示：

1. **`ERR_PNPM_PREPARE_PACKAGE`**（新 code：`git-prepare-failed`）—— git 插件在安装时执行它自己仓库里的构建脚本（内层 `pnpm install`）失败。pnpm 只把内层失败重抛成一行摘要（`pnpm install Exit status 1`），内层诊断不传播，用户完全看不到原因。最常见原因是仓库自带的 `pnpm-lock.yaml` 与镜像 registry 不兼容（tarball 地址指向 npmjs.org 而 profile 解析 npmmirror，pnpm 11 供应链检查拒绝）。分类器从摘要中提取包名，并提示固定 commit（`github:owner/repo#<commit>`）或切换 registry。

2. **`ERR_PNPM_TARBALL_URL_MISMATCH`**（新 code：`tarball-url-mismatch`）—— pnpm 11 供应链检查发现 lockfile 条目的 tarball URL 与当前 registry 发布的元数据不一致。分类器点名所有违规条目，并提示 `pnpm clean --lockfile` 或切回生成该 lockfile 的 registry。

两者都像现有 integrity 分类器一样解码生产环境的 NDJSON 转义形态。

## 背景 / Background

真实案例：更新 dsh-vision-router（npm 插件）时，profile 里一个浮动 `github:` 依赖（dsh-better-sidebar）被重解析到新 HEAD，其自带 lockfile 与 npmmirror 不兼容 → 内层构建失败 → 外层只报 `ERR_PNPM_PREPARE_PACKAGE`，用户看到的是无任何可操作信息的原始错误，且回滚也因同一原因失败。

## 测试 / Tests

- `tests/pnpm-compat.spec.ts`：20 个测试全部通过（含新增 2 个用例：prepare 失败提取包名 + tarball URL 不匹配点名违规条目，均覆盖 NDJSON 形态）
- `npm run typecheck` 通过
- 完整套件中另有 42 个失败为**既有基线问题**（测试数据快照过期：断言旧版本号如 `1.15.0-beta.1`，registry 实际返回 `1.19.0-beta.4`），在无本次改动的 main 上同样失败（已用 `git stash` 验证），与本次改动无关
- 未改版本号，未触碰 `src/client/`（无需重建 client 产物）
