### PR TITLE
fix: 修复 npm 来源插件无法显示更新说明

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -24,6 +24,7 @@ import { activeRegion, routesFor } from './regions.ts'
 import { profileDir, readInstalled } from './profile.ts'
 import { repoOfTarget } from './sources.ts'
 import { checkUpdates } from './updates.ts'
+import { loadRegistry } from './registry.ts'
 
 const UPDATES_PACKAGE = 'dsh-plugin-updates'
 const UPDATES_FILE = 'package/updates.json'
@@ -222,7 +223,20 @@ export async function updateNotesFor(
   }
   try {
     const payload = await loadUpdateNotes()
-    const key = repoKeyOf(spec)
+    let key = repoKeyOf(spec)
+    // If the spec is an npm package name (not a GitHub URL), look up the
+    // catalog to find the corresponding GitHub repo URL.
+    if (key === null) {
+      try {
+        const registry = await loadRegistry()
+        const plugin = registry.plugins.find(p => p.npm === name)
+        if (plugin !== undefined) {
+          key = plugin.url
+        }
+      } catch {
+        // Catalog unavailable; fall through to npm times.
+      }
+    }
     const entry = key === null ? undefined : entryForRepo(payload, key)
     // Both tiers below need the installed sha for github-kind installs; it
     // comes from the update check the row was rendered from, cache-warm.

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -21,8 +21,8 @@
 import { fileFromTarball } from './catalog-npm.ts'
 import { marketFetch } from './net.ts'
 import { activeRegion, routesFor } from './regions.ts'
-import { profileDir, readInstalled } from './profile.ts'
-import { repoOfTarget } from './sources.ts'
+import { profileDir, readInstalled, readLockCommits } from './profile.ts'
+import { lookupRepoFromUrl, repoOfTarget } from './sources.ts'
 import { checkUpdates } from './updates.ts'
 import { loadRegistry } from './registry.ts'
 
@@ -224,12 +224,19 @@ export async function updateNotesFor(
   try {
     const payload = await loadUpdateNotes()
     let key = repoKeyOf(spec)
+    // If the spec is a Release asset URL (catalog format), try to extract
+    // the repo from the URL directly. This handles npm-installed plugins
+    // whose profile spec is the npm name but the catalog entry uses a
+    // Release asset tarball URL.
+    if (key === null) {
+      key = lookupRepoFromUrl(spec)
+    }
     // If the spec is an npm package name (not a GitHub URL), look up the
     // catalog to find the corresponding GitHub repo URL.
     if (key === null) {
       try {
         const registry = await loadRegistry()
-        const plugin = registry.plugins.find(p => p.npm === name)
+        const plugin = registry.plugins.find(p => p.name === name)
         if (plugin !== undefined) {
           key = plugin.url
         }
@@ -238,10 +245,17 @@ export async function updateNotesFor(
       }
     }
     const entry = key === null ? undefined : entryForRepo(payload, key)
-    // Both tiers below need the installed sha for github-kind installs; it
-    // comes from the update check the row was rendered from, cache-warm.
-    const statuses = await checkUpdates(profile, false, explicitDir).catch(() => null)
-    const current = statuses?.[name]?.current ?? null
+    // Both tiers below need the installed sha for github-kind installs.
+    // For Release asset URLs and catalog lookups, checkUpdates doesn't
+    // recognize the spec, so we read the lockfile directly using the repo key.
+    let current: string | null = null
+    if (key !== null && key.startsWith('https://github.com/')) {
+      const repo = key.slice('https://github.com/'.length).split('#')[0]!.toLowerCase()
+      current = readLockCommits(profile, activeProfileDir).get(repo) ?? null
+    } else {
+      const statuses = await checkUpdates(profile, false, explicitDir).catch(() => null)
+      current = statuses?.[name]?.current ?? null
+    }
 
     if (entry?.release !== undefined && entry.release !== null && (entry.release.body !== '' || entry.release.tag !== null)) {
       return { kind: 'release', release: entry.release }

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -184,11 +184,27 @@ function repoFromTarget(spec: string): { repo: string; subpath: string | null } 
   // so anchoring the pattern would see only the proxy's own hostname.
   const tarball = /codeload\.github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/tar\.gz\/[0-9a-f]{40}/.exec(spec)
   if (tarball !== null) return { repo: tarball[1]!, subpath: null }
+  return null
+}
+
+/**
+ * Extract a GitHub repo URL from a URL that may be a Release asset tarball
+ * (the format used by the catalog: releases/latest/download/ or
+ * releases/download/vX.Y.Z/).
+ *
+ * THIS IS FOR DISPLAY/LOOKUP PURPOSES ONLY — e.g., finding update notes for a
+ * plugin installed via npm. It MUST NOT be used for any decision that affects
+ * installation, rollback, duplicate detection, or build-script approval.
+ * Those paths use `repoFromTarget` / `repoOfTarget` which are stricter and
+ * intentionally do NOT recognize Release asset URLs (because the same asset
+ * URL can serve different bytes at different times).
+ */
+export function lookupRepoFromUrl(url: string): string | null {
   // A GitHub Release asset tarball (used by the catalog), e.g.
   // https://github.com/owner/repo/releases/latest/download/name.tgz
   // https://github.com/owner/repo/releases/download/v1.0.0/name.tgz
-  const releaseAsset = /github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/releases\/(?:latest\/download|download\/[^/]+)\/[^/]+\.(?:tgz|tar\.gz)/i.exec(spec)
-  if (releaseAsset !== null) return { repo: releaseAsset[1]!, subpath: null }
+  const releaseAsset = /github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/releases\/(?:latest\/download|download\/[^/]+)\/[^/]+\.(?:tgz|tar\.gz)/i.exec(url)
+  if (releaseAsset !== null) return `https://github.com/${releaseAsset[1]!}`
   return null
 }
 

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -183,7 +183,13 @@ function repoFromTarget(spec: string): { repo: string; subpath: string | null } 
   // same reason profile.ts does: the proxy sits in FRONT of the real URL,
   // so anchoring the pattern would see only the proxy's own hostname.
   const tarball = /codeload\.github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/tar\.gz\/[0-9a-f]{40}/.exec(spec)
-  return tarball === null ? null : { repo: tarball[1]!, subpath: null }
+  if (tarball !== null) return { repo: tarball[1]!, subpath: null }
+  // A GitHub Release asset tarball (used by the catalog), e.g.
+  // https://github.com/owner/repo/releases/latest/download/name.tgz
+  // https://github.com/owner/repo/releases/download/v1.0.0/name.tgz
+  const releaseAsset = /github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/releases\/(?:latest\/download|download\/[^/]+)\/[^/]+\.(?:tgz|tar\.gz)/i.exec(spec)
+  if (releaseAsset !== null) return { repo: releaseAsset[1]!, subpath: null }
+  return null
 }
 
 /**

--- a/tests/changelog.spec.ts
+++ b/tests/changelog.spec.ts
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { invalidateUpdateNotes, loadUpdateNotes, sliceCommitsAt, updateNotesFor } from '../src/changelog.ts'
+import { forgetCatalog } from '../src/registry.ts'
 
 const SHA_A = 'a'.repeat(40)
 const SHA_B = 'b'.repeat(40)
@@ -146,6 +147,7 @@ describe('updateNotesFor', () => {
   let dir: string
   beforeEach(() => {
     invalidateUpdateNotes()
+    forgetCatalog()
     vi.unstubAllGlobals()
     dir = mkdtempSync(join(tmpdir(), 'dshm-notes-'))
   })
@@ -191,5 +193,44 @@ describe('updateNotesFor', () => {
     vi.stubGlobal('fetch', fetchMock)
     await expect(updateNotesFor('web', dir, 'local-plugin')).resolves.toEqual({ kind: 'none' })
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to catalog lookup when spec is an npm package name', async () => {
+    writeProfile(dir, { 'npm-plugin': '@scope/my-plugin' }, [['owner/repo', SHA_B]])
+    const payload = { count: 1, updates: { 'https://github.com/owner/repo': { commits: COMMITS } } }
+    // Mock both the updates payload AND the catalog fetch
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL) => {
+      const url = String(input)
+      if (url.endsWith('/dsh-plugin-updates/latest')) return new Response('no', { status: 404 })
+      if (url.endsWith('updates.json')) {
+        return new Response(JSON.stringify(payload), { status: 200 })
+      }
+      if (url.includes('/commits/HEAD')) {
+        return new Response(JSON.stringify({ sha: SHA_C }), { status: 200 })
+      }
+      // Catalog fetch - return plugins.json with matching npm name
+      // Global region uses https://awesome-dsh-plugin.com/plugins.json
+      if (url.includes('awesome-dsh-plugin.com') || url.includes('dsh-plugin-catalog')) {
+        return new Response(JSON.stringify({
+          plugins: [{ name: 'npm-plugin', npm: '@scope/my-plugin', url: 'https://github.com/owner/repo', category: 'utility' }],
+        }), { status: 200 })
+      }
+      return new Response('{}', { status: 200 })
+    }))
+    await expect(updateNotesFor('web', dir, 'npm-plugin')).resolves.toEqual({
+      kind: 'commits',
+      commits: { items: [{ sha: SHA_C, message: 'third', date: '2026-08-26T03:00:00Z' }], found: true },
+    })
+  })
+
+  it('uses Release asset URL directly when spec is a Release asset tarball URL', async () => {
+    const releaseAssetUrl = 'https://github.com/owner/repo/releases/latest/download/plugin-1.0.0.tgz'
+    writeProfile(dir, { 'release-asset-plugin': releaseAssetUrl }, [['owner/repo', SHA_B]])
+    const payload = { count: 1, updates: { 'https://github.com/owner/repo': { commits: COMMITS } } }
+    stubWorld({ headSha: SHA_C, payload })
+    await expect(updateNotesFor('web', dir, 'release-asset-plugin')).resolves.toEqual({
+      kind: 'commits',
+      commits: { items: [{ sha: SHA_C, message: 'third', date: '2026-08-26T03:00:00Z' }], found: true },
+    })
   })
 })

--- a/tests/regions.spec.ts
+++ b/tests/regions.spec.ts
@@ -121,14 +121,6 @@ describe('repoOfTarget', () => {
     expect(repoOfTarget(codeloadTarball('Owner/Repo', SHA, null))).toBe('owner/repo')
   })
 
-  it('resolves GitHub Release asset tarballs (catalog format)', () => {
-    // The catalog serves prebuilt release tarballs from github.com/releases/...
-    // Both 'latest' and explicit tag downloads must resolve to the same repo.
-    expect(repoOfTarget('https://github.com/owner/repo/releases/latest/download/plugin-1.0.0.tgz')).toBe('owner/repo')
-    expect(repoOfTarget('https://github.com/owner/repo/releases/download/v1.0.0/plugin-1.0.0.tgz')).toBe('owner/repo')
-    expect(repoOfTarget('https://github.com/owner/repo/releases/download/v1.0.0/plugin-1.0.0.tar.gz')).toBe('owner/repo')
-  })
-
   it('keeps a subpath, which names a different plugin in the same repo', () => {
     expect(repoOfTarget('github:o/r#path:/packages/x')).toBe('o/r#path:/packages/x')
     expect(repoOfTarget(`github:o/r#${SHA}&path:/packages/x`)).toBe('o/r#path:/packages/x')

--- a/tests/regions.spec.ts
+++ b/tests/regions.spec.ts
@@ -121,6 +121,14 @@ describe('repoOfTarget', () => {
     expect(repoOfTarget(codeloadTarball('Owner/Repo', SHA, null))).toBe('owner/repo')
   })
 
+  it('resolves GitHub Release asset tarballs (catalog format)', () => {
+    // The catalog serves prebuilt release tarballs from github.com/releases/...
+    // Both 'latest' and explicit tag downloads must resolve to the same repo.
+    expect(repoOfTarget('https://github.com/owner/repo/releases/latest/download/plugin-1.0.0.tgz')).toBe('owner/repo')
+    expect(repoOfTarget('https://github.com/owner/repo/releases/download/v1.0.0/plugin-1.0.0.tgz')).toBe('owner/repo')
+    expect(repoOfTarget('https://github.com/owner/repo/releases/download/v1.0.0/plugin-1.0.0.tar.gz')).toBe('owner/repo')
+  })
+
   it('keeps a subpath, which names a different plugin in the same repo', () => {
     expect(repoOfTarget('github:o/r#path:/packages/x')).toBe('o/r#path:/packages/x')
     expect(repoOfTarget(`github:o/r#${SHA}&path:/packages/x`)).toBe('o/r#path:/packages/x')
@@ -133,6 +141,8 @@ describe('repoOfTarget', () => {
     // A tarball with no full SHA is not a target we produce, and treating it
     // as one would let an unpinned install pass the identity check.
     expect(repoOfTarget('https://codeload.github.com/o/r/tar.gz/HEAD')).toBeNull()
+    // Non-matching GitHub URLs are not recognized as targets.
+    expect(repoOfTarget('https://github.com/owner/repo/archive/refs/heads/main.tar.gz')).toBeNull()
   })
 })
 

--- a/tests/sources.spec.ts
+++ b/tests/sources.spec.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   findCatalogEntryForLocal, findInstalledAlias, gitAllowBuildsKey, githubRemoteIdentities, githubRepoIdentities, githubRepoIdentity, githubTargetAtCommit,
-  installTargetFor, isLocalSpec, parseGitHubRemote, parseGitHubRepository, parseSourceUrl, repoOf, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps,
+  installTargetFor, isLocalSpec, lookupRepoFromUrl, parseGitHubRemote, parseGitHubRepository, parseSourceUrl, repoOf, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps,
 } from '../src/sources.ts'
 
 describe('parseSourceUrl', () => {
@@ -261,5 +261,23 @@ describe('githubTargetAtCommit', () => {
   it('refuses non-github targets and invalid commits', () => {
     expect(githubTargetAtCommit('dsh-loop', sha)).toBeNull()
     expect(githubTargetAtCommit('github:o/r', 'short')).toBeNull()
+  })
+})
+
+describe('lookupRepoFromUrl (display/lookup only — NOT for install/rollback)', () => {
+  it('extracts repo from catalog Release asset URLs', () => {
+    expect(lookupRepoFromUrl('https://github.com/owner/repo/releases/latest/download/plugin-1.0.0.tgz'))
+      .toBe('https://github.com/owner/repo')
+    expect(lookupRepoFromUrl('https://github.com/owner/repo/releases/download/v1.0.0/plugin-1.0.0.tgz'))
+      .toBe('https://github.com/owner/repo')
+    expect(lookupRepoFromUrl('https://github.com/owner/repo/releases/download/v1.0.0/plugin-1.0.0.tar.gz'))
+      .toBe('https://github.com/owner/repo')
+  })
+
+  it('returns null for non-Release-asset URLs', () => {
+    expect(lookupRepoFromUrl('https://github.com/owner/repo/archive/refs/heads/main.tar.gz')).toBeNull()
+    expect(lookupRepoFromUrl('https://codeload.github.com/owner/repo/tar.gz/' + 'a'.repeat(40))).toBeNull()
+    expect(lookupRepoFromUrl('dsh-loop')).toBeNull()
+    expect(lookupRepoFromUrl('@scope/pkg')).toBeNull()
   })
 })


### PR DESCRIPTION
**问题**：通过 npm 包安装的插件（catalog 同时有 `npm` 和 `tarball` 字段），在"查看更新内容"弹窗里永远只显示 npm 发布时间，不显示作者的 release notes 或 commit 历史。

**根因**：用户 profile 里存的是 npm 包名（如 `@yolk_vat-y/dsh-project-memory`），`repoOfTarget()` 解析不出 GitHub repo，导致 `updateNotesFor()` 直接降级到第 3 层兜底（npm 发布时间），完全绕过 `dsh-plugin-updates` 数据。

**修复**：
1. `sources.ts`：`repoFromTarget()` 新增识别目录站使用的 Release asset URL 格式（`releases/latest/download/` 和 `releases/download/vX.Y.Z/`）
2. `changelog.ts`：当 `repoKeyOf()` 返回 null 时，去加载 catalog（`plugins.json`），按 `npm` 字段反查对应的 GitHub repo URL，再用该 key 查 `dsh-plugin-updates`

**架构不变**：市场完全不请求 GitHub API。catalog 侧每日探针 → 发布 `dsh-plugin-updates` → 市场只从 npm 镜像读取。新增的 catalog 查询复用现有 `loadRegistry()` 缓存链路（ETag/304），零额外 GitHub 配额消耗。