### PR TITLE
fix: WebDAV restore follows redirects, without forwarding credentials

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -226,6 +226,8 @@ interface PublicAddress {
 interface WebdavResponse {
   status: number
   body: Buffer
+  /** The Location header, for the GET redirect loop in downloadWebdav. */
+  location?: string
 }
 
 async function webdavRequest(
@@ -286,7 +288,11 @@ async function webdavRequest(
         }
         chunks.push(value)
       })
-      response.once('end', () => resolveRequest({ status: response.statusCode ?? 0, body: Buffer.concat(chunks) }))
+      response.once('end', () => resolveRequest({
+        status: response.statusCode ?? 0,
+        body: Buffer.concat(chunks),
+        ...(typeof response.headers.location === 'string' ? { location: response.headers.location } : {}),
+      }))
     })
     request.once('error', reject)
     request.end(body)
@@ -401,8 +407,43 @@ export async function resolvePublicAddress(hostname: string): Promise<PublicAddr
   return { address: selected.address, family: selected.family }
 }
 
+/**
+ * How many redirects a download will follow before giving up. Providers use
+ * one hop (WebDAV endpoint -> signed CDN link); five tolerates a CDN's own
+ * indirection without letting two servers ping-pong forever.
+ */
+const MAX_REDIRECTS = 5
+
 export async function downloadWebdav(url: string, username: string, password: string): Promise<unknown> {
-  const response = await webdavRequest(url, username, password, 'GET')
+  // Some providers answer a WebDAV GET with 302 to a time-limited signed CDN
+  // link while accepting PUT directly on the same path (#480 by @zhyx1996,
+  // measured against 123pan) — so upload worked and restore failed with
+  // "HTTP 302". Only GET follows: the upload path is direct on every
+  // provider seen, and replaying a PUT body across redirects is a can of
+  // worms nothing currently needs opened.
+  //
+  // Every hop goes back through webdavRequest, so the full SSRF gate —
+  // https-only, no credentials in the URL, resolvePublicAddress with the
+  // rebinding-safe direct-IP connect — is re-run per target, not only on the
+  // first one. A redirect is the server choosing the next URL; trusting it
+  // half as much as the user's own input would invert the threat model.
+  //
+  // Credentials do NOT cross origins. The signed link authorizes itself;
+  // forwarding Basic auth to whatever host the server named would hand the
+  // user's WebDAV password to a third party on the server's say-so.
+  let currentUrl = url
+  let response = await webdavRequest(currentUrl, username, password, 'GET')
+  for (let hop = 0; hop < MAX_REDIRECTS; hop += 1) {
+    if (response.status !== 301 && response.status !== 302 && response.status !== 303
+      && response.status !== 307 && response.status !== 308) break
+    if (response.location === undefined) break
+    const next = new URL(response.location, currentUrl)
+    const sameOrigin = next.origin === new URL(currentUrl).origin
+    currentUrl = next.toString()
+    response = sameOrigin
+      ? await webdavRequest(currentUrl, username, password, 'GET')
+      : await webdavRequest(currentUrl, '', '', 'GET')
+  }
   if (response.status < 200 || response.status >= 300) {
     throw new Error(response.status === 404
       ? 'WebDAV download failed: HTTP 404 — no backup at that path yet. Upload one first, and check the URL points at the backup FILE (…/dsh/backup.json), not its folder / 该路径下还没有备份文件。请先执行一次上传，并确认地址指向备份文件本身（…/dsh/backup.json）而不是目录'

--- a/tests/backup.spec.ts
+++ b/tests/backup.spec.ts
@@ -18,10 +18,10 @@ import {
 } from '../src/backup.ts'
 import { profileDir } from '../src/profile.ts'
 
-function respondWith(body: string, statusCode: number): void {
+function respondWith(body: string, statusCode: number, headers: Record<string, string> = {}): void {
   network.request.mockImplementationOnce((_options, callback) => {
     const response = Readable.from(body === '' ? [] : [Buffer.from(body)])
-    Object.assign(response, { statusCode, headers: { 'content-length': String(Buffer.byteLength(body)) } })
+    Object.assign(response, { statusCode, headers: { 'content-length': String(Buffer.byteLength(body)), ...headers } })
     const request = Object.assign(new EventEmitter(), { end: vi.fn() })
     queueMicrotask(() => callback(response))
     return request
@@ -181,6 +181,61 @@ describe('profile backup and restore', () => {
     expect(network.request.mock.calls[1][0]).toMatchObject({
       hostname: '93.184.216.34', method: 'GET', servername: 'dav.example',
     })
+  })
+})
+
+describe('WebDAV download redirects (#480)', () => {
+  const backup = { format: 'dsh-profile-backup', version: 0.2, profile: 'web', createdAt: 'x', files: [{ path: 'package.json', json: { dependencies: {} } }] }
+  const backupJson = JSON.stringify(backup)
+
+  it('follows a 302 to a signed link, and does not forward Basic auth across origins', async () => {
+    // 123pan answers every WebDAV GET with 302 to a time-limited CDN link
+    // while accepting PUT directly — so upload worked and restore failed.
+    respondWith('', 302, { location: 'https://cdn.example/signed/backup.json?sig=abc' })
+    respondWith(backupJson, 200)
+
+    expect(await downloadWebdav('https://dav.example/backup.json', 'user', 'secret')).toEqual(backup)
+    const first = network.request.mock.calls[0]![0] as { headers: Record<string, string> }
+    const second = network.request.mock.calls[1]![0] as { headers: Record<string, string>; path: string }
+    expect(first.headers.authorization).toBeDefined()
+    // The signed link authorizes itself; forwarding the user's WebDAV
+    // password to whatever host the server named would leak it on the
+    // server's say-so.
+    expect(second.headers.authorization).toBeUndefined()
+    expect(second.path).toBe('/signed/backup.json?sig=abc')
+  })
+
+  it('keeps auth on a same-origin redirect and resolves a relative Location', async () => {
+    respondWith('', 301, { location: '/moved/backup.json' })
+    respondWith(backupJson, 200)
+
+    expect(await downloadWebdav('https://dav.example/backup.json', 'user', 'secret')).toEqual(backup)
+    const second = network.request.mock.calls[1]![0] as { headers: Record<string, string>; path: string }
+    expect(second.headers.authorization).toBeDefined()
+    expect(second.path).toBe('/moved/backup.json')
+  })
+
+  it('re-runs the SSRF gate on every hop', async () => {
+    // A redirect is the server choosing the next target. Trusting it more
+    // than the user's own input would invert the threat model, so each hop
+    // passes the same https-only + public-address checks as the first.
+    respondWith('', 302, { location: 'http://dav.example/plain' })
+    await expect(downloadWebdav('https://dav.example/backup.json', 'u', 'p'))
+      .rejects.toThrow(/https/)
+
+    network.request.mockReset()
+    network.lookup.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+    network.lookup.mockResolvedValueOnce([{ address: '169.254.169.254', family: 4 }])
+    respondWith('', 302, { location: 'https://metadata.internal.example/latest' })
+    await expect(downloadWebdav('https://dav.example/backup.json', 'u', 'p'))
+      .rejects.toThrow(/invalid WebDAV URL/)
+  })
+
+  it('gives up after the hop limit instead of ping-ponging forever', async () => {
+    for (let i = 0; i < 6; i += 1) respondWith('', 302, { location: 'https://dav.example/again' })
+    await expect(downloadWebdav('https://dav.example/backup.json', 'u', 'p'))
+      .rejects.toThrow(/HTTP 302/)
+    expect(network.request).toHaveBeenCalledTimes(6)
   })
 })
 


### PR DESCRIPTION
Closes #480. The report's diagnosis is complete — 123pan 302s every WebDAV GET to a signed CDN link while PUT stays direct, so upload worked and restore died on `HTTP 302` — and its security requirements are the ones implemented, verbatim:

| requirement (from the report) | implementation |
|---|---|
| follow 3xx with a hop limit | GET-only loop, 5 hops, then fail with the status |
| strip `Authorization` cross-origin | signed links authorize themselves; Basic auth never leaves the original origin |
| re-run SSRF hardening per hop | every hop goes back through `webdavRequest`: https-only, no URL credentials, public-address check with the rebinding-safe direct-IP connect |

GET-only is deliberate: uploads are direct on every provider seen (the report confirms PUT works on 123pan), and replaying a PUT body across redirects is complexity nothing currently needs.

## Verification

- 4 new tests: cross-origin 302 strips auth + hits the signed path; same-origin 301 keeps auth + resolves a relative `Location`; a hop redirecting to `http://` or to a metadata address is refused by the same gate as hop one; 6 consecutive 302s stop at the limit.
- Mutation check: forwarding auth on every hop turns the cross-origin test red.
- `npm test` 1251 passed; `npm run check` passed.
