### PR TITLE
fix: accept scheme-less proxy configuration

### DIFF
--- a/src/net.ts
+++ b/src/net.ts
@@ -44,6 +44,8 @@ import { EnvHttpProxyAgent, fetch as undiciFetch } from 'undici'
  *
  * Blank-is-unset is ours, and only widens that last one: undici would hand a
  * whitespace-only value to `new URL()` and throw out of the constructor.
+ * Scheme-less host:port values are also common in Windows proxy fields and
+ * npm config; proxy agents require URLs, so those default to `http://`.
  */
 export function configuredProxy(): string | null {
   const { http, https } = proxyFromEnv()
@@ -58,8 +60,11 @@ export function configuredProxy(): string | null {
  * back to npm's http proxy the same way undici's does.
  */
 function proxyFromEnv(): { http: string | null; https: string | null } {
-  const pick = (raw: string | undefined): string | null =>
-    raw === undefined || raw.trim() === '' ? null : raw.trim()
+  const pick = (raw: string | undefined): string | null => {
+    const value = raw?.trim()
+    if (value === undefined || value === '') return null
+    return /^[a-z][a-z\d+.-]*:\/\//iu.test(value) ? value : `http://${value}`
+  }
   const https =
     pick(process.env.https_proxy ?? process.env.HTTPS_PROXY) ??
     pick(process.env.npm_config_https_proxy)

--- a/tests/registry.spec.ts
+++ b/tests/registry.spec.ts
@@ -414,6 +414,19 @@ describe('configuredProxy', () => {
     expect(configuredProxy()).toBe('http://127.0.0.1:7897')
   })
 
+  it('defaults a scheme-less proxy to http', () => {
+    // Windows proxy fields and npm config both commonly store host:port.
+    // URL-based proxy agents require a scheme and otherwise throw before
+    // the catalog request starts (#450).
+    process.env.HTTPS_PROXY = '127.0.0.1:7890'
+    expect(configuredProxy()).toBe('http://127.0.0.1:7890')
+  })
+
+  it('preserves an explicitly configured proxy scheme', () => {
+    process.env.HTTPS_PROXY = 'socks5://proxy.corp.example:1080'
+    expect(configuredProxy()).toBe('socks5://proxy.corp.example:1080')
+  })
+
   it('uses npm_config_https_proxy when the standard variables are not set', () => {
     // The machine that reported this: its proxy was configured with
     // `npm config set proxy` (common on Windows), so it exists as
@@ -457,11 +470,11 @@ describe('marketFetch', () => {
     // The trap this guards: configuredProxy() alone would make the failure
     // message claim a proxy was tried while `new EnvHttpProxyAgent()` with
     // no arguments still reads only http(s)_proxy and goes direct.
-    process.env.npm_config_https_proxy = 'http://npm:1'
+    process.env.npm_config_https_proxy = 'proxy.corp.example:8080'
     await marketFetch('https://catalog.example/plugins.json')
     expect(undici.EnvHttpProxyAgent).toHaveBeenCalledWith({
       httpProxy: undefined,
-      httpsProxy: 'http://npm:1',
+      httpsProxy: 'http://proxy.corp.example:8080',
     })
     expect(undici.fetch).toHaveBeenCalledWith(
       'https://catalog.example/plugins.json',


### PR DESCRIPTION
## Summary

- normalize non-empty scheme-less proxy values such as `127.0.0.1:7890` to `http://127.0.0.1:7890`
- preserve explicitly configured proxy schemes and the existing lowercase/uppercase/npm-config precedence
- use the same normalized value for diagnostics and for the `EnvHttpProxyAgent` options
- add regression coverage for the reported standard-environment path and the npm-config handoff path

## Why

`EnvHttpProxyAgent` expects proxy URLs. Windows proxy fields and npm configuration commonly contain only `host:port`, which previously reached Undici unchanged and threw `Invalid URL` before the catalog request could start.

## Verification

- `npx vitest run tests/registry.spec.ts --maxWorkers=1` — 39/39 passed
- `npm test` — 55 files, 1180 tests passed
- `npm run check` — typecheck, build, client bundle rebuild, and restart smoke passed
- `npm run test:compat` — real pnpm 9/10/11 matrix, 11/11 passed
- `npm pack --dry-run --json` — preflight passed, 145 files
- `npm run check:web-auth-capture` — passed
- `git diff --check` — passed

No package version change and no client-source change.

Closes #450