### PR TITLE
test: 为 pnpm 10/11 compat「accepts it」用例拆分超时预算

### DIFF
--- a/tests/pnpm-behavior.compat.spec.ts
+++ b/tests/pnpm-behavior.compat.spec.ts
@@ -68,12 +68,16 @@ describe('#20 bug 1 — workspace-root add without -w', () => {
     expect(classifyPnpmFailure(out)?.code).toBe('adding-to-root')
   })
 
-  it('pnpm 10 and 11 accept it (the refusal is a pnpm-9-only behavior)', () => {
-    for (const version of [PNPM[10], PNPM[11]]) {
-      const dir = profileFixture({ workspace: true })
-      const { code } = pnpm(version, ['add', 'is-odd@3.0.1'], dir)
-      expect(code, `pnpm ${version}`).toBe(0)
-    }
+  it('pnpm 10 accepts it (the refusal is a pnpm-9-only behavior)', () => {
+    const dir = profileFixture({ workspace: true })
+    const { code } = pnpm(PNPM[10], ['add', 'is-odd@3.0.1'], dir)
+    expect(code, `pnpm ${PNPM[10]}`).toBe(0)
+  })
+
+  it('pnpm 11 accepts it (the refusal is a pnpm-9-only behavior)', () => {
+    const dir = profileFixture({ workspace: true })
+    const { code } = pnpm(PNPM[11], ['add', 'is-odd@3.0.1'], dir)
+    expect(code, `pnpm ${PNPM[11]}`).toBe(0)
   })
 })
 


### PR DESCRIPTION
## 摘要
- 将 `pnpm 10 and 11 accept it` 拆成按 major 各一个 `it`，使每次安装都有完整 300s `testTimeout`。
- 修复前一个 pnpm 9 用例已约 225s 时该用例偶发超时的问题。

Closes #499 

## 测试计划
- [x] CI `pnpm-compat` 通过