### PR TITLE
fix: let manual region choice clear auto marker

### DIFF
--- a/src/hot.ts
+++ b/src/hot.ts
@@ -319,7 +319,12 @@ export function writeMarketState(profileDir: string, state: MarketState): void {
   const notes = state.notes ?? onDisk.notes ?? {}
   const channel = state.channel ?? onDisk.channel
   const region = state.region ?? onDisk.region
-  const regionAuto = state.regionAuto ?? onDisk.regionAuto
+  // Unlike channel and region, regionAuto has an explicit clear path: a
+  // manual region choice owns this field and sets it to undefined. Preserve
+  // the disk value only when the caller omitted the property entirely.
+  const regionAuto = Object.prototype.hasOwnProperty.call(state, 'regionAuto')
+    ? state.regionAuto
+    : onDisk.regionAuto
   writeFileSync(stateFile(profileDir), JSON.stringify({
     disabled: [...state.disabled],
     groups: state.groups,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -204,6 +204,7 @@ export function mountMarketRoutes(
   commandRuntime?: PluginCommandRuntime,
   agentsLookup?: AgentsLookup,
 ): () => void {
+  let disposed = false
   // An ordinary profile must resolve under DSH_HOME by the same rules as the
   // DSH CLI. A host-authoritative explicit directory (DSH Desktop) does not
   // derive a path from this display/profile name.
@@ -295,6 +296,9 @@ export function mountMarketRoutes(
   // few seconds after boot.
   if (config.region === undefined) {
     void resolveRegion(undefined).then(({ region: probed }) => {
+      // A manual choice made while the probe was pending, or a replacement
+      // mount created after this one was disposed, owns the region now.
+      if (disposed || config.region !== undefined) return
       applyRegion(probed)
       regionAuto = true
       // Persisted as the decision, not re-probed each boot: a market that
@@ -3883,6 +3887,7 @@ export function mountMarketRoutes(
   ]
 
   return () => {
+    disposed = true
     configurePersistentLog(null)
     for (const dispose of disposers) dispose()
   }

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -356,24 +356,39 @@ const hot = vi.hoisted(() => ({
   groupOrder: [] as string[],
   /** Stands in for the channel line of state.json; undefined = never chosen. */
   channel: undefined as 'stable' | 'beta' | 'dev' | undefined,
+  region: undefined as 'global' | 'china' | undefined,
+  regionAuto: undefined as true | undefined,
+  notes: {} as Record<string, string>,
   failNext: false,
 }))
 vi.mock('../src/hot.ts', () => ({
+  MAX_NOTE: 200,
   cleanHotDir: () => {},
   readDisabledThemes: () => hot.disabled,
   writeDisabledThemes: (_dir: string, set: Set<string>) => { hot.disabled = new Set(set) },
   readDisabled: () => hot.disabled,
   writeDisabled: (_dir: string, set: Set<string>) => { hot.disabled = new Set(set) },
-  readMarketState: () => ({ disabled: hot.disabled, groups: hot.groups, groupOrder: hot.groupOrder, channel: hot.channel }),
+  readMarketState: () => ({
+    disabled: hot.disabled, groups: hot.groups, groupOrder: hot.groupOrder,
+    channel: hot.channel, region: hot.region, regionAuto: hot.regionAuto,
+    notes: hot.notes,
+  }),
   // Carries `channel` because the real one does. A stand-in that silently
   // drops a field cannot fail when the code under test forgets to persist
   // it — which is exactly how the channel choice reached this suite with
   // zero coverage while four route tests passed.
-  writeMarketState: (_dir: string, state: { disabled: Set<string>; groups: Record<string, string[]>; groupOrder: string[]; channel?: 'stable' | 'beta' | 'dev' }) => {
+  writeMarketState: (_dir: string, state: {
+    disabled: Set<string>; groups: Record<string, string[]>; groupOrder: string[]
+    channel?: 'stable' | 'beta' | 'dev'; region?: 'global' | 'china'; regionAuto?: true
+    notes?: Record<string, string>
+  }) => {
     hot.disabled = new Set(state.disabled)
     hot.groups = state.groups
     hot.groupOrder = state.groupOrder
     hot.channel = state.channel
+    if (Object.prototype.hasOwnProperty.call(state, 'region')) hot.region = state.region
+    if (Object.prototype.hasOwnProperty.call(state, 'regionAuto')) hot.regionAuto = state.regionAuto
+    if (state.notes !== undefined) hot.notes = state.notes
   },
   listHotMounts: () => [...hot.mounts],
   hotMount: (_ctx: unknown, _dir: string, name: string) => {
@@ -444,6 +459,22 @@ vi.mock('../src/registry.ts', async (importOriginal) => ({
   ...registryModule,
 }))
 registryModule.loadRegistry.mockImplementation(() => Promise.resolve(REGISTRY))
+
+// Most flow tests pin a region. These two hold the boot probe open so its
+// completion can be ordered deterministically against a manual choice or
+// route disposal.
+const regionProbe = vi.hoisted(() => ({
+  pending: null as Promise<{ region: 'global' | 'china'; probed: boolean }> | null,
+}))
+vi.mock('../src/region-probe.ts', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/region-probe.ts')>()
+  return {
+    ...original,
+    resolveRegion: (configured?: 'global' | 'china') => configured === undefined && regionProbe.pending !== null
+      ? regionProbe.pending
+      : original.resolveRegion(configured),
+  }
+})
 
 // ---------------------------------------------------------------- testbed
 import { marketVersion, mountMarketRoutes } from '../src/routes.ts'
@@ -551,6 +582,10 @@ beforeEach(() => {
   hot.groups = {}
   hot.groupOrder = []
   hot.channel = undefined
+  hot.region = undefined
+  hot.regionAuto = undefined
+  hot.notes = {}
+  regionProbe.pending = null
   hot.failNext = false
   bed = createTestbed()
 })
@@ -3578,6 +3613,42 @@ describe('self-uninstall — the market removing itself from its settings card',
 })
 
 describe('download region', () => {
+  it('does not let a late automatic probe replace a manual region choice', async () => {
+    let finishProbe!: (value: { region: 'china'; probed: true }) => void
+    regionProbe.pending = new Promise(resolve => { finishProbe = resolve })
+    bed.dispose()
+    bed = createTestbed({ region: undefined })
+
+    expect((await bed.dispatch('POST', '/dsh-market/region', { region: 'global' })).status).toBe(200)
+    finishProbe({ region: 'china', probed: true })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect((await bed.dispatch('GET', '/dsh-market/status')).json.region).toBe('global')
+    expect(hot.region).toBe('global')
+    expect(hot.regionAuto).toBeUndefined()
+  })
+
+  it('does not let a disposed mount apply its late automatic probe', async () => {
+    let finishProbe!: (value: { region: 'china'; probed: true }) => void
+    regionProbe.pending = new Promise(resolve => { finishProbe = resolve })
+    bed.dispose()
+    const staleMount = createTestbed({ region: undefined })
+    staleMount.dispose()
+
+    bed = createTestbed({ region: 'global' })
+    expect((await bed.dispatch('POST', '/dsh-market/region', { region: 'global' })).status).toBe(200)
+    expect((await bed.dispatch('POST', '/dsh-market/note', {
+      name: 'dsh-loop', text: 'new mount owns this note',
+    })).status).toBe(200)
+    finishProbe({ region: 'china', probed: true })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(hot.notes).toEqual({ 'dsh-loop': 'new mount owns this note' })
+    expect((await bed.dispatch('GET', '/dsh-market/status')).json.region).toBe('global')
+    expect(hot.region).toBe('global')
+    expect(hot.regionAuto).toBeUndefined()
+  })
+
   it('rejects anything but the two regions', async () => {
     expect((await bed.dispatch('POST', '/dsh-market/region', { region: 'CN' })).status).toBe(400)
     expect((await bed.dispatch('POST', '/dsh-market/region', {})).status).toBe(400)

--- a/tests/state.spec.ts
+++ b/tests/state.spec.ts
@@ -215,6 +215,27 @@ describe('a partial write must not erase the rest of the state (#435)', () => {
     expect('region' in written).toBe(false)
     rmSync(dir, { recursive: true, force: true })
   })
+
+  it('lets a manual region choice clear the automatic-region marker', () => {
+    const dir = stateDir()
+    try {
+      writeMarketState(dir, {
+        disabled: new Set(), groups: {}, groupOrder: [], region: 'china', regionAuto: true,
+      })
+
+      // The manual-region route spreads the current state, changes region,
+      // and explicitly clears regionAuto before writing.
+      const current = readMarketState(dir)
+      writeMarketState(dir, { ...current, region: 'global', regionAuto: undefined })
+
+      const written = JSON.parse(readFileSync(join(dir, '.dsh-market', 'state.json'), 'utf8')) as Record<string, unknown>
+      expect(written.region).toBe('global')
+      expect('regionAuto' in written).toBe(false)
+      expect(readMarketState(dir).regionAuto).toBeUndefined()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('group CRUD (groups.ts)', () => {

--- a/tests/state.spec.ts
+++ b/tests/state.spec.ts
@@ -223,6 +223,10 @@ describe('a partial write must not erase the rest of the state (#435)', () => {
         disabled: new Set(), groups: {}, groupOrder: [], region: 'china', regionAuto: true,
       })
 
+      // Partial writers still omit the field and must preserve the marker.
+      writeMarketState(dir, { disabled: new Set(['dsh-loop']), groups: {}, groupOrder: [] })
+      expect(readMarketState(dir).regionAuto).toBe(true)
+
       // The manual-region route spreads the current state, changes region,
       // and explicitly clears regionAuto before writing.
       const current = readMarketState(dir)


### PR DESCRIPTION
## Summary

- distinguish an omitted `regionAuto` field from an explicitly cleared one
- preserve the on-disk automatic marker for partial callers, but remove it after a manual region choice
- ignore a boot-time region probe that finishes after the user chooses a region
- prevent a disposed mount's late probe from overwriting its replacement's region or notes

## Why

This is a follow-up to #454. That merge correctly preserves fields omitted by partial state writers, but `regionAuto` has a clear path that channel and region do not: the manual-region route explicitly sets it to `undefined`. Using `state.regionAuto ?? onDisk.regionAuto` restored the previous `true`, so the automatic-region explanation returned after restart.

The same exact-head audit also held the boot probe open across a manual choice and route disposal. Without a mount-local guard, the late callback could switch a manual `global` choice back to `china`; after disposal, it could also write the old mount's captured state over the replacement mount's region and newly saved note.

Property-presence semantics preserve genuine omission while honoring the explicit clear. The probe now exits before any routing or disk mutation when a manual/configured region or disposal has made its result stale.

## Verification

- regression mutation check: the disposed-mount test fails by erasing the replacement note when the disposal guard is removed
- focused state + flow suites: 167 passed
- full suite on Node 22.22.2 and Node 24.19.0: 55 files, 1,158 passed and 1 skipped on each
- `npm run check`, preflight, registry validation, pnpm compatibility 11/11, authenticated-browser capture guard, and `git diff --check` passed
- independent exact-diff review found no blocking or material issue