### PR TITLE
docs: describe what gh-proxy actually accepts, measured

### DIFF
--- a/src/regions.ts
+++ b/src/regions.ts
@@ -43,10 +43,25 @@ const NPM_CHINA = 'https://mirrors.cloud.tencent.com/npm'
 /**
  * Prefix proxy for github.com-family URLs, no trailing slash.
  *
- * Verified against gh-proxy: it serves the GitHub API and commit-pinned
- * codeload tarballs, and it refuses anything that is not a github.com
- * hostname — which is why the catalog cannot be carried through it at all,
- * and travels as a published npm package instead.
+ * It serves the GitHub API and commit-pinned codeload tarballs. The catalog
+ * still does not travel through it — it goes as a published npm package
+ * instead, which additionally gives it a version number that can be rolled
+ * back when a bad build ships.
+ *
+ * What this proxy accepts is a list of GitHub SERVICES, not a hostname test.
+ * The previous note here said it "refuses anything that is not a github.com
+ * hostname", which #460 by @Homplex measured as wrong in both directions —
+ * re-measured 2026-09-01:
+ *
+ *   https://raw.githubusercontent.com/…   200   ← not a github.com hostname
+ *   https://github.com/owner/repo         403   ← is one
+ *   https://example.com/                  403
+ *
+ * So a plain repository page is refused while raw content is served. Do not
+ * reason about this proxy from the hostname; check the specific service, and
+ * re-measure rather than infer, because the policy is the operator's and can
+ * change under us. That fragility is the substance of #460's actual request
+ * (a mirror list and a visible setting), which is tracked separately.
  */
 const GITHUB_PROXY_CHINA = 'https://gh-proxy.com'
 


### PR DESCRIPTION
Comment-only. From #460 by @Homplex, whose point 3 I re-measured today — they are right, and the note was wrong in **both** directions:

```
https://gh-proxy.com/https://raw.githubusercontent.com/…   200   ← not a github.com hostname
https://gh-proxy.com/https://github.com/owner/repo         403   ← is one
https://gh-proxy.com/https://example.com/                  403
```

The note claimed the proxy "refuses anything that is not a github.com hostname". Raw content is not a github.com hostname and is served; a plain repository page is one and is refused. What it actually gates on is the GitHub **service**, not the host.

A wrong mental model here is worse than no comment: the next person routing something through this proxy would reason from the hostname and be surprised in whichever direction they happened to test first. The note now states the measurements, says to check the specific service rather than infer, and records that the policy belongs to an operator who can change it without telling us — which is the fragility #460 is actually about.

No behaviour change. The rest of #460 (a mirror list with fallback, and a visible setting instead of `DSHM_GITHUB_PROXY` only) is a real request and is tracked separately — it needs a design decision about probing and ordering, not a comment fix.