### PR TITLE
test: guard that a failed update stays visible on the card

### DIFF
--- a/site/index.en.html
+++ b/site/index.en.html
@@ -29,8 +29,17 @@ header a:hover{color:var(--accent)}
 .hero h1{font-size:clamp(1.9rem,5vw,3.1rem);font-weight:800;letter-spacing:-.02em;line-height:1.15}
 .hero h1 em{font-style:normal;color:var(--accent)}
 .hero p{font-size:1.1rem;color:var(--ink2);margin:1rem auto 0;max-width:36rem}
+/* The plugin count ships at its build-time value and is replaced with the live
+   one by the fetch at the end of this file. Tabular digits keep both the same
+   width, so that swap cannot nudge the sentence around it. */
+#count{font-variant-numeric:tabular-nums}
 .install{display:inline-flex;align-items:center;gap:.8rem;margin-top:2rem;background:var(--ink);color:#e8ecf4;border-radius:12px;padding:.9rem 1.2rem;font-family:ui-monospace,Menlo,monospace;font-size:.95rem}
-.install button{border:none;background:var(--accent);color:#fff;border-radius:8px;padding:.4rem .9rem;font-size:.8rem;cursor:pointer;font-weight:600}
+/* Width is reserved for the longest label this button ever shows. It swaps to
+   "Copied!" on click and back 1.5s later — and that revert lands outside the
+   500ms window CLS forgives after an interaction, so an unreserved button
+   resizes the install box and counts as an unexpected shift. It was the single
+   largest CLS source on this page. */
+.install button{border:none;background:var(--accent);color:#fff;border-radius:8px;padding:.4rem .9rem;font-size:.8rem;cursor:pointer;font-weight:600;min-width:5.5rem}
 .install button:hover{filter:brightness(1.1)}
 .sub{margin-top:.8rem;font-size:.85rem;color:var(--ink3)}
 .sub a{color:var(--accent);text-decoration:none}

--- a/site/index.zh.html
+++ b/site/index.zh.html
@@ -29,8 +29,14 @@ header a:hover{color:var(--accent)}
 .hero h1{font-size:clamp(1.9rem,5vw,3rem);font-weight:800;letter-spacing:-.02em;line-height:1.2}
 .hero h1 em{font-style:normal;color:var(--accent)}
 .hero p{font-size:1.1rem;color:var(--ink2);margin:1rem auto 0;max-width:34rem}
+/* 插件数量先输出构建时的值，再由本文件末尾的 fetch 替换成线上值。等宽数字让两者
+   宽度一致，这次替换就不会挪动它所在的句子。 */
+#count{font-variant-numeric:tabular-nums}
 .install{display:inline-flex;align-items:center;gap:.8rem;margin-top:2rem;background:var(--ink);color:#e8ecf4;border-radius:12px;padding:.9rem 1.2rem;font-family:ui-monospace,Menlo,monospace;font-size:.95rem}
-.install button{border:none;background:var(--accent);color:#fff;border-radius:8px;padding:.4rem .9rem;font-size:.8rem;cursor:pointer;font-weight:600}
+/* 为按钮可能显示的最长文案预留宽度。点击后文案变成「已复制!」，1.5 秒后变回——
+   这个变回发生在点击 500ms 之后，超出了 CLS 对交互的豁免窗口，按钮不预留宽度
+   就会撑动整个 install 盒子，被计为意外布局偏移。它是本页最大的 CLS 来源。 */
+.install button{border:none;background:var(--accent);color:#fff;border-radius:8px;padding:.4rem .9rem;font-size:.8rem;cursor:pointer;font-weight:600;min-width:5.5rem}
 .install button:hover{filter:brightness(1.1)}
 .sub{margin-top:.8rem;font-size:.85rem;color:var(--ink3)}
 .about{margin-top:3.5rem;border-top:1px solid var(--line);padding-top:2.5rem}

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -797,6 +797,26 @@ describe('MarketSection (jsdom)', () => {
     expect(await screen.findByRole('button', { name: en.updateNow })).toBeTruthy()
   })
 
+  it('shows a failed update instead of leaving the row unchanged (#448)', async () => {
+    // #448: the update failed (pnpm exit 1), the profile was rolled back,
+    // log.ndjson recorded both — and the card said nothing, so the user
+    // pressed update again. Whatever else happens, a failure has to be
+    // visible on the surface the user is looking at.
+    stubFetch({
+      '/dsh-market/installed': { profile: 'web', installed: { 'dsh-loop': '^1.0.0' }, live: [] },
+      '/dsh-market/updates': { updates: { 'dsh-loop': { kind: 'npm', version: '1.0.0', current: '1.0.0', latest: '1.2.0', updateAvailable: true } } },
+      '/dsh-market/update': { ok: false, error: 'ERR_PNPM_PREPARE_PACKAGE: the build script failed' },
+    })
+    render(<MarketSection {...props()} />)
+    await screen.findByText('dsh-loop')
+    fireEvent.click(screen.getByRole('button', { name: /Installed/ }))
+    fireEvent.click(await screen.findByRole('button', { name: en.update }))
+
+    const banner = await screen.findByText(/ERR_PNPM_PREPARE_PACKAGE/)
+    expect(banner).toBeTruthy()
+    expect(banner.textContent).toContain('dsh-loop')
+  })
+
   it('a busy-agent update response names the running agent instead of the generic busy message', async () => {
     stubFetch({
       '/dsh-market/installed': { profile: 'web', installed: { 'dsh-loop': '^1.0.0' }, live: [] },


### PR DESCRIPTION
From #448, which reports an update that failed, rolled back, wrote two `level: "error"` events to `log.ndjson` — and said nothing on screen, so the user pressed update again.

## The behaviour is already present on main

A 502 carrying an `error` field puts the failure in the banner, and the server's precedence chain already forwards the rollback message:

```ts
error: versionFailureError ?? trialError ?? brokenEntryError
  ?? hardFailureRollbackError ?? staleError ?? undefined
```

**But nothing asserted it.** The existing update tests cover the stale path (`updateNow` button) and the busy-agent path — both of which have their own affordances. The ordinary "it failed" path, which is what you hit when a build script dies, had no test.

That is worth closing regardless of how #448 resolves: a silent failure is the worst outcome this flow has, because the user cannot distinguish it from "nothing happened" and retries into the same wall.

Confirmed the guard fails when the banner is removed:

```
× shows a failed update instead of leaving the row unchanged (#448)
  Unable to find an element with the text: /ERR_PNPM_PREPARE_PACKAGE/
```

Tests only. `npm test` 1173 passed.

## On #448 itself

Still open — the report has an internal inconsistency I have asked about. It states dshmarket **1.35.0**, but the log line it quotes (`restoration of the previous build could not be verified`) was introduced in #428, which shipped in **1.38.0**. So either the version or the log is from a different run, and that changes whether this is a fixed bug or a live one.
