### PR TITLE
fix: name the reason a present pnpm would not run (#509)

### DIFF
--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -436,14 +436,43 @@ export function classifyPnpmFailure(output: string, exitCode?: number | null): P
   //
   // 9009 is cmd.exe's "command not found" and is language-independent, so it
   // leads; the text forms catch the same failure in a log with no exit code.
-  // Last in the chain deliberately: pnpm's own errors never exit 9009, and
-  // anything pnpm actually said has already matched above.
-  if (exitCode === 9009 || /is not recognized as an internal or external command|不是内部或外部命令|不是內部或外部命令/.test(output)) {
+  //
+  // #509 by @awslmowms added the other way a present pnpm fails to run: the
+  // spawn itself is refused, and dsh's wrapper rethrows Node's error
+  // verbatim — `EACCES, syscall: 'spawnSync pnpm'` on Ubuntu. Same class
+  // (pnpm is there, it will not run, and the market's own setup cannot help)
+  // but a different repair, so the message names the reason it was given.
+  //
+  // Last in the chain deliberately: pnpm's own errors never exit 9009 and
+  // never fail to spawn, and anything pnpm actually said has matched above.
+  const spawnRefused = /spawnSync pnpm/.test(output)
+    ? /EACCES/.test(output) ? 'EACCES' : /ENOENT/.test(output) ? 'ENOENT' : 'unknown'
+    : null
+  const cmdNotFound = exitCode === 9009
+    || /is not recognized as an internal or external command|不是内部或外部命令|不是內部或外部命令/.test(output)
+  if (cmdNotFound || spawnRefused !== null) {
+    // Each cause gets the repair that fits it. One generic sentence would
+    // send the EACCES reporter hunting for a missing wrapper variable and
+    // the Windows reporter reaching for chmod.
+    const why = spawnRefused === 'EACCES'
+      ? {
+          zh: '系统拒绝执行它（EACCES，权限不足）。多半是那个文件没有执行权限，或者它所在的分区是以 noexec 挂载的。用 `ls -l $(command -v pnpm)` 看一眼权限位，必要时 `chmod +x`；如果 pnpm 装在 noexec 的分区上，换个位置重装。',
+          en: 'the system refused to execute it (EACCES, permission denied). Usually the file has no execute permission, or it lives on a partition mounted noexec. Check the permission bits with `ls -l $(command -v pnpm)` and `chmod +x` if needed; if pnpm sits on a noexec partition, reinstall it elsewhere.',
+        }
+      : spawnRefused === 'ENOENT'
+        ? {
+            zh: '要执行的文件已经不在了（ENOENT）。PATH 里那条记录指向的 pnpm 被删掉或改名了，重新装一次 pnpm 即可。',
+            en: 'the file it tried to execute is gone (ENOENT). The pnpm that entry on PATH points at has been deleted or renamed; reinstall pnpm.',
+          }
+        : {
+            zh: '命令行没能把它启动起来（退出码 9009）。可能是它其实没装好，也可能它是一个包装脚本、而脚本需要的环境变量在市场启动的子进程里不存在。',
+            en: "the command line could not launch it (exit code 9009). Either it is not installed properly, or it is a wrapper script whose required environment variables are missing in the market's child process.",
+          }
     return {
       code: 'pnpm-unusable',
       recoverable: false,
       replaceOutput: true,
-      message: '找不到能用的 pnpm，插件没有任何改动。系统里确实有一个 pnpm，但它启动失败了（命令行退出码 9009）。可能是它其实没装好，也可能它是一个包装脚本、而脚本需要的环境变量在市场启动的子进程里不存在。在终端里执行一次 `pnpm --version` 就能分辨：那里同样失败，说明要修的是这台机器上的 pnpm；那里正常，说明是启动市场的方式带来的环境差异，改用普通的 `dsh web` 启动可以绕开。 / pnpm could not be started, and nothing was changed. A pnpm does exist on PATH, but launching it failed (command-line exit code 9009). Either that pnpm is not installed properly, or it is a wrapper script whose required environment variables are missing in the process the market spawns. Run `pnpm --version` in a terminal to tell them apart: failing there too means pnpm itself needs fixing on this machine; working there means the difference comes from how the market was launched, and starting dsh with a plain `dsh web` avoids it.',
+      message: `找不到能用的 pnpm，插件没有任何改动。系统里确实有一个 pnpm，但${why.zh}\n在终端里执行一次 \`pnpm --version\` 可以确认：那里同样失败，说明要修的是这台机器上的 pnpm；那里正常，说明是启动市场的方式带来的环境差异，改用普通的 \`dsh web\` 启动可以绕开。 / pnpm could not be started, and nothing was changed. A pnpm does exist on PATH, but ${why.en}\nRun \`pnpm --version\` in a terminal to check: failing there too means pnpm itself needs fixing on this machine; working there means the difference comes from how the market was launched, and starting dsh with a plain \`dsh web\` avoids it.`,
     }
   }
   return null

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -365,6 +365,10 @@ describe('pnpmNeverStarted (#502)', () => {
     expect(pnpmNeverStarted(failed({ exitCode: 9009, stderr: "'\"\"' \ufffd\ufffd\ufffd" }))).toBe(true)
     // pnpm ran and failed: package.json may already have been rewritten.
     expect(pnpmNeverStarted(failed({ stderr: 'ERR_PNPM_FETCH_404 GET https://registry.npmjs.org/ghost: Not Found - 404' }))).toBe(false)
+    // #509: the spawn was refused outright, so the profile is equally
+    // untouched — and the update route's "restoration could not be verified,
+    // inspect this profile" notice is equally an alarm about nothing.
+    expect(pnpmNeverStarted(failed({ stderr: "Error: spawnSync pnpm EACCES\n  code: 'EACCES',\n  syscall: 'spawnSync pnpm'," }))).toBe(true)
     expect(pnpmNeverStarted(failed({ stderr: 'some other failure' }))).toBe(false)
   })
 })

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -367,6 +367,35 @@ describe('a pnpm that exists on PATH but cannot be started (#502)', () => {
     expect(classifyPnpmFailure("'pnpm' 不是内部或外部命令。")?.code).toBe('pnpm-unusable')
   })
 
+  it('also covers a spawn the system refused, with the repair that fits it (#509)', () => {
+    // @awslmowms on Ubuntu: pnpm is on PATH and the spawn itself is denied.
+    // dsh's wrapper rethrows Node's error verbatim, so what the user saw was
+    // an argv dump and a Node version banner.
+    const EACCES = String.raw`Error: spawnSync pnpm EACCES
+    at Object.spawnSync (node:internal/child_process:1123:20) {
+  errno: -13,
+  code: 'EACCES',
+  syscall: 'spawnSync pnpm',
+  path: 'pnpm',
+  spawnargs: [ 'add', '-w', 'dshmarket@1.41.0' ]
+}`
+    const failure = classifyPnpmFailure(EACCES, 1)
+    expect(failure?.code).toBe('pnpm-unusable')
+    expect(failure?.replaceOutput).toBe(true)
+    // The repair is specific to being refused execution — not the Windows
+    // wrapper story, which would send this reporter looking for the wrong
+    // thing entirely.
+    expect(failure?.message).toContain('chmod +x')
+    expect(failure?.message).toContain('noexec')
+    expect(failure?.message).not.toContain('9009')
+
+    // A vanished target is a third repair again.
+    const gone = classifyPnpmFailure(String.raw`Error: spawnSync pnpm ENOENT { code: 'ENOENT', syscall: 'spawnSync pnpm' }`, 1)
+    expect(gone?.code).toBe('pnpm-unusable')
+    expect(gone?.message).toContain('ENOENT')
+    expect(gone?.message).not.toContain('chmod +x')
+  })
+
   it('never outranks a failure pnpm itself reported', () => {
     // pnpm's own errors never exit 9009. If one somehow arrives with that
     // status, what pnpm said is the more specific answer and must win.


### PR DESCRIPTION
Fixes #509.

@awslmowms updated the market on Ubuntu and was shown an argv dump and a Node version banner. Underneath it:

```
errno: -13, code: 'EACCES', syscall: 'spawnSync pnpm', path: 'pnpm'
```

pnpm is on PATH and the system refused to execute it. dsh's wrapper rethrows Node's error verbatim, so that raw object *was* the failure detail.

Same class as #502 — pnpm is there, it will not run, and the market's own one-click setup cannot help because as far as PATH is concerned pnpm is already installed — so it joins `pnpm-unusable`. But the repair is not the same, and one generic sentence would send this reporter hunting for a missing wrapper variable and the Windows reporter reaching for `chmod`. Each cause carries its own now:

| 症状 | 说法 |
|---|---|
| `EACCES` | 没有执行权限，或所在分区 noexec；查权限位、`chmod +x`，或换个位置重装 |
| `ENOENT` | PATH 里那条记录指向的文件已经不在了；重装 pnpm |
| exit 9009 | 命令行没能启动它（#502 的包装脚本情形） |

**The false alarm goes with it.** `pnpmNeverStarted` keys on this code, so the update route no longer attempts a rollback or reports that the previous build "could not be verified; inspect this profile before restarting" — the spawn never happened, so nothing was written. That notice is visible in the reporter's own error text.

Tests: the EACCES and ENOENT shapes with their distinct repairs (and that neither mentions 9009), plus `pnpmNeverStarted` covering the refused spawn. 1280 passed.
