### PR TITLE
docs: open a sponsor slot in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ English | [中文](README.zh.md)
 [![npm](https://img.shields.io/npm/v/dshmarket)](https://www.npmjs.com/package/dshmarket)
 [![stars](https://img.shields.io/github/stars/dsh-market/dsh-market?style=flat)](https://github.com/dsh-market/dsh-market)
 
+## ❤️ Sponsors
+
+> Put your product in front of the DeepSeek Harness community — this README plus [dshmarket.com](https://dshmarket.com) and [awesome-dsh-plugin.com](https://awesome-dsh-plugin.com) together serve **over half a million page views a month**. [Want to appear here? →](mailto:fkysly@gmail.com)
+
 The plugin market inside DeepSeek Harness. Open Settings → **Plugin Market** → browse, search, one-click install.
 
 ![dsh-market](assets/demo-en.png)

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,6 +9,10 @@
 [![npm](https://img.shields.io/npm/v/dshmarket)](https://www.npmjs.com/package/dshmarket)
 [![stars](https://img.shields.io/github/stars/dsh-market/dsh-market?style=flat)](https://github.com/dsh-market/dsh-market)
 
+## ❤️ 赞助商
+
+> 让你的产品出现在 DeepSeek Harness 社区面前——本 README 加上 [dshmarket.com](https://dshmarket.com) 与 [awesome-dsh-plugin.com](https://awesome-dsh-plugin.com)，每月合计**超过五十万次页面浏览**。[想出现在这里？→](mailto:fkysly@gmail.com)
+
 装在 DeepSeek Harness 里的插件市场。打开设置 → **插件市场** → 逛一逛，点一下，装好。
 
 ![dsh-market](assets/demo-zh.png)


### PR DESCRIPTION
cc-switch-style sponsor section: heading + invitation mailto at the top of both READMEs, sponsors to be added as rows when they sign. Starts empty on purpose — the invitation line is the pitch, backed by the real number (~570k PV/month across dshmarket.com + awesome-dsh-plugin.com).

Scope note: README and websites only. The plugin itself carries no advertising (privacy page commitment, unchanged).