### PR TITLE
feat: 发现页 byline 展示目录 npm latest 版本 (#348)

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -268,6 +268,8 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 			hostRequirementUndeclared: "未声明宿主要求",
 			hostRequirementUnavailable: "宿主要求未知",
 			sortDownloads: "npm 下载量(近 30 天)",
+			/** Discover/theme card byline tooltip for catalog `version`. */
+			catalogNpmLatest: "npm 当前 latest",
 			sortStars: "Star 数",
 			sortAdded: "发布时间",
 			sortDesc: "降序",
@@ -798,6 +800,8 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 			hostRequirementUndeclared: "Host requirement undeclared",
 			hostRequirementUnavailable: "Host requirement unknown",
 			sortDownloads: "npm downloads (30d)",
+			/** Discover/theme card byline tooltip for catalog `version`. */
+			catalogNpmLatest: "npm latest",
 			sortStars: "Stars",
 			sortAdded: "Release date",
 			sortDesc: "Descending",
@@ -6004,6 +6008,22 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 			});
 		}
 		/**
+		* Catalog npm latest in the card byline (#348). Same quiet style as ↓ / ★;
+		* omitted when absent so github-only and not-yet-backfilled rows stay clean.
+		*/
+		function CatalogVersionMark({ version, tip }) {
+			if (typeof version !== "string" || version.length === 0) return null;
+			const label = /^v/i.test(version) ? version : `v${version}`;
+			return /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Tooltip, {
+				label: tip,
+				side: "top",
+				children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+					className: Market_module_css_default.star,
+					children: `· ${label}`
+				})
+			});
+		}
+		/**
 		* Module-scope caches so re-entering the section renders instantly instead
 		* of refetching and rebuilding from a spinner (#30 by @StarsTom). Module
 		* state survives section switches; a background refetch keeps it current.
@@ -8111,6 +8131,10 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 												title: p.owner,
 												children: p.owner
 											}),
+											/* @__PURE__ */ (0, react_jsx_runtime.jsx)(CatalogVersionMark, {
+												version: p.version,
+												tip: t("catalogNpmLatest")
+											}),
 											typeof p.downloads === "number" && /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Tooltip, {
 												label: String(p.downloads),
 												side: "top",
@@ -8282,6 +8306,10 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 													className: Market_module_css_default.owner,
 													title: p.owner,
 													children: p.owner
+												}),
+												/* @__PURE__ */ (0, react_jsx_runtime.jsx)(CatalogVersionMark, {
+													version: p.version,
+													tip: t("catalogNpmLatest")
 												}),
 												typeof p.downloads === "number" && /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Tooltip, {
 													label: String(p.downloads),
@@ -10192,6 +10220,10 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 										className: Market_module_css_default.owner,
 										title: confirming.owner,
 										children: confirming.owner
+									}),
+									/* @__PURE__ */ (0, react_jsx_runtime.jsx)(CatalogVersionMark, {
+										version: confirming.version,
+										tip: t("catalogNpmLatest")
 									}),
 									typeof confirming.downloads === "number" && /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Tooltip, {
 										label: String(confirming.downloads),

--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -1064,6 +1064,20 @@ function BookmarkMark({ size = 14, filled = false, className }: { size?: number;
 }
 
 /**
+ * Catalog npm latest in the card byline (#348). Same quiet style as ↓ / ★;
+ * omitted when absent so github-only and not-yet-backfilled rows stay clean.
+ */
+function CatalogVersionMark({ version, tip }: { version: string | null | undefined; tip: string }) {
+  if (typeof version !== 'string' || version.length === 0) return null
+  const label = /^v/i.test(version) ? version : `v${version}`
+  return (
+    <Tooltip label={tip} side="top">
+      <span className={css.star}>{`· ${label}`}</span>
+    </Tooltip>
+  )
+}
+
+/**
  * Module-scope caches so re-entering the section renders instantly instead
  * of refetching and rebuilding from a spinner (#30 by @StarsTom). Module
  * state survives section switches; a background refetch keeps it current.
@@ -3325,6 +3339,7 @@ export function MarketSection(props: MarketSectionProps) {
             <div className={css.byline}>
               <OwnerAvatar name={p.name} owner={p.owner || ''} />
               <span className={css.owner} title={p.owner}>{p.owner}</span>
+              <CatalogVersionMark version={p.version} tip={t('catalogNpmLatest')} />
               {typeof p.downloads === 'number' && (
                 <Tooltip label={String(p.downloads)} side="top">
                   <span className={css.star}>{'· ↓ ' + formatCount(p.downloads)}</span>
@@ -3458,6 +3473,7 @@ export function MarketSection(props: MarketSectionProps) {
               <div className={css.byline}>
                 <OwnerAvatar name={p.name} owner={p.owner || ''} />
                 <span className={css.owner} title={p.owner}>{p.owner}</span>
+                <CatalogVersionMark version={p.version} tip={t('catalogNpmLatest')} />
                 {typeof p.downloads === 'number' && (
                   <Tooltip label={String(p.downloads)} side="top">
                     <span className={css.star}>{'· ↓ ' + formatCount(p.downloads)}</span>
@@ -4921,12 +4937,13 @@ export function MarketSection(props: MarketSectionProps) {
           )}
         >
           {/* The detail dialog has to show at LEAST what the card already
-              does — owner, downloads, stars, published date, category — a
-              "detail" view that shows less than the summary it opened from
+              does — owner, version, downloads, stars, published date, category —
+              a "detail" view that shows less than the summary it opened from
               is backwards. */}
           <div className={css.byline}>
             <OwnerAvatar name={confirming.name} owner={confirming.owner || ''} />
             <span className={css.owner} title={confirming.owner}>{confirming.owner}</span>
+            <CatalogVersionMark version={confirming.version} tip={t('catalogNpmLatest')} />
             {typeof confirming.downloads === 'number' && (
               <Tooltip label={String(confirming.downloads)} side="top">
                 <span className={css.star}>{'· ↓ ' + formatCount(confirming.downloads)}</span>

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -235,6 +235,8 @@ export const zh = {
   hostRequirementUndeclared: '未声明宿主要求',
   hostRequirementUnavailable: '宿主要求未知',
   sortDownloads: 'npm 下载量(近 30 天)',
+  /** Discover/theme card byline tooltip for catalog `version`. */
+  catalogNpmLatest: 'npm 当前 latest',
   sortStars: 'Star 数',
   sortAdded: '发布时间',
   sortDesc: '降序',
@@ -773,6 +775,8 @@ export const en: Record<MarketKey, string> = {
   hostRequirementUndeclared: 'Host requirement undeclared',
   hostRequirementUnavailable: 'Host requirement unknown',
   sortDownloads: 'npm downloads (30d)',
+  /** Discover/theme card byline tooltip for catalog `version`. */
+  catalogNpmLatest: 'npm latest',
   sortStars: 'Stars',
   sortAdded: 'Release date',
   sortDesc: 'Descending',

--- a/src/client/market-data.ts
+++ b/src/client/market-data.ts
@@ -48,6 +48,11 @@ export interface RegistryPlugin {
    * package. Absent means "no npm package" — a coverage gap, not a zero.
    */
   downloads?: number | null
+  /**
+   * Catalog npm `latest` (awesome-dsh-plugin / dsh-market#348). Shown in the
+   * discover byline only when it is a non-empty string.
+   */
+  version?: string | null
   added?: string
   install?: string
   /**

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -24,6 +24,12 @@ export interface RegistryPlugin {
    * zero — so sorting must not read it as "less popular than 0".
    */
   downloads?: number | null
+  /**
+   * Registry `dist-tags.latest` from awesome-dsh-plugin (#348). A string when
+   * known; `null`/absent when github-only or not yet backfilled — the UI
+   * omits the byline segment rather than showing a placeholder.
+   */
+  version?: string | null
   install: string
   added: string
   /**

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -4260,3 +4260,17 @@ describe('Git to npm source migration (#461)', () => {
     })
   })
 })
+
+describe('catalog version in discover byline (#348)', () => {
+  it('shows v{version} when the catalog supplies a string, and omits null/absent', async () => {
+    const registry = JSON.parse(JSON.stringify(REGISTRY))
+    registry.plugins[0].version = '1.2.3'
+    registry.plugins[1].version = null
+    stubFetch({ '/dsh-market/registry': { source: 'live', registry, hostVersion: '0.1.2-alpha.2' } })
+    render(<MarketSection {...props()} />)
+    const loop = (await screen.findByText('dsh-loop')).closest('[class*="card"]') as HTMLElement
+    const notify = screen.getByText('dsh-notify').closest('[class*="card"]') as HTMLElement
+    expect(within(loop).getByText('· v1.2.3')).toBeTruthy()
+    expect(within(notify).queryByText(/^· v/)).toBeNull()
+  })
+})


### PR DESCRIPTION
## 摘要
- 消费 awesome-dsh-plugin 的 `version` 字段，在发现/主题卡片 byline 显示 `· v1.2.3`
- 仅当 `typeof version === 'string'` 时渲染；纯 GitHub / 未背填不占位
- 样式与 ↓ 下载、★ star 一致，不新增行或 badge，尽可能少增加复杂度

Closes #348  
目录侧：awesome-dsh-plugin#4361 / #4358

## 测试计划
- [x] CI `check` 通过
- [x] 有 npm + version 的卡片 byline 可见 `· v…`
- [x] 无 version 的卡片 byline 与改前一致