### PR TITLE
fix: name the dead local dependency that blocks the whole profile (#436)

### DIFF
--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -47,7 +47,7 @@ export interface PnpmFailure {
   code: 'adding-to-root' | 'not-a-workspace' | 'hoist-pattern-diff' | 'pnpm-missing' | 'release-age-violation'
     | 'ignored-builds' | 'git-prepare-not-allowed' | 'fetch-404' | 'transient-network' | 'fetch-timeout'
     | 'unexpected-store' | 'patch-failed' | 'missing-tarball-integrity' | 'windows-file-locked'
-    | 'pnpm-unusable'
+    | 'pnpm-unusable' | 'missing-local-dependency'
   /** Bilingual, actionable message shown to the user instead of the raw wall of text. */
   message: string
   /** True when re-running `pnpm install` in the profile is the documented recovery. */
@@ -387,6 +387,27 @@ export function classifyPnpmFailure(output: string, exitCode?: number | null): P
       code: 'pnpm-missing',
       recoverable: false,
       message: '找不到 pnpm，请先在市场页顶部一键安装组件 / pnpm is not on PATH — use the one-click setup at the top of the market page',
+    }
+  }
+  // Reported by @screamff on #436: a `file:` dependency whose tarball or
+  // directory is no longer on disk. pnpm re-resolves every direct dependency
+  // before ANY mutation, so one dead local path blocks every install and
+  // uninstall in the profile — including uninstalling the market, which is
+  // what the reporter was trying to do. Same family as the #65 ghost
+  // registry entry; the local form has its own error, and it names the PATH
+  // rather than the package, which is why "a plugin is missing" was never a
+  // usable description of it.
+  //
+  // Measured on pnpm 10.28.2 and 11.21.0 (both exit 254): the wording only
+  // differs in how the code is bracketed, and both carry the path and the
+  // "direct dependency" line. Both are required — an ENOENT from a build
+  // script is a different failure and must not wear this explanation.
+  const localMiss = /ENOENT: no such file or directory, open '([^']+)'/.exec(output)
+  if (localMiss !== null && output.includes('while installing a direct dependency')) {
+    return {
+      code: 'missing-local-dependency',
+      recoverable: false,
+      message: `profile 里有一个从本地文件安装的插件，它的文件已经不在了（${localMiss[1]}）。pnpm 在做任何改动前都会重新解析全部直接依赖，所以这一条会挡住这个 profile 里的所有安装和卸载——包括卸载别的插件。请在 profile 的 package.json 的 dependencies 里删掉值等于上面这个路径的那一行（或在市场的「已安装」里卸载它），然后重试。 / a plugin in this profile was installed from a local file that no longer exists (${localMiss[1]}). pnpm re-resolves every direct dependency before making any change, so this one entry blocks every install and uninstall in the profile — including uninstalling other plugins. Remove the dependency whose value is that path from the profile's package.json (or uninstall it from the market's Installed list) and retry.`,
     }
   }
   // #502 by @Ztyss: a pnpm WAS found on PATH and could not be started.

--- a/tests/pnpm-behavior.compat.spec.ts
+++ b/tests/pnpm-behavior.compat.spec.ts
@@ -242,3 +242,31 @@ describe('#39 — a too-young lockfile entry blocks every later mutation', () =>
     }
   })
 })
+
+describe('a dead file: dependency blocks the whole profile (#436)', () => {
+  // @screamff could not uninstall the market until they removed an unrelated
+  // plugin that had been installed from a .tgz they had since deleted. pnpm
+  // re-resolves every direct dependency before any mutation, so one dead
+  // local path stops everything — and the error names the PATH, never the
+  // package, which is why it read as unrelated to what they were doing.
+  for (const version of [PNPM[10], PNPM[11]]) {
+    it(`pnpm ${version} refuses to remove an unrelated package, and the market names the cause`, () => {
+      const dir = profileFixture({ workspace: true })
+      expect(pnpm(version, ['add', '-w', 'is-odd@3.0.0'], dir).code).toBe(0)
+      const manifestPath = join(dir, 'package.json')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { dependencies?: Record<string, string> }
+      const ghost = join(dir, 'gone', 'ghost-plugin-1.0.0.tgz')
+      manifest.dependencies = { ...manifest.dependencies, 'ghost-plugin': `file:${ghost}` }
+      writeFileSync(manifestPath, JSON.stringify(manifest))
+
+      const blocked = pnpm(version, ['remove', '-w', 'is-odd'], dir)
+
+      expect(blocked.code, blocked.out.slice(-400)).not.toBe(0)
+      const failure = classifyPnpmFailure(blocked.out, blocked.code)
+      expect(failure?.code, blocked.out.slice(-400)).toBe('missing-local-dependency')
+      // The path is the only handle the user has: it is the literal value of
+      // the offending line in their package.json.
+      expect(failure?.message).toContain('ghost-plugin-1.0.0.tgz')
+    }, 300_000)
+  }
+})

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -358,3 +358,34 @@ describe('a pnpm that exists on PATH but cannot be started (#502)', () => {
     expect(classifyPnpmFailure('some other failure', 1)).toBeNull()
   })
 })
+
+describe('a local file: dependency whose file is gone (#436)', () => {
+  // Measured against real pnpm 10.28.2 and 11.21.0, both exit 254. Only the
+  // bracketing of the code differs; both carry the path and the direct-
+  // dependency line.
+  const PNPM_10 = " ENOENT  ENOENT: no such file or directory, open '/home/u/dl/dsh-sandbox-escalation-fix-0.1.2-alpha1.tgz'\n\nThis error happened while installing a direct dependency of /home/u/.dsh/profiles/web\n"
+  const PNPM_11 = "[ENOENT] ENOENT: no such file or directory, open '/home/u/dl/dsh-sandbox-escalation-fix-0.1.2-alpha1.tgz'\n\nThis error happened while installing a direct dependency of /home/u/.dsh/profiles/web\n"
+
+  it('is recognized on both pnpm majors, and names the path', () => {
+    for (const output of [PNPM_10, PNPM_11]) {
+      const failure = classifyPnpmFailure(output, 254)
+      expect(failure?.code).toBe('missing-local-dependency')
+      expect(failure?.recoverable).toBe(false)
+      expect(failure?.message).toContain('dsh-sandbox-escalation-fix-0.1.2-alpha1.tgz')
+    }
+  })
+
+  it('says the entry blocks operations on OTHER plugins, which is how it is met', () => {
+    // The reporter hit it while uninstalling the market, not while touching
+    // the dead entry — "this plugin is broken" would have been useless.
+    const message = classifyPnpmFailure(PNPM_11, 254)?.message ?? ''
+    expect(message).toContain('包括卸载别的插件')
+    expect(message).toContain('blocks every install and uninstall')
+  })
+
+  it('does not claim an ENOENT that is not about a profile dependency', () => {
+    // A build script opening a missing file is a different failure and must
+    // keep pnpm's own words.
+    expect(classifyPnpmFailure("ENOENT: no such file or directory, open '/tmp/whatever'", 1)).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes the second half of #436 (the boot failure it was opened for shipped in 1.39.0 via #437).

@screamff could not uninstall the market. The cause turned out to be an unrelated plugin installed earlier from a `.tgz` they had since deleted:

```
dsh-sandbox-escalation-fix@0.1.2-alpha1
  file:~/下载/…/dsh-sandbox-escalation-fix-0.1.2-alpha1.tgz   ← gone
```

pnpm re-resolves every direct dependency before **any** mutation, so one dead `file:` path stops every install and uninstall in the profile. They worked it out by hand — list the profile's plugins, remove the dead one first, then the market.

What the market showed them was pnpm's raw ENOENT, which names the **path** and never the package, so it read as unrelated to the uninstall they had asked for. Now it says what it blocks (everything, including other plugins), why, and the one line to delete — quoted with the path, which is literally the value of that line in `package.json`.

**Measured, not inferred.** Real pnpm 10.28.2 and 11.21.0, both exit 254, differing only in how the code is bracketed:

```
 ENOENT  ENOENT: no such file or directory, open '…/ghost-1.0.0.tgz'      ← pnpm 10
[ENOENT] ENOENT: no such file or directory, open '…/ghost-1.0.0.tgz'      ← pnpm 11

This error happened while installing a direct dependency of <profile>
```

Pinned in the compat lane against both majors, so a pnpm reword breaks a test rather than the user's error message. Both halves of the signature are required — an ENOENT from a build script is a different failure and keeps pnpm's own words.

Same family as #65's ghost registry entry, which has had a message since; the local form did not.
