### PR TITLE
Fix npm update to prevent double-fetching resolved version(#496)

### DIFF
--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -320,6 +320,19 @@ export interface InstallResult {
    */
   pnpmError?: string
   pnpmErrorCode?: string
+  /**
+   * Exact npm version this Desktop run actually handed to the host (#496).
+   *
+   * Anywhere Labs' install boundary rewrites a floating dist-tag (or bare
+   * name) to `name@x.y.z` with its own registry fetch. The update route
+   * normally pins that version itself before `add`, so this field matches
+   * the request and is unused for verification. It matters when registry
+   * metadata was unavailable and the add still carried `@latest`/`@beta`:
+   * verification then adopts this pin instead of leaving the expected
+   * version unset. When the route already sent an exact pin, callers must
+   * keep that pin authoritative and must not let this field lower it.
+   */
+  resolvedNpmVersion?: string
 }
 
 /** The shape every orchestration function takes to run plugin commands (injectable in tests). */
@@ -406,9 +419,9 @@ const EXACT_NPM_TARGET_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~
  * Their validator wants exactly one target of the form `name@1.2.3` — not a
  * bare name, not `@latest`, and not a `github:` source (read from
  * `validateExternalMarketInstallArgs`, dsh-plugin-desktop/src/pnpm.ts). The
- * market sends a bare name for a registry plugin and `dshmarket@latest` for
- * itself, so both need the version resolved before that boundary will take
- * them.
+ * market prefers to send an already-resolved `name@x.y.z` for npm updates
+ * (#496); a bare name or dist-tag still needs resolving here when some other
+ * path hands one over.
  *
  * Returning null is a normal outcome, not a failure: a github-sourced plugin
  * has no `name@version` spelling at all. The caller falls back to the
@@ -428,11 +441,18 @@ const NPM_ONLY_HOST_NOTE
   + 'That is the client\'s install boundary, not a fault in the plugin or the market. '
   + 'Install it from plain dsh web instead, or ask the author to publish to npm.'
 
-async function exactNpmArgs(args: readonly string[]): Promise<string[] | null> {
+async function exactNpmArgs(args: readonly string[]): Promise<{
+  args: string[]
+  resolvedNpmVersion: string
+} | null> {
   const targets = args.slice(1).filter(argument => !argument.startsWith('-'))
   const target = targets[0]
   if (targets.length !== 1 || target === undefined) return null
-  if (EXACT_NPM_TARGET_RE.test(target)) return [...args]
+  if (EXACT_NPM_TARGET_RE.test(target)) {
+    // Already exact — still report the pin so update verification can align
+    // with what this host will install, not with a separate `latest` fetch.
+    return { args: [...args], resolvedNpmVersion: target.slice(target.lastIndexOf('@') + 1) }
+  }
   // A bare name, or one pinned to a dist-tag. Only a registry package can be
   // resolved; `github:owner/repo` and file paths stop here.
   const at = target.lastIndexOf('@')
@@ -443,7 +463,10 @@ async function exactNpmArgs(args: readonly string[]): Promise<string[] | null> {
   const rewritten = `${name}@${version}`
   if (!EXACT_NPM_TARGET_RE.test(rewritten)) return null
   logEvent('info', 'install', `desktop install boundary needs an exact version: ${target} -> ${rewritten}`)
-  return args.map(argument => (argument === target ? rewritten : argument))
+  return {
+    args: args.map(argument => (argument === target ? rewritten : argument)),
+    resolvedNpmVersion: version,
+  }
 }
 
 /** Desktop runtime also owns cleanup of any operation started by this fiber. */
@@ -943,6 +966,8 @@ export function createDesktopPluginRuntime(
     let handle: DesktopPnpmHandleLike
     /** Set when this host only installs npm packages and the target is not one. */
     let boundaryRefusesTarget = false
+    /** Exact npm pin the install boundary actually sent (#496). */
+    let resolvedNpmVersion: string | undefined
     try {
       // `add` goes through Anywhere Labs' install boundary when that host
       // publishes one, because their Desktop rejects `add` on `runPlugin`
@@ -958,9 +983,10 @@ export function createDesktopPluginRuntime(
       // catalog has no npm package — reported in #138 after the user found
       // out by clicking Install and reading `exit 127`.
       boundaryRefusesTarget = boundary !== undefined && viaBoundary === null
+      if (viaBoundary !== null) resolvedNpmVersion = viaBoundary.resolvedNpmVersion
       handle = boundary === undefined || viaBoundary === null
         ? service.runPlugin(prepared.args, invokingDir, abort.signal)
-        : boundary.call(service, viaBoundary, invokingDir, abort.signal)
+        : boundary.call(service, viaBoundary.args, invokingDir, abort.signal)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       const busy = /another desktop pnpm operation is already running/i.test(message)
@@ -1012,6 +1038,7 @@ export function createDesktopPluginRuntime(
           ...(ignoredBuilds.length > 0 ? { ignoredBuilds } : {}),
           ...(pnpmError !== null ? { pnpmError } : {}),
           ...(pnpmErrorCode !== null ? { pnpmErrorCode } : {}),
+          ...(resolvedNpmVersion !== undefined ? { resolvedNpmVersion } : {}),
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
@@ -1023,6 +1050,7 @@ export function createDesktopPluginRuntime(
           stdout,
           stderr: boundaryRefusesTarget ? `${detail}\n${NPM_ONLY_HOST_NOTE}` : detail,
           cancelled: active.userCancelled,
+          ...(resolvedNpmVersion !== undefined ? { resolvedNpmVersion } : {}),
         }
       } finally {
         if (timer !== undefined) clearTimeout(timer)

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2820,6 +2820,41 @@ sendJson(response, 200, { updates })
             const selfChannel = SELF_NAMES.has(name) ? activeChannel() : null
             const tag = selfChannel === null ? 'latest' : DIST_TAG[selfChannel]
             let expectedNpmVersion: string | null = null
+            // Resolve the registry pin BEFORE building the add target (#496).
+            // Desktop's install boundary otherwise fetches `latest` again to
+            // rewrite `@latest` into `name@x.y.z`; when the two views drift,
+            // verification against the first fetch rolls back a correct
+            // install. Pinning the already-resolved version here makes the
+            // boundary a no-op rewrite and keeps one source of truth.
+            if (usesNpmUpdateTarget) {
+              const installedVersion = readInstalledVersion(config.profile, name, activeProfileDir)
+              const registryLatest = selfChannel === null
+                ? await fetchNpmLatest(name)
+                : await versionOnChannel(name, selfChannel, await fetchNpmLatest(name))
+              expectedNpmVersion = registryLatest
+              // Never let `@latest` walk a profile BACKWARDS (#64 by @ZeroOrigin64):
+              // a package whose latest dist-tag was left on an older release turns
+              // this update into a downgrade that also rewrites an exact pin to
+              // `@latest`. Detection already hides the button; this guards the
+              // route itself. Unreadable versions fall through and update as before.
+              //
+              // A channel-following package is exempt from the DIRECTION, not
+              // from the check. Going backwards is exactly what "put me back on
+              // stable" means, and #64 is about a downgrade nobody asked for —
+              // so here the guard only refuses when the channel already points
+              // at what is installed, and it compares against the target tag
+              // rather than `latest`, which is not the tag being installed.
+              const refuse = selfChannel === null
+                ? installedVersion !== null && registryLatest !== null && !isUpgrade(installedVersion, registryLatest)
+                : installedVersion !== null && registryLatest !== null && installedVersion === registryLatest
+              if (refuse) {
+                logEvent('info', 'update', `${name} refused: latest=${registryLatest} is not newer than installed=${installedVersion}`)
+                sendJson(response, 400, {
+                  error: `已是最新：registry 的 latest 是 ${registryLatest}，不高于已装的 ${installedVersion}，更新会造成降级。 / Already current: the registry's latest (${registryLatest}) is not newer than the installed ${installedVersion}, so updating would downgrade it.`,
+                })
+                return
+              }
+            }
             // Re-accelerated from the unpinned shortcut, never from the
             // installed URL: that one names the commit already on disk, so
             // reusing it would be an update that can never move.
@@ -2836,37 +2871,8 @@ sendJson(response, 200, { updates })
             const target = restore
               ? (NPM_NAME_RE.test(spec) ? `${spec}@${tag}` : await acceleratedTarget(spec, region))
               : gitSpec === null
-                ? `${name}@${tag}`
+                ? (expectedNpmVersion !== null ? `${name}@${expectedNpmVersion}` : `${name}@${tag}`)
                 : await acceleratedTarget(gitSpec, region)
-            // Never let `@latest` walk a profile BACKWARDS (#64 by @ZeroOrigin64):
-            // a package whose latest dist-tag was left on an older release turns
-            // this update into a downgrade that also rewrites an exact pin to
-            // `@latest`. Detection already hides the button; this guards the
-            // route itself. Unreadable versions fall through and update as before.
-            //
-            // A channel-following package is exempt from the DIRECTION, not
-            // from the check. Going backwards is exactly what "put me back on
-            // stable" means, and #64 is about a downgrade nobody asked for —
-            // so here the guard only refuses when the channel already points
-            // at what is installed, and it compares against the target tag
-            // rather than `latest`, which is not the tag being installed.
-            if (usesNpmUpdateTarget) {
-              const installedVersion = readInstalledVersion(config.profile, name, activeProfileDir)
-              const registryLatest = selfChannel === null
-                ? await fetchNpmLatest(name)
-                : await versionOnChannel(name, selfChannel, await fetchNpmLatest(name))
-              expectedNpmVersion = registryLatest
-              const refuse = selfChannel === null
-                ? installedVersion !== null && registryLatest !== null && !isUpgrade(installedVersion, registryLatest)
-                : installedVersion !== null && registryLatest !== null && installedVersion === registryLatest
-              if (refuse) {
-                logEvent('info', 'update', `${name} refused: latest=${registryLatest} is not newer than installed=${installedVersion}`)
-                sendJson(response, 400, {
-                  error: `已是最新：registry 的 latest 是 ${registryLatest}，不高于已装的 ${installedVersion}，更新会造成降级。 / Already current: the registry's latest (${registryLatest}) is not newer than the installed ${installedVersion}, so updating would downgrade it.`,
-                })
-                return
-              }
-            }
             const repoIdentity = isGit ? repoOfTarget(spec) : null
             const repoKey = repoIdentity?.split('#')[0] ?? null
             // dsh-cli's deliberately narrow target grammar rejects the `&`
@@ -3046,13 +3052,29 @@ sendJson(response, 200, { updates })
                 if (stale) ok = false
               }
             }
-            // pnpm's minimumReleaseAge can silently resolve `@latest` to an
-            // OLDER release and still exit 0. The old stale check only caught
-            // "same version"; a real 0.2.24 -> 0.2.23 regression therefore
-            // looked like a successful update. Verify the bytes that actually
-            // landed against both the pre-update version and the registry
-            // target, then rematerialize the previous build on any mismatch.
+            // Verify the bytes that landed against the pin this run asked for.
+            // When the route already sent an exact `name@x.y.z` (#496), that
+            // pin is authoritative: Desktop's install boundary must not be
+            // allowed to lower the bar by reporting a different
+            // `resolvedNpmVersion`. Only a floating dist-tag target (registry
+            // metadata unavailable, so the add still says `@latest`/`@beta`)
+            // adopts the boundary's reported pin — that is the version the
+            // host actually handed to pnpm.
+            //
+            // Getting LESS than the pin is still a mismatch (including the
+            // historical `@latest` + minimumReleaseAge silent-hold shape,
+            // when a floating tag is what was sent). A version above the pin
+            // is only possible on a floating target whose resolver moved
+            // forward mid-download; that stays accepted.
             if (ok && usesNpmUpdateTarget) {
+              const floatingDistTag = expectedNpmVersion === null
+              if (
+                floatingDistTag
+                && typeof result.resolvedNpmVersion === 'string'
+                && result.resolvedNpmVersion !== ''
+              ) {
+                expectedNpmVersion = result.resolvedNpmVersion
+              }
               const afterVersion = readInstalledVersion(config.profile, name, activeProfileDir)
               const direction = beforeVersion !== null && afterVersion !== null
                 ? compareVersions(afterVersion, beforeVersion)

--- a/tests/desktop-runtime.spec.ts
+++ b/tests/desktop-runtime.spec.ts
@@ -198,9 +198,23 @@ describe('Anywhere Labs install boundary (#215, #219, #272)', () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ version: '2.3.4' }), { status: 200 })))
     const { service, plain, boundary } = boundaryService()
     const runtime = createDesktopPluginRuntime(service, profileFixture(), '/tmp', 10_000)
-    await runtime.runPlugin('web', ['add', 'example-plugin'])
+    const result = await runtime.runPlugin('web', ['add', 'example-plugin'])
     expect(plain, 'add went down the path their host refuses').toHaveLength(0)
     expect(boundary[0]?.args).toContain('example-plugin@2.3.4')
+    // Update verification must see the pin this host actually sent (#496).
+    expect(result.resolvedNpmVersion).toBe('2.3.4')
+    await runtime.dispose()
+  })
+
+  it('reports an already-exact add target as resolvedNpmVersion without re-fetching', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ version: '9.9.9' }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { service, boundary } = boundaryService()
+    const runtime = createDesktopPluginRuntime(service, profileFixture(), '/tmp', 10_000)
+    const result = await runtime.runPlugin('web', ['add', 'example-plugin@1.2.3'])
+    expect(boundary[0]?.args).toContain('example-plugin@1.2.3')
+    expect(result.resolvedNpmVersion).toBe('1.2.3')
+    expect(fetchMock).not.toHaveBeenCalled()
     await runtime.dispose()
   })
 

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -1308,6 +1308,155 @@ describe('update flow — no npm publishing required', () => {
     expect(fake.calls.some(call => call.includes('dsh-loop@1.0.0'))).toBe(true)
   })
 
+  it('pins the npm update target to the resolved version so Desktop cannot re-fetch latest (#496)', async () => {
+    advanceNpmLatest('1.2.0')
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+    expect(r.json).toMatchObject({ ok: true })
+    // One registry resolution, one install target: Desktop's install boundary
+    // must not get `@latest` and fetch again (that drift was the false
+    // RESOLVED_VERSION_MISMATCH rollback).
+    const add = fake.calls.find(call => call[0] === 'add' && call.some(arg => arg.startsWith('dsh-loop@')))
+    expect(add).toContain('dsh-loop@1.2.0')
+    expect(add?.some(arg => arg === 'dsh-loop@latest')).toBe(false)
+  })
+
+  it('keeps an exact route pin authoritative over a mismatched Desktop resolvedNpmVersion (#496)', async () => {
+    // The route already sent name@1.2.0. A host that reports a different
+    // resolvedNpmVersion (and whose pnpm tree somehow landed there) must
+    // still fail verification — otherwise the boundary field could lower
+    // the bar the route just fixed in place.
+    advanceNpmLatest('1.2.0')
+    fake.npm['dsh-loop'].versions['1.1.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
+    bed.dispose()
+    bed = createTestbed({}, {
+      runPlugin: async (profile, args) => {
+        const target = args.filter(arg => !arg.startsWith('-')).at(-1) ?? ''
+        if (args[0] === 'add' && target.startsWith('dsh-loop@')) {
+          fake.resolvedNpmVersionOnce = '1.1.0'
+          const result = await runDshPlugin(profile, args) as {
+            exitCode: number | null
+            timedOut: boolean
+            stdout: string
+            stderr: string
+            cancelled: boolean
+          }
+          return { ...result, resolvedNpmVersion: '1.1.0' }
+        }
+        return await runDshPlugin(profile, args) as {
+          exitCode: number | null
+          timedOut: boolean
+          stdout: string
+          stderr: string
+          cancelled: boolean
+        }
+      },
+      probePnpm: () => Promise.resolve(true),
+      provisionPnpm: () => Promise.resolve({ ok: true }),
+      cancelActive: () => false,
+    })
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(502)
+    expect(r.json).toMatchObject({ ok: false, failureCode: 'RESOLVED_VERSION_MISMATCH' })
+    expect(String(r.json.error)).toMatch(/目标为 v1\.2\.0|targeted v1\.2\.0/)
+    expect(installedSpec('dsh-loop')).toBe('^1.0.0')
+  })
+
+  it('adopts the Desktop boundary pin only when the route sent a floating dist-tag (#496)', async () => {
+    // Registry metadata unavailable → add stays `name@latest`. Verification
+    // then has to trust the exact pin Desktop's boundary actually sent.
+    fake.npm['dsh-loop'].latest = '1.2.0'
+    fake.npm['dsh-loop'].versions['1.2.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('registry offline')))
+    bed.dispose()
+    bed = createTestbed({}, {
+      runPlugin: async (profile, args) => {
+        const target = args.filter(arg => !arg.startsWith('-')).at(-1) ?? ''
+        if (args[0] === 'add' && target === 'dsh-loop@latest') {
+          const result = await runDshPlugin(profile, args) as {
+            exitCode: number | null
+            timedOut: boolean
+            stdout: string
+            stderr: string
+            cancelled: boolean
+          }
+          return { ...result, resolvedNpmVersion: '1.2.0' }
+        }
+        if (args[0] === 'add' && target.startsWith('dsh-loop@')) {
+          // Wrong pin reported while a floating tag was NOT what we sent —
+          // should not reach here for this scenario.
+          const result = await runDshPlugin(profile, args) as {
+            exitCode: number | null
+            timedOut: boolean
+            stdout: string
+            stderr: string
+            cancelled: boolean
+          }
+          return { ...result, resolvedNpmVersion: '1.2.0' }
+        }
+        return await runDshPlugin(profile, args) as {
+          exitCode: number | null
+          timedOut: boolean
+          stdout: string
+          stderr: string
+          cancelled: boolean
+        }
+      },
+      probePnpm: () => Promise.resolve(true),
+      provisionPnpm: () => Promise.resolve({ ok: true }),
+      cancelActive: () => false,
+    })
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(200)
+    expect(r.json).toMatchObject({ ok: true })
+    expect(fake.calls.some(call => call[0] === 'add' && call.includes('dsh-loop@latest'))).toBe(true)
+    const installed = JSON.parse(readFileSync(join(fake.profileDir, 'node_modules', 'dsh-loop', 'package.json'), 'utf8')) as { version?: string }
+    expect(installed.version).toBe('1.2.0')
+  })
+
+  it('rejects a floating-tag update whose Desktop pin does not match what landed (#496)', async () => {
+    fake.npm['dsh-loop'].latest = '1.2.0'
+    fake.npm['dsh-loop'].versions['1.2.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
+    fake.npm['dsh-loop'].versions['1.1.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('registry offline')))
+    bed.dispose()
+    bed = createTestbed({}, {
+      runPlugin: async (profile, args) => {
+        const target = args.filter(arg => !arg.startsWith('-')).at(-1) ?? ''
+        if (args[0] === 'add' && target === 'dsh-loop@latest') {
+          fake.resolvedNpmVersionOnce = '1.1.0'
+          const result = await runDshPlugin(profile, args) as {
+            exitCode: number | null
+            timedOut: boolean
+            stdout: string
+            stderr: string
+            cancelled: boolean
+          }
+          return { ...result, resolvedNpmVersion: '1.2.0' }
+        }
+        return await runDshPlugin(profile, args) as {
+          exitCode: number | null
+          timedOut: boolean
+          stdout: string
+          stderr: string
+          cancelled: boolean
+        }
+      },
+      probePnpm: () => Promise.resolve(true),
+      provisionPnpm: () => Promise.resolve({ ok: true }),
+      cancelActive: () => false,
+    })
+
+    const r = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(502)
+    expect(r.json).toMatchObject({ ok: false, failureCode: 'RESOLVED_VERSION_MISMATCH' })
+    expect(installedSpec('dsh-loop')).toBe('^1.0.0')
+  })
+
   it('exposes a versioned capability and update-check contract for plugin-owned UIs', async () => {
     advanceNpmLatest('1.2.0')
     const capabilities = await bed.dispatch('GET', '/dsh-market/api/v1/capabilities')
@@ -1688,7 +1837,7 @@ describe('update flow — no npm publishing required', () => {
     expect(readFileSync(join(fake.profileDir, 'node_modules', 'dsh-loop', 'lib', 'index.js'), 'utf8')).toBe('old-build')
     expect(existsSync(lockfilePath)).toBe(false)
     expect(fake.calls.slice(callsBefore).filter(call => call[0] === 'add')).toEqual([
-      ['add', 'dsh-loop@latest'],
+      ['add', 'dsh-loop@1.3.0'],
       ['add', '--force', '--config.minimumReleaseAge=0', 'dsh-loop@1.0.0'],
     ])
   })
@@ -2489,7 +2638,7 @@ describe('update flow — no npm publishing required', () => {
     expect(r.status).toBe(409)
     expect(r.json).toMatchObject({ ok: false, busy: true })
     expect(runPlugin.mock.calls).toEqual([
-      ['web', ['add', 'dsh-loop@latest']],
+      ['web', ['add', 'dsh-loop@1.2.0']],
       ['web', ['store', 'path']],
     ])
     expect(installedSpec('dsh-loop')).toBe('^1.0.0')
@@ -3870,20 +4019,39 @@ describe('release channel', () => {
     // The offer and the install have to agree. `@latest` was hardcoded, so a
     // beta subscriber would be told an update existed and then handed the
     // stable build — the setting would look like it did nothing.
-    fake.npm['dshmarket'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    //
+    // The add target is the exact pin the channel resolved (#496), not the
+    // dist-tag itself: Desktop's install boundary would otherwise re-fetch
+    // `latest` and drift. What must still hold is that beta does not install
+    // the stable release.
+    fake.npm['dshmarket'] = {
+      latest: '1.0.0',
+      versions: {
+        '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] },
+        '9.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] },
+        '9.1.0-beta.1': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] },
+      },
+    }
     await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dshmarket' })
     fake.npm['dshmarket'].latest = '9.0.0'
-    fake.npm['dshmarket'].versions['9.0.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
     await bed.dispatch('POST', '/dsh-market/channel', { channel: 'beta' })
+    vi.stubGlobal('fetch', (url: string) => {
+      const u = String(url)
+      if (u.includes('/beta')) {
+        return Promise.resolve(new Response(JSON.stringify({ version: '9.1.0-beta.1' }), { status: 200 }))
+      }
+      return Promise.resolve(new Response(JSON.stringify({ version: '9.0.0' }), { status: 200 }))
+    })
     fake.calls = []
     await bed.dispatch('POST', '/dsh-market/update', { name: 'dshmarket' })
     const added = fake.calls.find(call => call[0] === 'add')
-    expect(added?.join(' '), 'the update ran with the wrong dist-tag').toContain('dshmarket@beta')
+    expect(added?.join(' '), 'the update ran with the wrong channel pin').toContain('dshmarket@9.1.0-beta.1')
+    expect(added?.join(' ')).not.toContain('dshmarket@9.0.0')
 
     await bed.dispatch('POST', '/dsh-market/channel', { channel: 'stable' })
     fake.calls = []
     await bed.dispatch('POST', '/dsh-market/update', { name: 'dshmarket' })
-    expect(fake.calls.find(call => call[0] === 'add')?.join(' ')).toContain('dshmarket@latest')
+    expect(fake.calls.find(call => call[0] === 'add')?.join(' ')).toContain('dshmarket@9.0.0')
   })
 
   it('re-checks immediately when the channel changes', async () => {


### PR DESCRIPTION
- Fixes #496：npm 更新不再用两次独立的 `latest` fetch 互相对账。更新路由在降级门禁解析后直接 `add name@<resolved>`，Desktop install boundary 不会再二次解析，从而避免正确安装被误报 `RESOLVED_VERSION_MISMATCH` 并回滚。
- 保留 `InstallResult.resolvedNpmVersion` 作为**兜底**：仅当 registry 元数据不可用、add 仍是浮动 dist-tag（`@latest` / `@beta`）时，校验采用 Desktop 实际交出的 pin。路由已发送精确版本时，该字段不能压低期望。
- 回归：精确 pin；精确 pin 不被假 boundary 字段削弱；浮动 tag 路径按 boundary pin 通过/拒绝。

## 为何保留兜底
常态路径（两次都能 fetch）只靠 pin-exact 即可修好 #496。浮动 tag + `resolvedNpmVersion` 覆盖的是：`fetchNpmLatest` 失败时仍传 `@latest`、Desktop 自行改写的残余形状——没有它，校验会空窗或对错期望。这是有意保留的防御，不是主修复本身。

## 连带行为（有意）
- 更新安装的是点击时解析到的版本，不再跟随下载过程中新发布的 latest。
- 市场频道更新也会 pin 解析结果，而不再把浮动 dist-tag 留在 add 参数上。

## Test plan
- [x] `npm test -- tests/desktop-runtime.spec.ts`
- [x] `npm test -- tests/flows.spec.ts -t 'update flow|installs from the channel'`
- [ ] CI
- [ ] Desktop 上对频繁发版的 npm 插件连更两次，确认无误回滚