### PR TITLE
fix: an uninstall that cannot release a native addon says so (#441)

### DIFF
--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -332,16 +332,29 @@ export function classifyPnpmFailure(output: string, exitCode?: number | null): P
   }
   // #389 by @qq1054435284: on Windows, pnpm stages the new version in a
   // sibling `<name>_tmp_<pid>_<n>` directory and renames it over the old one.
-  // Windows refuses that rename while any file underneath the target is open
-  // — and for an UPDATE the target is a plugin the running dsh has loaded, so
-  // its own files are exactly the ones held open. POSIX does not have this
-  // problem: replacing an open file there leaves the old inode alive for
-  // whoever still holds it.
+  // Windows refuses that rename while any file underneath the target is open,
+  // and the process holding them is usually the one asking. POSIX does not
+  // have this problem: replacing an open file there leaves the old inode
+  // alive for whoever still holds it.
+  //
+  // Worded for the RENAME, not for an update (#441 by @yandidan1). The
+  // reporter met this while INSTALLING — a reinstall of a plugin they had
+  // just uninstalled — and was told their update had not applied, that their
+  // existing version was intact, and to disable the plugin under Installed,
+  // which they had already removed. The package pnpm names here is also not
+  // necessarily a plugin: theirs was `node-hid`, a dependency.
+  //
+  // The native-module sentence is the part that makes the advice usable in
+  // that case. Node never unloads a native addon: once a `.node` is loaded
+  // there is no dlclose, so disabling the plugin, unmounting it, or
+  // uninstalling it cannot release the file — only ending the process does.
+  // That is why "uninstall, then install again" fails on Windows for those
+  // plugins while it works for every other one.
   //
   // Not retried automatically. A retry from inside the same process cannot
   // win, because that process is the thing holding the handles; retrying
   // would only turn one clear failure into several slow ones. So this names
-  // the cause and the two ways out instead of guessing.
+  // the cause and the ways out instead of guessing.
   if (/ERR_PNPM_EPERM|EPERM: operation not permitted, rename/i.test(output)) {
     // Read through the NDJSON reporter like the integrity classifier does:
     // in production this arrives JSON-escaped, so every separator is doubled
@@ -355,7 +368,7 @@ export function classifyPnpmFailure(output: string, exitCode?: number | null): P
       code: 'windows-file-locked',
       recoverable: false,
       ...(pkg === undefined ? {} : { pkg }),
-      message: `Windows 不允许替换正在被打开的文件，而更新一个插件${zh}要替换的正是当前 DeepSeek Harness 已经加载的那些文件，所以 pnpm 改名失败、更新没有生效（原来的版本没有被破坏，仍可正常使用）。两种做法：完全退出 DeepSeek Harness 后在命令行执行一次更新；或先在「已安装」里停用该插件、重启、再更新。杀毒软件或文件索引临时占用目录也会造成同样的报错，若上述都不适用可稍后重试 / Windows will not replace a file that is open, and updating a plugin${en} replaces exactly the files the running DeepSeek Harness has loaded, so pnpm's rename failed and the update did not apply (the existing version is intact and still works). Two ways round it: quit DeepSeek Harness completely and run the update from the command line, or disable the plugin under Installed, restart, then update. Antivirus or a file indexer holding the directory produces the same error, so a later retry is worth trying if neither applies`,
+      message: `Windows 不允许替换正在被打开的文件。pnpm 要用新目录替换${zh === '' ? '一个已装好的包' : ` ${pkg!}`}，而它的文件正被运行中的 DeepSeek Harness 打开着，改名因此失败，这一步没有生效——已经装好的内容没有被破坏。\n如果这个包带原生模块（.node 文件，例如 node-hid 这类），那么停用插件、甚至卸载插件都不够：原生模块一旦被加载，在进程退出前都不会释放。刚卸载完立刻重装同一个插件在 Windows 上失败，通常就是这个原因。\n可行的做法：完全退出 DeepSeek Harness（不是刷新页面），重新启动后再操作一次；或退出后在命令行执行。杀毒软件或文件索引临时占用目录也会报同样的错，若都不适用可稍后重试。 / Windows will not replace a file that is open. pnpm tried to swap a new directory over${en === '' ? ' an installed package' : en}, whose files the running DeepSeek Harness holds open, so the rename failed and this step did not apply — what was already installed is intact. If that package ships a native module (a .node file, node-hid and friends), disabling the plugin — even uninstalling it — is not enough: once a native module is loaded it is not released until the process exits, which is the usual reason reinstalling a plugin right after uninstalling it fails on Windows. What works: quit DeepSeek Harness completely (not a page refresh), start it again, and repeat the operation; or run it from the command line with the app closed. Antivirus or a file indexer holding the directory produces the same error, so a later retry is worth trying if neither applies.`,
     }
   }
   // #83: pnpm replays the WHOLE dependency tree on every add/remove, so a

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -260,6 +260,51 @@ export function readInstalledManifest(profile: string, name: string, explicitDir
   }
 }
 
+/**
+ * Whether a package or one of its direct dependencies ships a native addon.
+ *
+ * The question behind it: can unloading this plugin actually free its files?
+ * For ordinary JavaScript, yes — and on POSIX it does not even matter,
+ * because replacing an open file leaves the old inode to whoever holds it.
+ * For a native addon it is no on both counts: Node has no dlclose, so once a
+ * `.node` is loaded the process holds it until it exits. On Windows that
+ * turns "uninstall, then install again" into an EPERM on the rename, which
+ * is what @yandidan1 hit with node-hid (#441) — and no amount of disabling,
+ * unmounting or uninstalling from inside the running process can fix it.
+ *
+ * Deliberately a cheap structural check rather than a scan. Walking a
+ * dependency's tree for `*.node` means recursing through packages that can
+ * be tens of thousands of files, on the uninstall path, to answer a question
+ * three `existsSync` calls answer for every native module built or shipped
+ * the conventional way: node-gyp's `build/Release`, prebuild's `prebuilds/`,
+ * and the `binding.gyp` that names the addon in the first place.
+ *
+ * Direct dependencies are included because that is where these live: the
+ * plugin is JavaScript and the addon is a package it depends on, hoisted to
+ * the profile root beside it.
+ * @param profile - profile name.
+ * @param name - the installed package to ask about.
+ * @param explicitDir - resolved profile directory, when the caller has it.
+ * @returns true when a native addon is present in the package or a direct dependency.
+ */
+export function holdsNativeAddon(profile: string, name: string, explicitDir?: string): boolean {
+  const modules = join(profileDir(profile, explicitDir), 'node_modules')
+  const shipsAddon = (packageName: string): boolean => {
+    const dir = join(modules, packageName)
+    return existsSync(join(dir, 'build', 'Release'))
+      || existsSync(join(dir, 'prebuilds'))
+      || existsSync(join(dir, 'binding.gyp'))
+  }
+  if (shipsAddon(name)) return true
+  const manifest = readInstalledManifest(profile, name, explicitDir)
+  if (manifest === null || typeof manifest !== 'object') return false
+  const dependencies = (manifest as { dependencies?: unknown }).dependencies
+  if (dependencies === null || typeof dependencies !== 'object') return false
+  return Object.keys(dependencies as Record<string, unknown>)
+    .filter(dependency => PACKAGE_NAME_RE.test(dependency))
+    .some(shipsAddon)
+}
+
 const PACKAGE_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/i
 
 function localSpecDirectory(root: string, spec: string): string | null {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -28,7 +28,7 @@ import {
   BOOT_ID, cancelActive, probePnpm, progress, provisionPnpm, runDshPlugin, TARGET_RE,
   type PluginCommandRuntime,
 } from './dsh-cli.ts'
-import { addProfileBundle, dropFromManifest, hasLoadableEntry, INBOX_BUNDLES, isDshProfileName, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readProfileBundles, readProfileManifestSnapshot, removeProfileBundle, restoreProfileManifest, setAllowBuilds, type ProfileManifestSnapshot } from './profile.ts'
+import { addProfileBundle, dropFromManifest, hasLoadableEntry, holdsNativeAddon, INBOX_BUNDLES, isDshProfileName, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readProfileBundles, readProfileManifestSnapshot, removeProfileBundle, restoreProfileManifest, setAllowBuilds, type ProfileManifestSnapshot } from './profile.ts'
 import { assessProfile, classifyPeer, introducedDuplicateNames, introducedRisks, type CompatibilityRisk } from './compatibility.ts'
 import { runningAgentIds, type AgentsLookup } from './agents.ts'
 import { analyzeProfile, corePackageNames, type DuplicateName } from './check.ts'
@@ -890,6 +890,15 @@ export function mountMarketRoutes(
   }
 
   async function removeInstalledPackage(name: string): Promise<{ ok: boolean; hot: boolean; detail: string | null }> {
+    // Asked BEFORE the removal, while the files are still there to look at.
+    // A native addon is never released by unloading (#441): Node has no
+    // dlclose, so the process keeps the `.node` open until it exits, and on
+    // Windows the next install of the same plugin fails renaming over it.
+    // Reporting this uninstall as `hot` would be claiming it took effect
+    // without a restart, which for these is exactly what did not happen —
+    // and the page then tells the user to refresh, which is the one thing
+    // that cannot help.
+    const native = holdsNativeAddon(config.profile, name, activeProfileDir)
     const result = await runPlugin(config.profile, ['remove', name])
     if (result.exitCode !== 0 || result.timedOut || result.cancelled) {
       return { ok: false, hot: false, detail: failureDetail(result) }
@@ -899,7 +908,10 @@ export function mountMarketRoutes(
     // because the first succeeded.
     const unmounted = await hotUnmount(name)
     const entryDisabled = await themes.setEntryDisabled(name, true)
-    const hot = unmounted || entryDisabled
+    const hot = (unmounted || entryDisabled) && !native
+    if (native) {
+      logEvent('info', 'uninstall', `${name} ships or depends on a native addon; a restart is needed before it can be installed again`)
+    }
     removeRowBlocks(userPatchPath, rowIdsForPackage(host, activeProfileDir, name))
     disabled.delete(name)
     replacedWhileLive.delete(name)
@@ -3889,6 +3901,15 @@ sendJson(response, 200, { updates })
             // runPlugin the package may be gone from node_modules, so a post-hoc
             // check would always return false on a successful uninstall.
             const hadClientPart = packageHasClientPart(activeProfileDir, name)
+            // Also captured before the removal, and for the same reason: a
+            // native addon in this plugin or one of its dependencies is not
+            // released by unloading it (#441). Node has no dlclose, so the
+            // process holds the `.node` until it exits — and on Windows the
+            // next install of the same plugin then fails renaming over the
+            // copy this process is still holding. Calling such an uninstall
+            // `hot` would send the user to a page refresh, which is the one
+            // thing that cannot help.
+            const heldNativeAddon = holdsNativeAddon(config.profile, name, activeProfileDir)
             const result = await runPlugin(config.profile, ['remove', name])
             const cancelled = result.cancelled
             const ok = result.exitCode === 0 && !result.timedOut && !cancelled
@@ -3929,6 +3950,10 @@ sendJson(response, 200, { updates })
               // successful unmount costs a lookup and nothing else.
               const entryDisabled = await themes.setEntryDisabled(name, true)
               hot = hot || entryDisabled
+              if (heldNativeAddon && hot) {
+                logEvent('info', 'uninstall', `${name} ships or depends on a native addon, which this process cannot release — reporting the uninstall as needing a restart`)
+              }
+              hot = hot && !heldNativeAddon
               // Patch-layer rows must not survive the remove either: a
               // `- id: X` + `disabled: true` row for a package that no longer
               // mounts is a boot-time orphan (port of dsh-plugin-hub).

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -2985,6 +2985,28 @@ describe('local-dev restore flow', () => {
 })
 
 describe('uninstall flow', () => {
+  it('does not call the uninstall hot when a native addon is involved (#441)', async () => {
+    // Node has no dlclose: once a `.node` is loaded the process holds it
+    // until it exits, so unmounting the plugin does not release the file.
+    // Reporting `hot` would tell the page a refresh is enough — and on
+    // Windows the next install of the same plugin then fails renaming over
+    // the copy this process is still holding, which is what @yandidan1 hit.
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+    // The plugin is JavaScript; the addon is a dependency hoisted beside it.
+    const installedManifest = join(fake.profileDir, 'node_modules', 'dsh-loop', 'package.json')
+    const manifest = JSON.parse(readFileSync(installedManifest, 'utf8')) as Record<string, unknown>
+    writeFileSync(installedManifest, JSON.stringify({ ...manifest, dependencies: { 'node-hid': '3.4.0' } }))
+    mkdirSync(join(fake.profileDir, 'node_modules', 'node-hid', 'build', 'Release'), { recursive: true })
+    writeFileSync(join(fake.profileDir, 'node_modules', 'node-hid', 'package.json'), '{"name":"node-hid","version":"3.4.0"}')
+
+    const r = await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(200)
+    expect(r.json.hot).toBe(false)
+    expect(installedSpec('dsh-loop')).toBeUndefined()
+  })
+
   it('removes the plugin (live when hot mounted) and protects the market itself', async () => {
     fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
     await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -97,11 +97,31 @@ describe('classifyPnpmFailure', () => {
     expect(failed?.pkg).toBe('dsh-passwords')
     // Says which plugin, that nothing was broken, and what to do about it.
     expect(failed?.message).toContain('dsh-passwords')
-    expect(failed?.message).toContain('原来的版本没有被破坏')
+    expect(failed?.message).toContain('没有被破坏')
     expect(failed?.message).toContain('quit DeepSeek Harness')
     // Not retried: the process that would retry is the one holding the files.
     expect(failed?.recoverable).toBe(false)
     expect(failed?.message).not.toContain('undefined')
+  })
+
+  it('is worded for the rename, so it also fits a reinstall (#441)', () => {
+    // @yandidan1 met this while INSTALLING — a reinstall of a plugin they had
+    // just uninstalled — and the message told them their UPDATE had not
+    // applied and to disable the plugin under Installed, which no longer
+    // existed. The package pnpm names is a dependency, not their plugin.
+    const failed = classifyPnpmFailure(String.raw`{"name":"pnpm","level":"error","err":{"code":"ERR_PNPM_EPERM","message":"[importPackage C:\p\web\node_modules\node-hid] EPERM: operation not permitted, rename 'C:\p\web\node_modules\node-hid_tmp_9120_3' -> 'C:\p\web\node_modules\node-hid'"}}`)
+
+    expect(failed?.pkg).toBe('node-hid')
+    // Never calls the named package a plugin, and never says "update".
+    expect(failed?.message).not.toContain('更新')
+    expect(failed?.message).not.toMatch(/updating a plugin/)
+    // Names the reason disabling or uninstalling cannot help here.
+    expect(failed?.message).toContain('.node')
+    expect(failed?.message).toContain('刚卸载完立刻重装')
+    expect(failed?.message).toContain('native module')
+    // A page refresh is what the uninstall flow suggests, and it is exactly
+    // the thing that does not release a native module.
+    expect(failed?.message).toContain('not a page refresh')
   })
 
   it('classifies a locked rename with no readable package name (#389)', () => {

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -9,7 +9,7 @@ import { homedir, tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { resolveDshHome } from '../src/home-paths.ts'
 import {
-  addProfileBundle, conflictingEntryIds, dropFromManifest, entryArtifactExists, hasDshManifest, hasLoadableEntry, isDshProfileName, pluginSubdirs, profileDir,
+  addProfileBundle, conflictingEntryIds, dropFromManifest, entryArtifactExists, hasDshManifest, hasLoadableEntry, holdsNativeAddon, isDshProfileName, pluginSubdirs, profileDir,
   readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledRepoIdentities, readInstalledVersion, readLockCommits,
   removeProfileBundle,
 } from '../src/profile.ts'
@@ -147,6 +147,57 @@ describe('readInstalledManifest', () => {
     } finally {
       rmSync(explicitDir, { recursive: true, force: true })
     }
+  })
+})
+
+describe('holdsNativeAddon (#441)', () => {
+  /** Put a package in the profile's node_modules with the given layout. */
+  const packageAt = (dir: string, name: string, manifest: unknown, subdirs: string[] = [], files: string[] = []): void => {
+    const packageDir = join(dir, 'node_modules', name)
+    mkdirSync(packageDir, { recursive: true })
+    writeFileSync(join(packageDir, 'package.json'), JSON.stringify(manifest))
+    for (const sub of subdirs) mkdirSync(join(packageDir, sub), { recursive: true })
+    for (const file of files) writeFileSync(join(packageDir, file), '')
+  }
+
+  it('finds an addon in a DEPENDENCY, which is where plugins keep theirs', () => {
+    // @yandidan1's plugin is JavaScript; node-hid is the addon, hoisted to
+    // the profile root beside it. Asking only about the plugin's own
+    // directory would answer no for every case this exists to catch.
+    const dir = writeProfile({ dependencies: {} })
+    packageAt(dir, 'dsh-music-huazai', { name: 'dsh-music-huazai', dependencies: { 'node-hid': '3.4.0' } })
+    packageAt(dir, 'node-hid', { name: 'node-hid' }, ['build/Release'])
+    expect(holdsNativeAddon('web', 'dsh-music-huazai')).toBe(true)
+  })
+
+  it('recognizes all three conventional layouts, on the package itself too', () => {
+    const dir = writeProfile({ dependencies: {} })
+    packageAt(dir, 'gyp-built', { name: 'gyp-built' }, ['build/Release'])
+    packageAt(dir, 'prebuilt', { name: 'prebuilt' }, ['prebuilds'])
+    packageAt(dir, 'source-built', { name: 'source-built' }, [], ['binding.gyp'])
+    for (const name of ['gyp-built', 'prebuilt', 'source-built']) {
+      expect(holdsNativeAddon('web', name), name).toBe(true)
+    }
+  })
+
+  it('answers no for ordinary JavaScript, and for packages that are not there', () => {
+    // A false yes costs the user a restart they did not need, on every
+    // uninstall — so plain packages must stay plain.
+    const dir = writeProfile({ dependencies: {} })
+    packageAt(dir, 'dsh-loop', { name: 'dsh-loop', dependencies: { 'plain-dep': '1.0.0' } }, ['dist', 'lib'])
+    packageAt(dir, 'plain-dep', { name: 'plain-dep' }, ['dist'])
+    expect(holdsNativeAddon('web', 'dsh-loop')).toBe(false)
+    expect(holdsNativeAddon('web', 'never-installed')).toBe(false)
+  })
+
+  it('is not confused by a malformed manifest or a junk dependency name', () => {
+    const dir = writeProfile({ dependencies: {} })
+    const packageDir = join(dir, 'node_modules', 'broken')
+    mkdirSync(packageDir, { recursive: true })
+    writeFileSync(join(packageDir, 'package.json'), '{')
+    expect(holdsNativeAddon('web', 'broken')).toBe(false)
+    packageAt(dir, 'odd', { name: 'odd', dependencies: { '../escape': '1.0.0' } })
+    expect(holdsNativeAddon('web', 'odd')).toBe(false)
   })
 })
 


### PR DESCRIPTION
Addresses the part of #441 that is the market's, and corrects a message that actively misled the reporter.

**The physics.** Node has no `dlclose`. Once a `.node` is loaded the process holds it until it exits — so unmounting a plugin, disabling it, even uninstalling it, does not release the file. On POSIX that is invisible (replacing an open file leaves the old inode to whoever holds it); on Windows the rename is refused, which is the EPERM @yandidan1 hit reinstalling a plugin they had just uninstalled.

**What the market was claiming.** The uninstall reported `hot: true` — "this took effect, a refresh is enough". For a plugin holding a native addon that is the one thing that cannot be true, and the page then told them to refresh, which is exactly what does not help.

- `holdsNativeAddon` asks cheaply: node-gyp's `build/Release`, prebuild's `prebuilds/`, or a `binding.gyp` — on the package **and its direct dependencies**, which is where these live (the plugin is JavaScript; `node-hid` is a hoisted dependency beside it). Three `existsSync` calls per dependency, not a scan of trees that can run to tens of thousands of files.
- The uninstall route, and the rollback path that also removes packages, no longer call such a removal hot. The page asks for a restart.

**The EPERM message.** It was written for #389, an *update*, and told this reporter that their update had not applied, that their existing version was intact, and to "disable the plugin under Installed" — a plugin they had already uninstalled. It also called `node-hid` a plugin; it is a dependency. Now it describes the rename, works for install/update/reinstall alike, and says why disabling or uninstalling cannot help here while a full quit can:

> 如果这个包带原生模块（.node 文件，例如 node-hid 这类），那么停用插件、甚至卸载插件都不够：原生模块一旦被加载，在进程退出前都不会释放。刚卸载完立刻重装同一个插件在 Windows 上失败，通常就是这个原因。

**Not answered here.** The 1.31.2 → 1.36.2 regression. The uninstall has reported hot on both sides of that range, so whatever they measured is elsewhere — that needs their environment, which they have offered.

Tests: `holdsNativeAddon` across the three layouts, on a dependency, and its negative cases (a false yes costs a needless restart on every uninstall); a route test that the uninstall is not called hot; and the reworded EPERM asserted against a reinstall-shaped log. 1279 passed.
