### PR TITLE
fix: a plugin installed from a branch stays on that branch

### DIFF
--- a/src/accelerate.ts
+++ b/src/accelerate.ts
@@ -72,11 +72,20 @@ const RESOLVE_TIMEOUT_MS = 6000
  * `<sha> HEAD\0<capabilities>`. Read with a pattern rather than a parser:
  * one 40-character hex string followed by `HEAD` is unambiguous in this
  * payload, and a length-prefix reader would be more code to get wrong.
+ *
+ * The same advertisement lists every branch and tag, which is what `ref`
+ * uses. A plugin installed from `github:owner/repo#publish` is not asking
+ * about the default branch at all, and answering with it made the market
+ * report an update forever (#446) — the two SHAs simply never match. Both
+ * namespaces are searched because pnpm accepts a tag there too, branches
+ * first since that is what the reports are about.
+ * @param ref - branch or tag to resolve, or undefined for the default branch.
  */
 export async function headCommit(
   repo: string,
   proxy: string | null,
   signal?: AbortSignal,
+  ref?: string,
 ): Promise<string | null> {
   const base = `https://github.com/${repo}/info/refs?service=git-upload-pack`
   try {
@@ -85,8 +94,20 @@ export async function headCommit(
       headers: { 'user-agent': 'git/2.40.0' },
     })
     if (!res.ok) return null
-    const found = /([0-9a-f]{40}) HEAD/.exec(await res.text())
-    return found === null ? null : found[1]!
+    const body = await res.text()
+    if (ref === undefined) {
+      const found = /([0-9a-f]{40}) HEAD/.exec(body)
+      return found === null ? null : found[1]!
+    }
+    // Anchored to the ref's full name so `publish` cannot match a branch
+    // called `publish-old`, and escaped because a ref may contain regex
+    // metacharacters (`.` is legal in a branch name).
+    const quoted = ref.replace(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`)
+    for (const namespace of ['heads', 'tags']) {
+      const found = new RegExp(String.raw`([0-9a-f]{40}) refs/${namespace}/${quoted}(?![^\s])`, 'u').exec(body)
+      if (found !== null) return found[1]!
+    }
+    return null
   } catch {
     return null
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -138,18 +138,42 @@ export function marketVersion(): string {
 const SELF_NAMES = new Set(['dshmarket', 'dsh-market'])
 
 /**
- * Rebuild a GitHub target for an update: revision selectors are deliberately
- * dropped so pnpm resolves the repository again, while one valid `path:`
- * selector is kept because it identifies the package inside a monorepo.
- * pnpm permits both in one fragment (`#main&path:/packages/plugin`).
+ * Rebuild a GitHub target for an update.
+ *
+ * A commit pin is dropped so pnpm resolves the repository again — that is the
+ * whole point of asking for an update. One valid `path:` selector is kept
+ * because it identifies the package inside a monorepo; pnpm permits both in
+ * one fragment (`#main&path:/packages/plugin`).
+ *
+ * A BRANCH or tag is kept, which used to be the same case as a commit and
+ * was not (#446 by @Dave-12138). `github:owner/repo#publish` names the line
+ * of development the user installed from; dropping it silently moved them to
+ * the default branch on the next update — a source change wearing the word
+ * "update". A 40-character hex selector is a pin worth discarding, and
+ * anything else is a choice worth preserving. A short hex string stays too:
+ * it is indistinguishable from a branch named `abc1234`, and keeping a pin
+ * by mistake only means the update is a no-op, while dropping a branch by
+ * mistake reinstalls different code.
  */
 function githubUpdateTarget(spec: string): string {
   const fragmentAt = spec.indexOf('#')
   if (fragmentAt === -1) return spec
   const repo = spec.slice(0, fragmentAt)
   let subpath: string | null = null
+  let ref: string | null = null
   for (const selector of spec.slice(fragmentAt + 1).split('&')) {
-    if (!selector.startsWith('path:/')) continue
+    if (!selector.startsWith('path:/')) {
+      // `semver:<range>` selects a release line, so it is preserved for the
+      // same reason a branch is.
+      const isCommitPin = /^[0-9a-f]{40}$/i.test(selector)
+      if (selector !== '' && !isCommitPin) {
+        // Two refs in one fragment is not a shape pnpm produces; refuse to
+        // guess which one the user meant and fall back to the bare repo.
+        if (ref !== null) return repo
+        ref = selector
+      }
+      continue
+    }
     const candidate = selector.slice('path:/'.length)
     const valid = /^[A-Za-z0-9_./-]+$/.test(candidate)
       && !candidate.split('/').some(segment => segment === '' || segment === '.' || segment === '..')
@@ -158,8 +182,10 @@ function githubUpdateTarget(spec: string): string {
     if (subpath !== null || !valid) return repo
     subpath = candidate
   }
-  return subpath === null ? repo : `${repo}#path:/${subpath}`
+  const selectors = [...(ref === null ? [] : [ref]), ...(subpath === null ? [] : [`path:/${subpath}`])]
+  return selectors.length === 0 ? repo : `${repo}#${selectors.join('&')}`
 }
+
 
 /**
  * Whether an installed package declares a client part (`dsh.client`). Its UI

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -201,6 +201,27 @@ export function repoOfTarget(spec: string): string | null {
 }
 
 /**
+ * The branch or tag a GitHub spec selects, or null for the default branch.
+ *
+ * Update detection has to ask about the same ref the install used, or it
+ * compares the installed commit against a line the user never chose (#446).
+ * A commit pin yields null: the answer for a pinned install is the default
+ * branch, which is what "is there something newer" means there.
+ */
+export function githubRefOfTarget(spec: string): string | null {
+  if (!spec.startsWith('github:')) return null
+  const fragmentAt = spec.indexOf('#')
+  if (fragmentAt === -1) return null
+  for (const selector of spec.slice(fragmentAt + 1).split('&')) {
+    if (selector === '' || selector.startsWith('path:/')) continue
+    if (/^[0-9a-f]{40}$/i.test(selector)) continue
+    if (selector.startsWith('semver:')) continue
+    return selector
+  }
+  return null
+}
+
+/**
  * An immutable GitHub commit already carried by an install target.
  *
  * Build-script approval on pnpm below 11.21 needs the exact commit-pinned

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -9,7 +9,7 @@ import { headCommit } from './accelerate.ts'
 import { marketFetch } from './net.ts'
 import { activeRegion, routesFor } from './regions.ts'
 import { profileDir, readInstalled, readInstalledVersion, readLockCommits } from './profile.ts'
-import { githubCommitOfTarget, repoOfTarget } from './sources.ts'
+import { githubCommitOfTarget, githubRefOfTarget, repoOfTarget } from './sources.ts'
 
 export interface UpdateStatus {
   kind: 'github' | 'npm' | 'linked'
@@ -310,7 +310,12 @@ export async function checkUpdates(
         // stops reporting updates (#349). The ref endpoint git itself uses
         // has no such quota; this is the same call `acceleratedTarget`
         // already makes to resolve a commit for the China region.
-        const latest = await headCommit(repo, routesFor(activeRegion()).githubProxy)
+        // Ask about the ref the install actually names. Answering with the
+        // default branch for a `#branch` install compares two lines that
+        // never converge, so the row reported an update forever (#446).
+        const latest = await headCommit(
+          repo, routesFor(activeRegion()).githubProxy, undefined, githubRefOfTarget(spec) ?? undefined,
+        )
         result[name] = {
           kind: 'github', version, current, latest,
           updateAvailable: current !== null && latest !== null && current !== latest,

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -1483,18 +1483,50 @@ describe('update flow — no npm publishing required', () => {
     expect(fake.calls.at(-1)).toContain(target)
     expect(installedSpec('plug-a')).toBe(target)
 
-    // A ref and path may share pnpm's fragment. Updating still discards the
-    // ref (so HEAD is re-resolved) but must not discard the package subpath.
+    // A ref and path may share pnpm's fragment. A COMMIT PIN is what an
+    // update discards, so the repository is resolved again rather than the
+    // pin reinstalled — but the package subpath must survive.
     const manifestPath = join(profileDir('web'), 'package.json')
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
-    manifest.dependencies['plug-a'] = 'github:m/mono#release-1&path:/packages/plug-a'
+    const pin = 'c'.repeat(40)
+    manifest.dependencies['plug-a'] = `github:m/mono#${pin}&path:/packages/plug-a`
     writeFileSync(manifestPath, JSON.stringify(manifest))
 
     const refreshed = await bed.dispatch('POST', '/dsh-market/update', { name: 'plug-a' })
     expect(refreshed.status).toBe(200)
     expect(fake.calls.at(-1)).toContain(target)
-    expect(fake.calls.at(-1)).not.toContain('release-1')
+    expect(fake.calls.at(-1)).not.toContain(pin)
     expect(installedSpec('plug-a')).toBe(target)
+  })
+
+  it('keeps the branch an update was installed from, alongside the subpath (#446)', async () => {
+    // #281 dropped every revision selector, which was right for a pin and
+    // wrong for a branch: `github:owner/repo#publish` names the line of
+    // development the user chose, and discarding it moved them to the
+    // default branch under the word "update" — a source change, not an
+    // update. The pin case above still drops.
+    const target = 'github:m/mono#publish&path:/packages/plug-b'
+    fake.repos[target] = {
+      name: 'plug-b', manifest: { dsh: {}, main: 'index.js' }, artifacts: ['index.js'],
+    }
+    fake.repos['github:m/mono#path:/packages/plug-b'] = {
+      name: 'plug-b', manifest: { dsh: {}, main: 'index.js' }, artifacts: ['index.js'],
+    }
+    const installed = await bed.dispatch('POST', '/dsh-market/install', {
+      url: 'https://github.com/m/mono/tree/main/packages/plug-b',
+    })
+    expect(installed.status).toBe(200)
+
+    const manifestPath = join(profileDir('web'), 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    manifest.dependencies['plug-b'] = target
+    writeFileSync(manifestPath, JSON.stringify(manifest))
+
+    const refreshed = await bed.dispatch('POST', '/dsh-market/update', { name: 'plug-b' })
+    expect(refreshed.status).toBe(200)
+    // The whole target, not a substring: fake.calls entries are argv arrays,
+    // so an exact element is what proves both selectors survived together.
+    expect(fake.calls.at(-1)).toContain(target)
   })
 
   it('does not offer a rollback that the real CLI cannot execute for a github subpath', async () => {

--- a/tests/sources.spec.ts
+++ b/tests/sources.spec.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  githubRefOfTarget,
   findCatalogEntryForLocal, findInstalledAlias, gitAllowBuildsKey, githubRemoteIdentities, githubRepoIdentities, githubRepoIdentity, githubTargetAtCommit,
   installTargetFor, isLocalSpec, parseGitHubRemote, parseGitHubRepository, parseSourceUrl, repoOf, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps,
 } from '../src/sources.ts'
@@ -131,6 +132,31 @@ describe('gitAllowBuildsKey (#68/#69)', () => {
     expect(gitAllowBuildsKey('dsh-loop', '^1.2.0')).toBeNull()
     expect(gitAllowBuildsKey('dsh-loop', 'link:../dev')).toBeNull()
     expect(gitAllowBuildsKey('dsh-loop', '')).toBeNull()
+  })
+})
+
+describe('githubRefOfTarget (#446)', () => {
+  it('reads the branch or tag an install actually names', () => {
+    expect(githubRefOfTarget('github:o/r#publish')).toBe('publish')
+    expect(githubRefOfTarget('github:o/r#v2.1.0')).toBe('v2.1.0')
+    // pnpm allows a ref and a subpath in one fragment.
+    expect(githubRefOfTarget('github:o/r#publish&path:/packages/p')).toBe('publish')
+    expect(githubRefOfTarget('github:o/r#path:/packages/p&publish')).toBe('publish')
+  })
+
+  it('answers null where the default branch is the right question', () => {
+    expect(githubRefOfTarget('github:o/r')).toBeNull()
+    expect(githubRefOfTarget('github:o/r#path:/packages/p')).toBeNull()
+    // A pin: "is there something newer" means the default branch, and
+    // resolving the pin as a ref would compare a commit against itself.
+    expect(githubRefOfTarget(`github:o/r#${'a'.repeat(40)}`)).toBeNull()
+    // A semver range selects a release line the ref advertisement cannot
+    // answer; treating it as a branch name would look up a ref that is not
+    // there and report no update at all.
+    expect(githubRefOfTarget('github:o/r#semver:^1.2.0')).toBeNull()
+    // Not a github spec.
+    expect(githubRefOfTarget('dsh-loop@1.0.0')).toBeNull()
+    expect(githubRefOfTarget('https://example.test/x.tgz')).toBeNull()
   })
 })
 


### PR DESCRIPTION
Closes #446. Both halves of @Dave-12138's report check out, and the second is worse than they described.

## 1. Detection compared against a line the user never chose

`checkUpdates` stripped the fragment and asked for the **default branch**:

```ts
const repo = repoOfTarget(spec)?.split('#')[0] ?? null   // "Dave-12138/dsh-file"
const latest = await headCommit(repo, …)                 // master's HEAD
```

So a plugin tracking `publish` had its commit measured against `master`. Those never converge — hence an update badge that never goes away. Verified against their actual repository:

```
default branch  5aece615d576803fb689db75bf84beea5fcfd56b
refs/heads/publish  70f8650f0c83d47edc0ecc6587fb471b1bd5ba36
```

## 2. The update **action** dropped the branch

`githubUpdateTarget` discarded every selector that was not `path:`, so pressing update reinstalled `github:Dave-12138/dsh-file` — the default branch. **A source change wearing the word "update"**, with nothing saying so. This is the part worth fixing even more than the badge.

## The shared cause

Both treat everything after `#` as a pin to discard. A commit pin is one; a **branch or tag is a choice of which line of development to follow**.

- 40-char hex → still dropped. That is what makes an update re-resolve instead of reinstalling the same commit.
- anything else → kept.
- a **short** hex string is kept too: it cannot be distinguished from a branch named `abc1234`, and the asymmetry decides it — keeping a pin by mistake makes the update a no-op, dropping a branch by mistake installs different code.

`headCommit` now takes an optional ref and reads it from the advertisement it **already fetches** (which lists every branch and tag beside HEAD), so this costs no extra request and stays off the REST API's 60/hour quota. The ref is anchored and regex-escaped: `publish` must not match `publish-old`, and `.` is legal in a ref name.

## This changes a case #281 asserted — deliberately

That issue was about a monorepo **subpath** being dropped. Its test happened to use `release-1` — a branch — as the discarded "revision selector", and the commit message states the goal as *"so HEAD is re-resolved"*. Re-resolving **the branch the user chose** serves that goal better than re-resolving a different branch. The pin case #281 actually cared about still drops, and its test now uses a real 40-char sha instead of a branch name.

## Verification

- Confirmed the new regression is red without the fix: `expected [ 'add', …(1) ] to include 'github:m/mono#publish&path:/packages/…'`
- Unit tests for `githubRefOfTarget` cover branch, tag, ref+subpath in either order, bare repo, subpath-only, 40-char pin, `semver:` range, and non-github specs.
- Live check against the reporter's repository resolves `publish` and returns null for a ref that does not exist.
- `npm test` 1172 passed; `npm run check` passed.
