### PR TITLE
seo: concede the plugin pages to the catalog site they mirror

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -479,7 +479,7 @@ ${readmeHtml}
       .replaceAll('__TITLE__', () => esc(loc.P_TITLE.replace('{NAME}', p.displayName)))
       .replaceAll('__DESC__', () => esc(metaDesc))
       .replaceAll('__URL__', () => url)
-      .replaceAll('__HREFLANGS__', () => hreflangs((l) => pluginPath(l, p.slug)))
+      .replaceAll('__CANONICAL__', () => CATALOG + pluginPath(loc, p.slug))
       .replaceAll('__OG_IMAGE__', () => `${ORIGIN}/assets/demo-${loc.code}.png`)
       .replaceAll('__JSONLD__', () => ldSafe(jsonld))
       .replaceAll('__HOME__', () => loc.urlPath)
@@ -514,12 +514,17 @@ const urlEntry = (pathFor, lastmod, freq) => LOCALES.map((l) => `  <url>
 ${alt(pathFor)}
   </url>`).join('\n')
 
+// Plugin pages are deliberately absent. They canonicalize to
+// awesome-dsh-plugin.com (see plugin-template.html), and a sitemap is a list
+// of URLs we claim as canonical — submitting 4,900 URLs whose canonical says
+// "not this site" is what kept 920 of them parked in Search Console's
+// "Discovered - currently not indexed" bucket. The pages still exist and are
+// reachable from /browse/; they just are not put forward for indexing.
 const updated = registry.updated ?? new Date().toISOString().slice(0, 10)
 fs.writeFileSync(`${OUT}/sitemap.xml`, `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 ${urlEntry((l) => l.urlPath, updated, 'weekly')}
 ${urlEntry((l) => l.browsePath, updated, 'daily')}
-${plugins.map((p) => urlEntry((l) => pluginPath(l, p.slug), p.added ?? updated, 'weekly')).join('\n')}
 ${urlEntry((l) => l.privacyPath, updated, 'yearly')}
 </urlset>
 `)

--- a/site/plugin-template.html
+++ b/site/plugin-template.html
@@ -9,8 +9,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>__TITLE__</title>
 <meta name="description" content="__DESC__">
-<link rel="canonical" href="__URL__">
-__HREFLANGS__
+<!-- The canonical points at awesome-dsh-plugin.com, not at this page. Both
+     sites render the same plugin from the same README under the same slug, and
+     Google noticed: 920 of these pages sat in "Discovered - currently not
+     indexed" while the catalog site's copies were indexed. Conceding the
+     duplicate is the fix — this site's search surface is the home and browse
+     pages, not per-plugin content it mirrors. No hreflang here for the same
+     reason: alternates are declared by the canonical pages, not by copies. -->
+<link rel="canonical" href="__CANONICAL__">
 <link rel="sitemap" type="application/xml" href="https://dshmarket.com/sitemap.xml">
 <link rel="icon" href="/assets/logo.svg" type="image/svg+xml">
 <meta property="og:type" content="website">


### PR DESCRIPTION
Search Console reports **954 pages unindexed** on dshmarket.com, 920 of them *Discovered – currently not indexed*: Google found the URLs in the sitemap and declined to crawl them. The cause is duplicate content — every `/p/<slug>/` page here renders the same README as the same slug on awesome-dsh-plugin.com, and Google indexed that copy (5,217 indexed, 48 not) while parking this one.

The slugs were made identical for exactly this moment — `slugOf()` has carried a comment that a cross-domain canonical would be "a pure host swap with nothing to map." This is that swap:

- **Canonical** on plugin pages now points at the awesome-dsh-plugin.com page for the same slug and locale. Verified against the live catalog site: URL shapes match (`/p/<owner>/<repo>/`, `/zh/p/...`) and its pages are self-canonical.
- **hreflang alternates removed** from plugin pages — alternates are declared by canonical pages, not by copies. (The visible language-switch `<a>` links are untouched.)
- **Sitemap drops all plugin URLs** (4,910 entries → 6: home, browse, privacy × 2 locales). Also retires the 22 stale 404 URLs GSC remembers from earlier sitemaps.

## What this trades away

Any chance of a dshmarket.com `/p/` page ranking on its own — which was already ~zero, since the indexed copy is the catalog's. This site's real search value is home + browse (`dsh market` and variants, 4,950 clicks/28d), which keep their canonicals and sitemap entries. The catalog site gets consolidated signals for plugin-name queries (`dsh-tui` alone: 122 clicks/28d), where its detail page is the better landing page anyway.

Pages themselves are unchanged and stay reachable from `/browse/`.

## Verification

- Built: `/p/dsh-market/dsh-market/` canonical → `https://awesome-dsh-plugin.com/p/dsh-market/dsh-market/` (zh → `/zh/p/...`)
- No `<link rel="alternate" hreflang>` left on plugin pages; browse/home unchanged (4 hreflang links intact)
- `sitemap.xml`: 6 `<loc>` entries, no `/p/` URLs, no leftover tokens
- `npx vitest run`: 55 files, 1178 tests passing
- client/ untouched (artifact-consistency guard unaffected)