### PR TITLE
fix: say what happened when pnpm exists on PATH but will not start (#502)

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -97,7 +97,7 @@ export async function withHoistRecovery(
   let result = await run(profile, pluginArgs)
   const ok = (r: InstallResult): boolean => r.exitCode === 0 && !r.timedOut && !r.cancelled
   if (!ok(result) && !result.cancelled) {
-    const failure = classifyPnpmFailure(`${result.stderr}\n${result.stdout}`)
+    const failure = classifyPnpmFailure(`${result.stderr}\n${result.stdout}`, result.exitCode)
     if (failure?.code === 'hoist-pattern-diff') {
       logEvent('warn', 'install', `modules dir was built by a different pnpm major — rebuilding (pnpm install) and retrying once`)
       // --no-frozen-lockfile: the market runs pnpm with CI=true (TTY hangs),
@@ -151,9 +151,13 @@ export async function withHoistRecovery(
     // construction: directories are only removed when their owning pid is
     // gone (the name carries it), so a live download is never touched.
     await cleanOrphanedStore(run, profile)
-    const failure = classifyPnpmFailure(`${result.stderr}\n${result.stdout}`)
+    const failure = classifyPnpmFailure(`${result.stderr}\n${result.stdout}`, result.exitCode)
     if (failure !== null) {
-      result = { ...result, stderr: `${result.stderr}\n\n${failure.message}` }
+      result = {
+        ...result,
+        stderr: failure.replaceOutput === true ? failure.message : `${result.stderr}\n\n${failure.message}`,
+        ...(failure.replaceOutput === true ? { stdout: '' } : {}),
+      }
     } else if (result.pnpmError !== undefined && result.pnpmError !== '') {
       // Nothing matched, but pnpm DID say what went wrong — in its ndjson
       // stream, which never reaches stderr. Without this the user is shown
@@ -169,6 +173,22 @@ export async function withHoistRecovery(
     }
   }
   return result
+}
+
+/**
+ * Whether pnpm never started at all, so the profile cannot have been touched.
+ *
+ * Worth its own question because the update route answers a failed run by
+ * reinstalling the previous build and reporting loudly when it cannot verify
+ * that (#502 by @Ztyss): three updates in a row told the user their profile
+ * might be broken and to inspect it before restarting, when in fact nothing
+ * had been written — the command line could not launch pnpm, so package.json
+ * and node_modules were exactly as they had been.
+ * @param result - the failed run.
+ * @returns true when the failure happened before pnpm could run.
+ */
+export function pnpmNeverStarted(result: InstallResult): boolean {
+  return classifyPnpmFailure(`${result.stderr}\n${result.stdout}`, result.exitCode)?.code === 'pnpm-unusable'
 }
 
 /**

--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -47,10 +47,21 @@ export interface PnpmFailure {
   code: 'adding-to-root' | 'not-a-workspace' | 'hoist-pattern-diff' | 'pnpm-missing' | 'release-age-violation'
     | 'ignored-builds' | 'git-prepare-not-allowed' | 'fetch-404' | 'transient-network' | 'fetch-timeout'
     | 'unexpected-store' | 'patch-failed' | 'missing-tarball-integrity' | 'windows-file-locked'
+    | 'pnpm-unusable'
   /** Bilingual, actionable message shown to the user instead of the raw wall of text. */
   message: string
   /** True when re-running `pnpm install` in the profile is the documented recovery. */
   recoverable: boolean
+  /**
+   * Show this message INSTEAD of the captured output, not after it.
+   *
+   * Normally the raw text is worth keeping: it is pnpm's own account of what
+   * happened, and the explanation sits under it. Set only where the captured
+   * bytes carry nothing a user can read — cmd.exe writes its errors in the
+   * OEM code page, which arrives here as replacement characters, so pasting
+   * them under an explanation adds noise and hides the explanation (#502).
+   */
+  replaceOutput?: boolean
   /**
    * The package pnpm could not resolve, when the failure names one.
    *
@@ -165,9 +176,13 @@ function integrityViolators(diagnostic: string): string[] {
  * dsh's own wrapper line ("dsh: pnpm failed in profile directory …") names no
  * cause, so the market must recognize pnpm's real diagnostics itself (#20).
  * @param output - stdout+stderr of the failed run.
+ * @param exitCode - the run's exit status, when the caller has it (null when
+ *   the process was signalled). Only a
+ *   failure whose whole signal IS the status reads it (#502); everything else
+ *   is recognized from what pnpm said.
  * @returns the classified failure, or null when unrecognized (raw output is then shown as-is).
  */
-export function classifyPnpmFailure(output: string): PnpmFailure | null {
+export function classifyPnpmFailure(output: string, exitCode?: number | null): PnpmFailure | null {
   if (output.includes('ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF')
     || output.includes('ERR_PNPM_VIRTUAL_STORE_DIR_MAX_LENGTH_DIFF')) {
     return {
@@ -372,6 +387,29 @@ export function classifyPnpmFailure(output: string): PnpmFailure | null {
       code: 'pnpm-missing',
       recoverable: false,
       message: '找不到 pnpm，请先在市场页顶部一键安装组件 / pnpm is not on PATH — use the one-click setup at the top of the market page',
+    }
+  }
+  // #502 by @Ztyss: a pnpm WAS found on PATH and could not be started.
+  //
+  // Different from `pnpm-missing` in the one way that matters to the user:
+  // the market's own setup does not fix it, because as far as PATH is
+  // concerned pnpm is already there. The reported case is a `pnpm.cmd`
+  // wrapper built out of environment variables that only exist in its
+  // installer's own process — expanded in the market's child process it
+  // collapses to an empty command, and cmd.exe answers 9009 with its message
+  // in the OEM code page, which reaches us as replacement characters. Three
+  // updates in a row failed showing the user nothing but that.
+  //
+  // 9009 is cmd.exe's "command not found" and is language-independent, so it
+  // leads; the text forms catch the same failure in a log with no exit code.
+  // Last in the chain deliberately: pnpm's own errors never exit 9009, and
+  // anything pnpm actually said has already matched above.
+  if (exitCode === 9009 || /is not recognized as an internal or external command|不是内部或外部命令|不是內部或外部命令/.test(output)) {
+    return {
+      code: 'pnpm-unusable',
+      recoverable: false,
+      replaceOutput: true,
+      message: '找不到能用的 pnpm，插件没有任何改动。系统里确实有一个 pnpm，但它启动失败了（命令行退出码 9009）。可能是它其实没装好，也可能它是一个包装脚本、而脚本需要的环境变量在市场启动的子进程里不存在。在终端里执行一次 `pnpm --version` 就能分辨：那里同样失败，说明要修的是这台机器上的 pnpm；那里正常，说明是启动市场的方式带来的环境差异，改用普通的 `dsh web` 启动可以绕开。 / pnpm could not be started, and nothing was changed. A pnpm does exist on PATH, but launching it failed (command-line exit code 9009). Either that pnpm is not installed properly, or it is a wrapper script whose required environment variables are missing in the process the market spawns. Run `pnpm --version` in a terminal to tell them apart: failing there too means pnpm itself needs fixing on this machine; working there means the difference comes from how the market was launched, and starting dsh with a plain `dsh web` avoids it.',
     }
   }
   return null

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -37,7 +37,7 @@ import { applyPreset, deletePreset, listPresets, previewPreset, savePreset } fro
 import { createProfileSnapshot, DEFAULT_MAX_SNAPSHOTS, deleteSnapshot, listSnapshots, restoreSnapshot } from './snapshot.ts'
 import { trialValidate } from './trial.ts'
 import { codeloadAllowBuildsKey, findCatalogEntryForLocal, findInstalledAlias, githubCommitOfTarget, githubTargetAtCommit, gitAllowBuildsKey, installTargetFor, isLocalSpec, NPM_NAME_RE, repoOfTarget, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps } from './sources.ts'
-import { failureDetail, groupConflictsByOwner, isStaleUpdate, parseIgnoredBuilds, parsePrepareNotAllowed, RELEASE_AGE_OVERRIDE, retargetCollections, validateAddedPlugins, withHoistRecovery } from './install.ts'
+import { failureDetail, groupConflictsByOwner, isStaleUpdate, parseIgnoredBuilds, parsePrepareNotAllowed, pnpmNeverStarted, RELEASE_AGE_OVERRIDE, retargetCollections, validateAddedPlugins, withHoistRecovery } from './install.ts'
 import { asChannel, CHANNELS, DIST_TAG, resolveChannel, type Channel } from './channels.ts'
 import {
   asRegion, githubProxyManaged, normalizeGithubProxy, REGIONS, routesFor, setActiveRegion,
@@ -3016,7 +3016,13 @@ sendJson(response, 200, { updates })
             // exact prior source identity unless the host rejected the start
             // as busy or the user deliberately cancelled and chose to inspect
             // the resulting partial state.
-            if ((result.exitCode !== 0 || result.timedOut) && !cancelled && result.busy !== true) {
+            // pnpm never launched (#502): nothing was written, so there is
+            // nothing to restore — and the notice this block produces when a
+            // rollback cannot be verified ("inspect this profile before
+            // restarting") would be alarm over an untouched profile, on top
+            // of a failure the user already cannot act on from here.
+            if ((result.exitCode !== 0 || result.timedOut) && !cancelled && result.busy !== true
+              && !pnpmNeverStarted(result)) {
               const rollback = await rollbackAttemptBuild()
               rollbackOk = rollback.ok
               rollbackDetail = rollback.detail

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -11,7 +11,7 @@ import { join } from 'node:path'
 import type { InstallResult } from '../src/dsh-cli.ts'
 import {
   failureDetail, FETCH_TIMEOUT_OVERRIDE, groupConflictsByOwner, isStaleUpdate, parseIgnoredBuilds,
-  parsePrepareNotAllowed, retargetCollections, validateAddedPlugins, withHoistRecovery,
+  parsePrepareNotAllowed, pnpmNeverStarted, retargetCollections, validateAddedPlugins, withHoistRecovery,
 } from '../src/install.ts'
 import { profileDir } from '../src/profile.ts'
 
@@ -335,6 +335,37 @@ describe('withHoistRecovery', () => {
     expect(calls).toEqual([['add', FETCH_TIMEOUT_OVERRIDE, 'dsh-loop'], ['store', 'path']])
     // The final failure message is appended for the UI.
     expect(result.stderr).toContain('下载超时')
+  })
+
+  it('replaces cmd.exe\'s undecodable output rather than printing it (#502)', async () => {
+    // Windows answers 9009 for "command not found" and writes its message in
+    // the OEM code page, which reaches us as replacement characters. Leaving
+    // that above the explanation was what the user was shown three times in
+    // a row, with no way to tell it was a pnpm launch problem.
+    const run = async (): Promise<InstallResult> => ({
+      exitCode: 9009,
+      timedOut: false,
+      stdout: '\ufffd\ufffd\ufffd\ufffd',
+      stderr: "'\"\"' \ufffd\ufffd\ufffd\ufffd\ndsh: pnpm failed in profile directory",
+      cancelled: false,
+    })
+    const result = await withHoistRecovery(run, 'web', ['add', 'dsh-loop'])
+    expect(result.stderr).toContain('pnpm --version')
+    expect(result.stderr).not.toContain('\ufffd')
+    expect(result.stdout).toBe('')
+  })
+})
+
+describe('pnpmNeverStarted (#502)', () => {
+  it('is true only when the failure happened before pnpm could run', () => {
+    const failed = (over: Partial<InstallResult>): InstallResult =>
+      ({ exitCode: 1, timedOut: false, stdout: '', stderr: '', cancelled: false, ...over })
+    // The profile is untouched here, so the update route must not report a
+    // rollback it could not verify — there is nothing to roll back.
+    expect(pnpmNeverStarted(failed({ exitCode: 9009, stderr: "'\"\"' \ufffd\ufffd\ufffd" }))).toBe(true)
+    // pnpm ran and failed: package.json may already have been rewritten.
+    expect(pnpmNeverStarted(failed({ stderr: 'ERR_PNPM_FETCH_404 GET https://registry.npmjs.org/ghost: Not Found - 404' }))).toBe(false)
+    expect(pnpmNeverStarted(failed({ stderr: 'some other failure' }))).toBe(false)
   })
 })
 

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -314,3 +314,47 @@ pnpm now wants to use the store at "C:\\Users\\lenovo\\AppData\\Local\\pnpm\\sto
     expect(failure?.message).toContain('--store-dir')
   })
 })
+
+describe('a pnpm that exists on PATH but cannot be started (#502)', () => {
+  // Reported on Windows: the pnpm first on PATH was a `.cmd` wrapper built
+  // out of environment variables that only exist in its installer's own
+  // process. Expanded in the market's child process it collapsed to an empty
+  // command; cmd.exe answered 9009 and wrote its message in the OEM code
+  // page, which arrives here as replacement characters. Three updates in a
+  // row failed showing the user nothing else.
+  const MOJIBAKE = "'\"\"' ��������������\ndsh: pnpm failed in profile directory"
+
+  it('is recognized by the exit status, whatever locale cmd answered in', () => {
+    const failure = classifyPnpmFailure(MOJIBAKE, 9009)
+    expect(failure?.code).toBe('pnpm-unusable')
+    expect(failure?.recoverable).toBe(false)
+  })
+
+  it('replaces the unreadable output instead of appending to it', () => {
+    // The captured bytes are undecodable by construction, so printing them
+    // above the explanation only buries the explanation.
+    expect(classifyPnpmFailure(MOJIBAKE, 9009)?.replaceOutput).toBe(true)
+  })
+
+  it('tells the two causes apart for the user with one command they can run', () => {
+    const message = classifyPnpmFailure(MOJIBAKE, 9009)?.message ?? ''
+    expect(message).toContain('pnpm --version')
+    expect(message).toContain('9009')
+  })
+
+  it('also matches on cmd\'s own wording when no exit status is available', () => {
+    expect(classifyPnpmFailure("'pnpm' is not recognized as an internal or external command,\noperable program or batch file.")?.code).toBe('pnpm-unusable')
+    expect(classifyPnpmFailure("'pnpm' 不是内部或外部命令。")?.code).toBe('pnpm-unusable')
+  })
+
+  it('never outranks a failure pnpm itself reported', () => {
+    // pnpm's own errors never exit 9009. If one somehow arrives with that
+    // status, what pnpm said is the more specific answer and must win.
+    expect(classifyPnpmFailure('ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root', 9009)?.code)
+      .toBe('adding-to-root')
+  })
+
+  it('leaves an ordinary failure alone', () => {
+    expect(classifyPnpmFailure('some other failure', 1)).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #502 (market side).

Three updates in a row failed on Windows and the failure detail shown to the user was cmd.exe's own message in the OEM code page — replacement characters, nothing identifying it as a pnpm launch problem. Underneath: the first pnpm on PATH was a `.cmd` wrapper assembled from environment variables that exist only in its installer's own process, so in the process the market spawns it expanded to an empty command and cmd answered **9009**.

**Recognized.** New `pnpm-unusable` class, keyed on exit status 9009 (cmd's language-independent "command not found"), with the English and Chinese wordings as a fallback for logs carrying no status. It sits last in the chain — pnpm's own errors never exit 9009, so anything pnpm actually said still wins.

Deliberately distinct from the existing `pnpm-missing`: that one tells the user to run the market's one-click setup, which cannot help here, because as far as PATH is concerned pnpm is already there. The message names both possible causes and the single command that separates them:

> 找不到能用的 pnpm，插件没有任何改动。系统里确实有一个 pnpm，但它启动失败了（命令行退出码 9009）。可能是它其实没装好，也可能它是一个包装脚本、而脚本需要的环境变量在市场启动的子进程里不存在。在终端里执行一次 `pnpm --version` 就能分辨…

**Readable.** New `replaceOutput` flag on `PnpmFailure`, set only here — the captured bytes are undecodable by construction, so printing them above the explanation only buries it. Everywhere else the raw text stays, since it is pnpm's own account.

**No false alarm.** The update route no longer attempts a rollback when pnpm never started: nothing was written, so there is nothing to restore, and its unverified-rollback notice ("inspect this profile before restarting") was alarm about an untouched profile on top of a failure the user could not act on from there.

Not adopted: the suggested pre-flight `pnpm --version` probe before every update (an extra process spawn on every operation to catch a failure the update itself already reports one moment later, now legibly), and preferring a specific hardcoded wrapper path (a guess about one host's private layout, which the market has no way to keep true).

Tests: `tests/pnpm-compat.spec.ts` for the classification, including that it never outranks a failure pnpm itself reported; `tests/install.spec.ts` for the output replacement and for `pnpmNeverStarted`. 1264 passed locally.
