### PR TITLE
fix: keep "restart to apply" after the page reloads, and measure it against a real host (#491)

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -299,6 +299,22 @@ export function mountMarketRoutes(
   const marketState = readMarketState(activeProfileDir)
   setCustomGithubProxy(marketState.githubProxy ?? null)
   const disabled = marketState.disabled
+  /**
+   * Packages whose files were replaced while their host half was already
+   * running, this process only.
+   *
+   * Replacing a package on disk does not unload the module Node has already
+   * imported — measured against a real host in tests/web/update.e2e.ts, where
+   * 2.0.0 is on disk and the process keeps answering as 1.0.0. The update
+   * REPLY says so, but the installed listing recomputed activation from the
+   * loader's inventory alone, and the loader still lists the name: so the
+   * moment the page refreshed, a plugin serving its old build read as `live`
+   * and the restart notice vanished.
+   *
+   * Deliberately not persisted. What it records is a fact about THIS
+   * process, and a restart — the thing that resolves it — ends the process.
+   */
+  const replacedWhileLive = new Set<string>()
   const groups = marketState.groups
   const groupOrder = marketState.groupOrder
   // A choice made in a previous session outranks whatever the entry layer
@@ -492,6 +508,11 @@ export function mountMarketRoutes(
         const result = await hotMount(host, dir, name)
         ok = result.ok
         reason = result.reason ?? undefined
+        // A mount that succeeded imported the module as it is on disk NOW,
+        // so whatever was replaced under the old instance is no longer what
+        // this process is serving. Off-and-on is a real way out of the
+        // restart notice, and holding it after that would be wrong.
+        if (result.ok) replacedWhileLive.delete(name)
       }
     } else {
       ok = await hotUnmount(name) || await themes.setEntryDisabled(name, true)
@@ -881,6 +902,7 @@ export function mountMarketRoutes(
     const hot = unmounted || entryDisabled
     removeRowBlocks(userPatchPath, rowIdsForPackage(host, activeProfileDir, name))
     disabled.delete(name)
+    replacedWhileLive.delete(name)
     removeFromGroups({ groups, groupOrder }, name)
     writeMarketState(activeProfileDir, { disabled, groups, groupOrder })
     return { ok: true, hot, detail: null }
@@ -1595,8 +1617,11 @@ export function mountMarketRoutes(
         const activation: Record<string, ReturnType<typeof verifyActivation>> = {}
         const live = liveNames()
         for (const name of Object.keys(installed)) {
-          activation[name] = verifyActivation(config.profile, name, live, activeProfileDir,
-            disabled.has(name) || patchFlags.disabled.includes(name))
+          activation[name] = activationAfterReplace(
+            verifyActivation(config.profile, name, live, activeProfileDir,
+              disabled.has(name) || patchFlags.disabled.includes(name)),
+            replacedWhileLive.has(name),
+          )
         }
         const diagnostics = diagnosePackageManifests(Object.keys(installed).map(packageName => ({
           packageName,
@@ -2670,6 +2695,7 @@ sendJson(response, 200, { updates })
             if (patchDisabled) await themes.setEntryDisabled(targetName, true)
 
             invalidateUpdates()
+            if (wasLive) replacedWhileLive.add(targetName)
             const activation = {
               [targetName]: activationAfterReplace(
                 verifyActivation(config.profile, targetName, liveNames(), activeProfileDir, disabled.has(targetName)),
@@ -3194,6 +3220,10 @@ sendJson(response, 200, { updates })
             } | undefined
             if (ok) {
               invalidateUpdates()
+              // Remembered, not just reported: the listing recomputes
+              // activation on every page load and would otherwise call this
+              // live again the moment the user refreshed.
+              if (wasLive) replacedWhileLive.add(name)
               activation = {
                 [name]: activationAfterReplace(
                   verifyActivation(config.profile, name, liveNames(), activeProfileDir, disabled.has(name)),

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -1245,6 +1245,33 @@ describe('update flow — no npm publishing required', () => {
     expect(r.json.activation['dsh-loop']).toMatchObject({ state: 'restart', hot: false })
   })
 
+  it('keeps saying "restart to apply" on every later listing, not only in the reply', async () => {
+    // The reply is read once; the listing is read on every page load. It
+    // recomputed activation from the loader's inventory alone — which still
+    // lists the name, because the process never unloaded the module — so a
+    // refresh turned the notice back into "live" and the update looked
+    // finished while the old build was still answering. Measured against a
+    // real host in tests/web/update.e2e.ts.
+    advanceNpmLatest('1.2.0')
+    await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+
+    const listed = await bed.dispatch('GET', '/dsh-market/installed')
+    expect(listed.json.activation['dsh-loop']).toMatchObject({ state: 'restart', hot: false })
+  })
+
+  it('drops the restart notice once the plugin is genuinely remounted', async () => {
+    // Off and on again imports the module as it is on disk now, so this
+    // process really is serving the new build — the one way out of the
+    // notice that is not a restart, and it has to be honoured.
+    advanceNpmLatest('1.2.0')
+    await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+    await bed.dispatch('POST', '/dsh-market/toggle', { name: 'dsh-loop', enabled: false })
+    await bed.dispatch('POST', '/dsh-market/toggle', { name: 'dsh-loop', enabled: true })
+
+    const listed = await bed.dispatch('GET', '/dsh-market/installed')
+    expect(listed.json.activation['dsh-loop']?.state).toBe('live')
+  })
+
   it('refuses an update before mutation when package.json cannot be captured exactly', async () => {
     const manifestPath = join(fake.profileDir, 'package.json')
     const malformed = JSON.stringify({

--- a/tests/web/fixtures/fixture-a/index.js
+++ b/tests/web/fixtures/fixture-a/index.js
@@ -13,10 +13,26 @@
  * registered here outlive the plugin's disposal, and a probe built on one
  * reports a disabled plugin as still alive.
  */
-import { writeFileSync, rmSync } from 'node:fs'
+import { writeFileSync, rmSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 export const name = 'dshm-e2e-fixture-a'
+
+/**
+ * The version of the build that is actually RUNNING, read from the copy of
+ * package.json this module was loaded beside.
+ *
+ * Written into the marker so an update can be observed from outside: after
+ * the market replaces this package on disk under a running host, a marker
+ * still naming the old version proves the old module is what the process is
+ * serving, and one naming the new version proves the host reloaded (#491).
+ * `activation[name].state` is the market's own inference and cannot settle
+ * that question about itself.
+ */
+const version = JSON.parse(
+  readFileSync(join(fileURLToPath(new URL('.', import.meta.url)), 'package.json'), 'utf8'),
+).version
 
 const marker = () => join(process.env.DSH_HOME ?? '.', `e2e-${name}.alive`)
 
@@ -25,7 +41,7 @@ export function apply(ctx) {
     // ctx.effect is how this host models a disposable side effect: the
     // returned function runs when the plugin is unloaded.
     host.effect(() => {
-      writeFileSync(marker(), String(Date.now()))
+      writeFileSync(marker(), version)
       return () => { rmSync(marker(), { force: true }) }
     }, `${name}: e2e liveness marker`)
   })

--- a/tests/web/registry.ts
+++ b/tests/web/registry.ts
@@ -17,7 +17,7 @@ import { createServer } from 'node:http'
 import type { Server } from 'node:http'
 import { createHash } from 'node:crypto'
 import { execSync } from 'node:child_process'
-import { readFileSync, readdirSync } from 'node:fs'
+import { cpSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Registry, RegistryPlugin } from '../../src/registry.ts'
@@ -37,8 +37,14 @@ export interface ServedPackage {
  * Pack a fixture directory into `destination` and describe it for the
  * registry. Uses `npm pack` so the tarball layout is the real thing.
  */
-export function packFixture(dir: string, destination: string): ServedPackage {
-  const source = join(FIXTURE_ROOT, dir)
+export function packFixture(dir: string, destination: string, version?: string): ServedPackage {
+  // A second version of the same fixture is packed from a COPY with its
+  // version rewritten, so one fixture directory can play both sides of an
+  // update. Copying rather than editing in place keeps the checked-in
+  // fixture at its own version, which several specs install by name.
+  const source = version === undefined
+    ? join(FIXTURE_ROOT, dir)
+    : versionedCopy(dir, destination, version)
   // execSync, not execFileSync: on Windows `npm` is npm.cmd, a batch shim
   // that cannot be spawned without a shell — the same trap the market's own
   // tool spawning handles (#2/#3/#5/#80). Node reports it as ENOENT on
@@ -49,6 +55,16 @@ export function packFixture(dir: string, destination: string): ServedPackage {
   const file = readdirSync(destination).find(entry => entry.startsWith(prefix) && entry.endsWith('.tgz'))
   if (file === undefined) throw new Error(`npm pack produced no tarball for ${dir}`)
   return { name: String(manifest.name), tarball: join(destination, file), manifest }
+}
+
+/** The same fixture directory at a different version, in a temp copy. */
+function versionedCopy(dir: string, destination: string, version: string): string {
+  const target = join(destination, `${dir}@${version}`)
+  cpSync(join(FIXTURE_ROOT, dir), target, { recursive: true })
+  const manifestPath = join(target, 'package.json')
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>
+  writeFileSync(manifestPath, `${JSON.stringify({ ...manifest, version }, null, 2)}\n`)
+  return target
 }
 
 /** A catalog entry pointing at a served package, shaped like a real one. */
@@ -72,17 +88,32 @@ export interface FixtureRegistry {
   npmUrl: string
   /** Value for DSHM_REGISTRY_URL — the market's curated catalog. */
   catalogUrl: string
+  /**
+   * Move a package's `latest` dist-tag, the way an author publishing a new
+   * release does.
+   *
+   * A spec that wants to test UPDATING cannot simply serve two versions and
+   * install the older one: installing by name resolves `latest`. Publishing
+   * in two steps is also what actually happens to a user — they are running
+   * the version that was current when they installed.
+   */
+  setLatest(name: string, version: string): void
   close(): Promise<void>
 }
 
 export async function startFixtureRegistry(packages: ServedPackage[]): Promise<FixtureRegistry> {
+  // One catalog entry per NAME, not per served package: a fixture published
+  // at two versions is still one plugin, and listing it twice would make the
+  // market's own duplicate handling the thing under test.
+  const names = [...new Set(packages.map(pkg => pkg.name))]
   const catalog: Registry = {
     updated: '2026-01-01',
-    count: packages.length,
+    count: names.length,
     categories: { testing: { en: 'Testing', zh: '测试' } },
-    plugins: packages.map(catalogEntry),
+    plugins: names.map(name => catalogEntry(packages.find(pkg => pkg.name === name)!)),
   }
 
+  const latestFor = new Map<string, string>()
   const server: Server = createServer((request, response) => {
     const url = new URL(request.url ?? '/', 'http://127.0.0.1')
     if (url.pathname === '/plugins.json') {
@@ -96,31 +127,72 @@ export async function startFixtureRegistry(packages: ServedPackage[]): Promise<F
       response.end(readFileSync(tarball.tarball))
       return
     }
-    const pkg = packages.find(
+    // `/{name}/latest` and `/{name}/{version}` are the abbreviated manifest
+    // endpoints, and the market's update check reads the first of them —
+    // serving only the full packument sent every fixture update check
+    // upstream to the public registry, where it 404s and the market
+    // truthfully reports "no update" for a package that exists only here.
+    const abbreviated = packages.filter(candidate => {
+      const prefix = `/${candidate.name}/`
+      return url.pathname.startsWith(prefix) && !url.pathname.startsWith(`${prefix}-/`)
+    })
+    if (abbreviated.length > 0) {
+      const wanted = url.pathname.slice(`/${abbreviated[0]!.name}/`.length)
+      const version = wanted === 'latest'
+        ? latestFor.get(abbreviated[0]!.name) ?? String(abbreviated[abbreviated.length - 1]!.manifest.version)
+        : wanted
+      const pkg = abbreviated.find(candidate => String(candidate.manifest.version) === version)
+      if (pkg === undefined) {
+        response.writeHead(404, { 'content-type': 'application/json' })
+        response.end(JSON.stringify({ error: 'version not found' }))
+        return
+      }
+      const bytes = readFileSync(pkg.tarball)
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({
+        ...pkg.manifest,
+        dist: {
+          tarball: `http://127.0.0.1:${String(addressPort(server))}/${pkg.name}/-/${basename(pkg.tarball)}`,
+          shasum: createHash('sha1').update(bytes).digest('hex'),
+          integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
+        },
+      }))
+      return
+    }
+    const served = packages.filter(
       candidate => url.pathname === `/${candidate.name}` || url.pathname === `/${encodeURIComponent(candidate.name)}`,
     )
-    if (pkg === undefined) {
+    if (served.length === 0) {
       response.writeHead(302, { location: `${UPSTREAM}${url.pathname}` })
       response.end()
       return
     }
-    const bytes = readFileSync(pkg.tarball)
     const port = addressPort(server)
-    const version = String(pkg.manifest.version)
+    const versions: Record<string, unknown> = {}
+    for (const pkg of served) {
+      const bytes = readFileSync(pkg.tarball)
+      versions[String(pkg.manifest.version)] = {
+        ...pkg.manifest,
+        dist: {
+          tarball: `http://127.0.0.1:${String(port)}/${pkg.name}/-/${basename(pkg.tarball)}`,
+          shasum: createHash('sha1').update(bytes).digest('hex'),
+          integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
+        },
+      }
+    }
+    // The LAST one listed is `latest` until a spec moves the tag, so the
+    // order fixtures are passed in spells the starting point rather than a
+    // version-compare rule this file would have to keep true.
+    const latest = latestFor.get(served[0]!.name) ?? String(served[served.length - 1]!.manifest.version)
     response.writeHead(200, { 'content-type': 'application/json' })
     response.end(JSON.stringify({
-      name: pkg.name,
-      'dist-tags': { latest: version },
-      versions: {
-        [version]: {
-          ...pkg.manifest,
-          dist: {
-            tarball: `http://127.0.0.1:${String(port)}/${pkg.name}/-/${basename(pkg.tarball)}`,
-            shasum: createHash('sha1').update(bytes).digest('hex'),
-            integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
-          },
-        },
-      },
+      name: served[0]!.name,
+      'dist-tags': { latest },
+      // Real packuments carry publish times, and the market reads them
+      // (#45) before offering an update. Dated in the past so a fixture
+      // "published" this second is not held back as too young.
+      time: Object.fromEntries(Object.keys(versions).map(v => [v, '2026-01-01T00:00:00.000Z'])),
+      versions,
     }))
   })
 
@@ -129,6 +201,7 @@ export async function startFixtureRegistry(packages: ServedPackage[]): Promise<F
   return {
     npmUrl: `${base}/`,
     catalogUrl: `${base}/plugins.json`,
+    setLatest: (name: string, version: string): void => { latestFor.set(name, version) },
     close: () => new Promise<void>(done => { server.close(() => { done() }) }),
   }
 }

--- a/tests/web/scaffold.ts
+++ b/tests/web/scaffold.ts
@@ -68,6 +68,11 @@ export interface WebScaffold {
   home: string
   /** Stop dsh and boot it again on the same DSH_HOME, same port. */
   restart(): Promise<void>
+  /**
+   * Move a fixture's `latest` dist-tag — an author publishing a release
+   * while the user is running the previous one. Throws without fixtures.
+   */
+  publish(name: string, version: string): void
   close(): Promise<void>
 }
 
@@ -364,8 +369,12 @@ export interface ScaffoldOptions {
    * Fixture directories under `tests/web/fixtures` to publish to a local
    * npm registry and list in a curated catalog the market is pointed at.
    * With this set the specs can drive the REAL install route end to end.
+   *
+   * `{ dir, version }` publishes the same fixture directory again under a
+   * different version, which is how a spec gets something to update TO. The
+   * last entry for a name is the registry's `latest`.
    */
-  fixtures?: string[]
+  fixtures?: (string | { dir: string; version: string })[]
 }
 
 function run(command: string, env: NodeJS.ProcessEnv, cwd: string = REPO_ROOT): void {
@@ -421,7 +430,9 @@ export async function launchMarketScaffold(options: ScaffoldOptions = {}): Promi
   // specs install go through real resolution without touching the network.
   let registry: FixtureRegistry | null = null
   if (options.fixtures !== undefined && options.fixtures.length > 0) {
-    registry = await startFixtureRegistry(options.fixtures.map(dir => packFixture(dir, home)))
+    registry = await startFixtureRegistry(options.fixtures.map(
+      entry => typeof entry === 'string' ? packFixture(entry, home) : packFixture(entry.dir, home, entry.version),
+    ))
     writeFileSync(
       join(home, 'profiles', 'web', '.npmrc'),
       // minimum-release-age=0: a fixture "published" seconds ago would
@@ -431,7 +442,18 @@ export async function launchMarketScaffold(options: ScaffoldOptions = {}): Promi
     // npm_config_registry OUTRANKS .npmrc, and `npm run test:web` puts the
     // caller's registry there — so the file alone silently sends pnpm to the
     // public registry, where a fixture does not exist. Set both.
-    env = { ...env, DSHM_REGISTRY_URL: registry.catalogUrl, npm_config_registry: registry.npmUrl }
+    // DSHM_NPM_MIRROR as well as the pnpm registry: the market reads package
+    // METADATA itself (update checks, #45's publish times) through its own
+    // region routing table, which npm_config_registry does not touch. Without
+    // it a fixture's update check goes to the public registry, 404s, and the
+    // market truthfully reports "no update" for a package that only exists
+    // here — a green run that asserted nothing.
+    env = {
+      ...env,
+      DSHM_REGISTRY_URL: registry.catalogUrl,
+      npm_config_registry: registry.npmUrl,
+      DSHM_NPM_MIRROR: registry.npmUrl.replace(/\/+$/, ''),
+    }
   }
 
   const port = await freePort()
@@ -531,6 +553,10 @@ export async function launchMarketScaffold(options: ScaffoldOptions = {}): Promi
       launched = await boot()
       child = launched.child
       processLaunchUrl = launched.processLaunchUrl
+    },
+    publish: (name: string, version: string): void => {
+      if (registry === null) throw new Error('no fixture registry — pass `fixtures` to launchMarketScaffold')
+      registry.setLatest(name, version)
     },
     close: async () => {
       await registry?.close()

--- a/tests/web/update.e2e.ts
+++ b/tests/web/update.e2e.ts
@@ -1,0 +1,124 @@
+/**
+ * Layer 3 — the REAL update chain, against a running host.
+ *
+ * install.e2e.ts proves a plugin can be put in place and made live. What it
+ * cannot answer is what happens to a plugin that is ALREADY live when its
+ * files are replaced underneath it, and that is where the update bugs live:
+ * #491 (a loader entry re-imported into a mix of old and new instances),
+ * #495 (a second update of something already current), #496 (a version
+ * resolved twice and rolled back for disagreeing with itself).
+ *
+ * The one question a fake host can never settle is whether the RUNNING
+ * process picked up the new files. The market's `activation[name].state` is
+ * its own inference about that — the inference #103, #135 and #147 all got
+ * wrong — so it is asserted against the fixture's marker, never trusted as
+ * ground truth. The marker names the version of the module the process is
+ * actually serving.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { dshAvailable, launchMarketScaffold } from './scaffold.ts'
+import type { WebScaffold } from './scaffold.ts'
+
+const HAS_DSH = dshAvailable()
+const A = 'dshm-e2e-fixture-a'
+
+describe.skipIf(!HAS_DSH).sequential('web e2e: the real update chain', () => {
+  let scaffold: WebScaffold
+  let base: string
+
+  beforeAll(async () => {
+    // The same fixture twice: 1.0.0 to install, 2.0.0 to update to. 1.0.0 is
+    // `latest` to begin with, because installing by name resolves the tag —
+    // and because that is the user's actual position: running whatever was
+    // current when they installed.
+    scaffold = await launchMarketScaffold({
+      fixtures: [{ dir: 'fixture-a', version: '2.0.0' }, { dir: 'fixture-a', version: '1.0.0' }],
+    })
+    base = scaffold.baseUrl
+  }, 600_000)
+
+  afterAll(async () => { await scaffold?.close() })
+
+  const post = async (path: string, body: unknown): Promise<Response> =>
+    fetch(`${base}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: base },
+      body: JSON.stringify(body),
+    })
+
+  const get = async (path: string): Promise<any> => (await fetch(`${base}${path}`)).json()
+
+  /** The version the RUNNING process is serving, or null when not live. */
+  const liveVersion = (): string | null => {
+    const marker = join(scaffold.home, `e2e-${A}.alive`)
+    return existsSync(marker) ? readFileSync(marker, 'utf8').trim() : null
+  }
+
+  it('installs the fixture at 1.0.0 and runs it', async () => {
+    const installed = await post('/dsh-market/install', { url: `https://github.com/dshm-e2e/${A}` })
+    expect(installed.status).toBe(200)
+    expect(liveVersion()).toBe('1.0.0')
+  }, 300_000)
+
+  it('offers 2.0.0 as an update once it is published', async () => {
+    scaffold.publish(A, '2.0.0')
+    const updates = await get('/dsh-market/updates?force=1')
+    expect(updates.updates[A]).toMatchObject({ kind: 'npm', current: '1.0.0', latest: '2.0.0', updateAvailable: true })
+  }, 120_000)
+
+  it('replaces the files but leaves the running process on the old module', async () => {
+    const updated = await post('/dsh-market/update', { name: A })
+    expect(updated.status).toBe(200)
+    expect(await updated.json()).toMatchObject({ ok: true })
+
+    // 2.0.0 is on disk…
+    const installedPkg = JSON.parse(
+      readFileSync(join(scaffold.home, 'profiles', 'web', 'node_modules', A, 'package.json'), 'utf8'),
+    ) as { version: string }
+    expect(installedPkg.version).toBe('2.0.0')
+
+    // …and the process is still serving 1.0.0, because replacing a package
+    // on disk does not unload the module Node already imported. This is the
+    // fact the market's "restart to apply" verdict rests on; measuring it
+    // here is what makes that verdict a claim about the host rather than
+    // about our model of it.
+    expect(liveVersion()).toBe('1.0.0')
+  }, 300_000)
+
+  it('says so, rather than reporting the update as live', async () => {
+    // #491: the danger is a host that re-imports the entry into a process
+    // still holding the old instances. If this host ever starts doing that,
+    // the marker above flips to 2.0.0 and this suite fails loudly — which is
+    // the point of writing the marker with a version rather than a
+    // timestamp.
+    const state = await get('/dsh-market/installed')
+    expect(state.activation[A]?.state).toBe('restart')
+    expect(state.activation[A]?.hot).toBe(false)
+  }, 120_000)
+
+  it('keeps saying so across a page refresh, not just in the update reply', async () => {
+    // The reply is a one-shot; the listing is what every later page load
+    // reads. Recomputing activation from the loader's inventory alone made
+    // the notice disappear on refresh, leaving a plugin that serves its old
+    // build looking finished and current.
+    const again = await get('/dsh-market/installed')
+    expect(again.activation[A]?.state).toBe('restart')
+    expect(liveVersion()).toBe('1.0.0')
+  }, 120_000)
+
+  it('is live on the new build after a restart, with the notice gone', async () => {
+    await scaffold.restart()
+    expect(liveVersion()).toBe('2.0.0')
+    const state = await get('/dsh-market/installed')
+    expect(state.activation[A]?.state).toBe('live')
+  }, 300_000)
+
+  it('treats a second update of the now-current plugin as a skip, not a failure (#495)', async () => {
+    const again = await post('/dsh-market/update', { name: A })
+    expect(again.status).toBe(200)
+    expect(await again.json()).toMatchObject({ ok: true, skipped: 'current', version: '2.0.0' })
+  }, 300_000)
+})


### PR DESCRIPTION
Addresses the half of #491 that is the market's, and adds the lane that found it.

**What was measured.** New layer-3 e2e (`tests/web/update.e2e.ts`) drives the real update chain against a real `dsh web`: install fixture-a 1.0.0, publish 2.0.0, update, and ask the *running process* which build it is serving. The fixture's liveness marker now carries the version it was loaded as, read from the package.json beside it — so this is ground truth, not the market's own inference about itself.

Result: **2.0.0 on disk, 1.0.0 still answering.** Replacing a package does not unload the module Node already imported. That is exactly what the market's "restart to apply" verdict claims, and it now has a measurement behind it instead of a model.

**The bug.** That verdict was only in the update *reply*. The installed listing recomputed activation from the loader's inventory alone — and the loader still lists the name — so the first page refresh turned the row back to `live`. The update looked finished while the old code was still answering every request. @eddiedon's report is the sharper end of the same window; this is the part that is ours.

Fixed by remembering, for the life of the process, which packages were replaced while their host half was live, and applying the correction wherever activation is computed. Cleared on a genuine remount (off-and-on imports what is on disk now — the one way out that is not a restart) and on uninstall. Not persisted: it is a fact about this process, and the thing that resolves it ends the process.

**Lane changes.**
- The fixture registry serves several versions of one package, serves the abbreviated `/{name}/latest` manifest the market's update check actually reads, and can move a dist-tag — so a spec can install 1.0.0 and have 2.0.0 published underneath it, which is the user's real position.
- The scaffold points `DSHM_NPM_MIRROR` at the fixture registry too. The market reads package metadata through its own region routing, which `npm_config_registry` does not touch; without it every fixture update check went to the public registry, 404'd, and the market truthfully reported "no update" — a green run that asserted nothing.

The same lane also covers #495's skip and #496's pin against a real host, and it is where a host that *does* re-import a live entry would surface as a failing test rather than as a bug report.

7 new e2e (37 total in the lane), 1260 unit.
