### PR TITLE
fix: recognize a per-user systemd manager, not only PID 1

### DIFF
--- a/src/restart.ts
+++ b/src/restart.ts
@@ -10,6 +10,7 @@
  */
 
 import { spawn } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import inspector from 'node:inspector'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -64,9 +65,20 @@ function argvHasInspectFlag(tokens: readonly string[]): boolean {
  * large population of hosts where it works fine, which is a worse bug than
  * the one being fixed.
  *
- * `ppid === 1` is what distinguishes being the unit's own main process from
- * merely descending from one: systemd forks its services from PID 1, while a
- * terminal's node has the shell as its parent and a runner's has the agent.
+ * The parent test is what distinguishes being the unit's own main process
+ * from merely descending from one: a terminal's node has the shell as its
+ * parent and a runner's has the agent. It used to be `ppid === 1`, which is
+ * only true for SYSTEM units. A per-user unit's service is forked by that
+ * user's manager instance — `systemd --user`, an ordinary PID — so user-unit
+ * hosts read as unsupervised, and one-click restart killed them for good
+ * (#471 by @automagik-genie, with the journal to prove the whole chain:
+ * clean SIGTERM exit → `Restart=on-failure` does not fire → `KillMode=mixed`
+ * SIGKILLs the detached helper before it can spawn the replacement). So the
+ * parent counts as a manager when it is PID 1 or its comm is `systemd` —
+ * the one name both manager instances share and the false-positive parents
+ * (shells, CI agents) never carry. `/proc` is Linux-only, which is exactly
+ * as wide as systemd itself; anywhere it cannot be read the answer stays
+ * "not a manager".
  *
  * Scoped to systemd on purpose. pm2 sets `pm_id`, but it is inherited the
  * same way and pm2's God daemon — not PID 1 — is the parent, so there is no
@@ -78,10 +90,21 @@ function argvHasInspectFlag(tokens: readonly string[]): boolean {
 export function detectedSupervisor(
   env: NodeJS.ProcessEnv = process.env,
   ppid: number = process.ppid,
+  parentComm: (pid: number) => string | null = readParentComm,
 ): string | null {
   const set = (name: string): boolean => (env[name] ?? '') !== ''
-  if ((set('INVOCATION_ID') || set('JOURNAL_STREAM')) && ppid === 1) return 'systemd'
+  if (!set('INVOCATION_ID') && !set('JOURNAL_STREAM')) return null
+  if (ppid === 1 || parentComm(ppid) === 'systemd') return 'systemd'
   return null
+}
+
+/** The comm of `pid` from /proc, or null wherever that cannot be read. */
+function readParentComm(pid: number): string | null {
+  try {
+    return readFileSync(`/proc/${String(pid)}/comm`, 'utf8').trim()
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/tests/restart.spec.ts
+++ b/tests/restart.spec.ts
@@ -150,8 +150,28 @@ describe('supervisor detection gates self-restart (#229)', () => {
     // unit. Reading inheritance as ownership would hide the button on a
     // large population of hosts where restart works fine — a worse bug than
     // the one being fixed.
-    expect(detectedSupervisor({ INVOCATION_ID: 'abc123' }, 4242)).toBeNull()
-    expect(detectedSupervisor({ JOURNAL_STREAM: '8:12345' }, 4242)).toBeNull()
+    //
+    // The parent's comm is injected: on the Linux CI runner the default
+    // implementation would read the REAL /proc entry of whatever happens to
+    // own pid 4242, and the assertion would depend on the runner's process
+    // table.
+    expect(detectedSupervisor({ INVOCATION_ID: 'abc123' }, 4242, () => 'bash')).toBeNull()
+    expect(detectedSupervisor({ JOURNAL_STREAM: '8:12345' }, 4242, () => 'Runner.Worker')).toBeNull()
+    // No /proc to consult (macOS, or the pid vanished) keeps the old answer.
+    expect(detectedSupervisor({ INVOCATION_ID: 'abc123' }, 4242, () => null)).toBeNull()
+  })
+
+  it('names systemd for a per-user unit, whose manager is not PID 1 (#471)', () => {
+    // A user unit's service is forked by that user's `systemd --user`
+    // instance — an ordinary pid. Reading that as "unsupervised" is how
+    // one-click restart killed a user-unit host for good: clean SIGTERM
+    // exit, Restart=on-failure does not fire, KillMode=mixed SIGKILLs the
+    // detached helper before it can spawn the replacement.
+    expect(detectedSupervisor({ INVOCATION_ID: 'abc123' }, 1759, () => 'systemd')).toBe('systemd')
+    expect(detectedSupervisor({ JOURNAL_STREAM: '8:1' }, 1759, () => 'systemd')).toBe('systemd')
+    // The comm alone is not enough — the env marker is still required, so a
+    // bare child of some unrelated process named systemd does not count.
+    expect(detectedSupervisor({}, 1759, () => 'systemd')).toBeNull()
   })
 
   it('defaults restart OFF under a detected supervisor and ON without one', () => {


### PR DESCRIPTION
Closes #471. The reporter's diagnosis is correct end to end, their journal evidence proves each link, and their suggested fix is the right discriminator — this lands it with tests.

## The chain their journal proves

1. `detectedSupervisor()` requires the env marker **and** `ppid === 1`. A user unit's service is forked by that user's manager instance (`systemd[1759]` in their journal) — an ordinary pid — so user-unit hosts read as unsupervised, and `restartAllowed()` said yes.
2. The market SIGTERMs the main process; DSH's launcher exits cleanly, code 0.
3. `Restart=on-failure` — the default `dsh-service` generates — does not fire on a clean exit. The unit stops.
4. `KillMode=mixed` SIGKILLs everything left in the cgroup, including the detached helper. Their helper log exists and is empty: created at :57, killed before it could spawn anything.

This is the same class as #229 ("杀死了服务但是无法重复启动服务") — the worst failure the market can cause — reaching a population #229's fix could not see.

## The fix

The parent counts as a systemd manager when it is PID 1 **or its `/proc/<ppid>/comm` is `systemd`** — the one name both manager instances share, and one the false-positive parents the two-signal design protects against (terminal shells, CI agents) never carry. Unchanged:

- the env marker (`INVOCATION_ID`/`JOURNAL_STREAM`) is still required — a child of some unrelated process named `systemd` still does not count;
- `/proc` unreadable (macOS, vanished pid) → not a manager, the old behaviour. `/proc` is Linux-only, which is exactly as wide as systemd itself;
- `allowRestart: true` still overrides, per #229's design — an operator who configured `KillMode=process` is making a statement about their own deployment.

## A test bug fixed in passing

The existing descendant assertions called `detectedSupervisor({...}, 4242)` with the **real** default `/proc` reader. On the Linux CI runner that reads the comm of whatever actually owns pid 4242 in the runner's process table — the assertions held by luck. They now inject the parent comm.

## Verification

- New case red without the fix: `expected null to be 'systemd'`.
- Covers: user manager (env + comm=systemd → systemd), comm alone without env marker → null, shells/CI agents → null, unreadable /proc → null.
- `npm test` 1174 passed; `npm run check` passed.
