### PR TITLE
fix: stop the copy button and the plugin count from shifting the page

### DIFF
--- a/site/index.en.html
+++ b/site/index.en.html
@@ -29,8 +29,17 @@ header a:hover{color:var(--accent)}
 .hero h1{font-size:clamp(1.9rem,5vw,3.1rem);font-weight:800;letter-spacing:-.02em;line-height:1.15}
 .hero h1 em{font-style:normal;color:var(--accent)}
 .hero p{font-size:1.1rem;color:var(--ink2);margin:1rem auto 0;max-width:36rem}
+/* The plugin count ships at its build-time value and is replaced with the live
+   one by the fetch at the end of this file. Tabular digits keep both the same
+   width, so that swap cannot nudge the sentence around it. */
+#count{font-variant-numeric:tabular-nums}
 .install{display:inline-flex;align-items:center;gap:.8rem;margin-top:2rem;background:var(--ink);color:#e8ecf4;border-radius:12px;padding:.9rem 1.2rem;font-family:ui-monospace,Menlo,monospace;font-size:.95rem}
-.install button{border:none;background:var(--accent);color:#fff;border-radius:8px;padding:.4rem .9rem;font-size:.8rem;cursor:pointer;font-weight:600}
+/* Width is reserved for the longest label this button ever shows. It swaps to
+   "Copied!" on click and back 1.5s later — and that revert lands outside the
+   500ms window CLS forgives after an interaction, so an unreserved button
+   resizes the install box and counts as an unexpected shift. It was the single
+   largest CLS source on this page. */
+.install button{border:none;background:var(--accent);color:#fff;border-radius:8px;padding:.4rem .9rem;font-size:.8rem;cursor:pointer;font-weight:600;min-width:5.5rem}
 .install button:hover{filter:brightness(1.1)}
 .sub{margin-top:.8rem;font-size:.85rem;color:var(--ink3)}
 .sub a{color:var(--accent);text-decoration:none}

--- a/site/index.zh.html
+++ b/site/index.zh.html
@@ -29,8 +29,14 @@ header a:hover{color:var(--accent)}
 .hero h1{font-size:clamp(1.9rem,5vw,3rem);font-weight:800;letter-spacing:-.02em;line-height:1.2}
 .hero h1 em{font-style:normal;color:var(--accent)}
 .hero p{font-size:1.1rem;color:var(--ink2);margin:1rem auto 0;max-width:34rem}
+/* 插件数量先输出构建时的值，再由本文件末尾的 fetch 替换成线上值。等宽数字让两者
+   宽度一致，这次替换就不会挪动它所在的句子。 */
+#count{font-variant-numeric:tabular-nums}
 .install{display:inline-flex;align-items:center;gap:.8rem;margin-top:2rem;background:var(--ink);color:#e8ecf4;border-radius:12px;padding:.9rem 1.2rem;font-family:ui-monospace,Menlo,monospace;font-size:.95rem}
-.install button{border:none;background:var(--accent);color:#fff;border-radius:8px;padding:.4rem .9rem;font-size:.8rem;cursor:pointer;font-weight:600}
+/* 为按钮可能显示的最长文案预留宽度。点击后文案变成「已复制!」，1.5 秒后变回——
+   这个变回发生在点击 500ms 之后，超出了 CLS 对交互的豁免窗口，按钮不预留宽度
+   就会撑动整个 install 盒子，被计为意外布局偏移。它是本页最大的 CLS 来源。 */
+.install button{border:none;background:var(--accent);color:#fff;border-radius:8px;padding:.4rem .9rem;font-size:.8rem;cursor:pointer;font-weight:600;min-width:5.5rem}
 .install button:hover{filter:brightness(1.1)}
 .sub{margin-top:.8rem;font-size:.85rem;color:var(--ink3)}
 .about{margin-top:3.5rem;border-top:1px solid var(--line);padding-top:2.5rem}


### PR DESCRIPTION
29% of visits to this site record a **Poor CLS**. Cloudflare's debug view names `div.install` as the largest contributor by a wide margin — 195 of the top five occurrences, at the maximum score.

## It is the copy button

Clicking it swaps `Copy` for `Copied!` (61px → 76px) and a `setTimeout` puts it back 1500ms later. CLS forgives shifts within 500ms of an interaction; **1500ms is outside that window**, so the revert counts as an unexpected shift every time anyone copies the install command — which is the main call to action on the page.

Measured in a real browser with a `PerformanceObserver`, not inferred: the button resized on both the swap and the revert, and the revert produced a shift attributed to `div.install`, exactly as reported.

Fixed by reserving width for the longest label the button ever shows.

## A second, smaller source

The same measurement turned up one more: the count in the hero ships at its build-time value (2821 at the time) and the fetch at the end of the file replaces it with the live one (2848). Same digit count, but proportional digits are not the same width, so the sentence moved. Tabular figures make the swap free.

## Verification

Against a local build, with the same observer that found them:

| | before | after |
|---|---|---|
| layout-shift entries (click copy + let the count update) | 2 | **0** |
| copy button width through both swaps | 61 → 76 → 61 px | **88 px throughout** |

`npx vitest run` → 55 files, 1172 tests passing.

## Note

The sibling change in `awesome-dsh-plugin` targets a **different element** (`#count`, shipped as `0 / 0`), which was that site's largest source. The two fixes are not copies of each other — I checked this repo's own data before assuming, and the assumption would have been wrong.

Not addressed here, because there is no measurement behind them yet: `#popular` and `html>body>div.wrap` also appear in this site's CLS debug list.