### PR TITLE
fix: collapse stuck category row without a delayed catsOpen flip

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -6440,6 +6440,14 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 			const [visibleCatsOneRow, setVisibleCatsOneRow] = (0, react.useState)(null);
 			const catsWrapRef = (0, react.useRef)(null);
 			const [catsStuck, setCatsStuck] = (0, react.useState)(false);
+			/** While the sticky header is pinned, expansion is this flag — not
+			* `catsOpen`. Becoming stuck collapses on the SAME render (stuckExpanded
+			* starts false) instead of a follow-up `useLayoutEffect` that flipped
+			* `catsOpen` and forced a second commit; that delayed height change is
+			* what lined up with the host Settings dialog hitching after tab 收放.
+			* An explicit chevron click while stuck sets this true and keeps
+			* `catsOpen` in sync so unstuck restores the user's choice. */
+			const [stuckExpanded, setStuckExpanded] = (0, react.useState)(false);
 			const [catsSentinel, setCatsSentinel] = (0, react.useState)(null);
 			const refreshInstalled = (0, react.useCallback)((force) => {
 				fetch(api("/dsh-market/installed"), { cache: "no-store" }).then((res) => res.json()).then((body) => {
@@ -8496,7 +8504,7 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 					if (leftView && root !== null && wrap !== null) {
 						if (root.scrollHeight - root.clientHeight <= wrap.offsetHeight) return;
 					}
-					setCatsStuck(leftView);
+					setCatsStuck((prev) => prev === leftView ? prev : leftView);
 				}, {
 					root: bodyRef.current,
 					threshold: 0
@@ -8504,28 +8512,14 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 				observer.observe(catsSentinel);
 				return () => observer.disconnect();
 			}, [catsSentinel]);
-			/**
-			* Becoming stuck auto-collapses an open row — a REAL `catsOpen` flip, not
-			* a display-only override. An earlier version faked this by computing a
-			* separate "effectively open" value for rendering while leaving `catsOpen`
-			* itself true; the chevron's own click handler only ever toggled the real
-			* `catsOpen`, so while stuck it flipped a value the render path had
-			* already stopped consulting — clicking "expand" did nothing visible
-			* (reported: "吸顶滚动了之后，展开没反应了"). Driving the same state the
-			* chevron drives means the chevron always works, stuck or not.
-			*/
-			const catsAutoCollapsedRef = (0, react.useRef)(false);
-			(0, react.useLayoutEffect)(() => {
-				if (catsStuck) {
-					if (catsOpen) {
-						setCatsOpen(false);
-						catsAutoCollapsedRef.current = true;
-					}
-				} else if (catsAutoCollapsedRef.current) {
-					setCatsOpen(true);
-					catsAutoCollapsedRef.current = false;
-				}
+			(0, react.useEffect)(() => {
+				if (!catsStuck) setStuckExpanded(false);
 			}, [catsStuck]);
+			/** Expanded chips + chevron share one value. Stuck uses `stuckExpanded`
+			* so pinning collapses without rewriting `catsOpen` in a layout effect
+			* (see stuckExpanded state). Leaving stuck falls back to `catsOpen`,
+			* which still holds the pre-pin / in-pin user choice. */
+			const catsExpanded = catsStuck ? stuckExpanded : catsOpen;
 			/**
 			* A fresh install (hotUrls/hotNames) and a toggle/group action
 			* (refreshNames) both end in the same place — "reload the page" — and
@@ -8975,7 +8969,10 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 					/* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
 						className: Market_module_css_default.body,
 						ref: bodyRef,
-						onScroll: (e) => setShowTop(e.currentTarget.scrollTop > 400),
+						onScroll: (e) => {
+							const show = e.currentTarget.scrollTop > 400;
+							setShowTop((prev) => prev === show ? prev : show);
+						},
 						children: tab === "backup" ? /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
 							className: Market_module_css_default.backupGrid,
 							children: [
@@ -9257,8 +9254,8 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 											className: visibleCats === null ? `${Market_module_css_default.catsWrap} ${Market_module_css_default.catsCollapsed}` : Market_module_css_default.catsWrap,
 											children: (() => {
 												const budget = catsStuck ? visibleCatsOneRow : visibleCats;
-												const ordered = orderedCategories(categories, cat, catsOpen, budget);
-												const shown = catsOpen || budget === null ? ordered : ordered.slice(0, Math.max(0, budget - 1));
+												const ordered = orderedCategories(categories, cat, catsExpanded, budget);
+												const shown = catsExpanded || budget === null ? ordered : ordered.slice(0, Math.max(0, budget - 1));
 												return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)(react_jsx_runtime.Fragment, { children: [
 													/* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Pill, {
 														"data-chip": "1",
@@ -9276,11 +9273,12 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 														variant: "ghost",
 														size: "sm",
 														className: Market_module_css_default.catsToggle,
-														icon: catsOpen ? /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconChevronUpOutline14, { size: 14 }) : /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconChevronDownOutline14, { size: 14 }),
-														"aria-label": catsOpen ? t("catsLess") : t("catsMore"),
+														icon: catsExpanded ? /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconChevronUpOutline14, { size: 14 }) : /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconChevronDownOutline14, { size: 14 }),
+														"aria-label": catsExpanded ? t("catsLess") : t("catsMore"),
 														onClick: () => {
-															catsAutoCollapsedRef.current = false;
-															setCatsOpen((o) => !o);
+															const next = !catsExpanded;
+															if (catsStuck) setStuckExpanded(next);
+															setCatsOpen(next);
 														}
 													})
 												] });

--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -1542,6 +1542,14 @@ export function MarketSection(props: MarketSectionProps) {
   // (padding, sticky `top`), which drifts silently whenever that CSS
   // changes. The sentinel just reports what's actually true on screen.
   const [catsStuck, setCatsStuck] = useState(false)
+  /** While the sticky header is pinned, expansion is this flag — not
+   * `catsOpen`. Becoming stuck collapses on the SAME render (stuckExpanded
+   * starts false) instead of a follow-up `useLayoutEffect` that flipped
+   * `catsOpen` and forced a second commit; that delayed height change is
+   * what lined up with the host Settings dialog hitching after tab 收放.
+   * An explicit chevron click while stuck sets this true and keeps
+   * `catsOpen` in sync so unstuck restores the user's choice. */
+  const [stuckExpanded, setStuckExpanded] = useState(false)
   const [catsSentinel, setCatsSentinel] = useState<HTMLDivElement | null>(null)
 
   const refreshInstalled = useCallback((force?: boolean) => {
@@ -3638,32 +3646,23 @@ export function MarketSection(props: MarketSectionProps) {
           const overflow = root.scrollHeight - root.clientHeight
           if (overflow <= wrap.offsetHeight) return
         }
-        setCatsStuck(leftView)
+        setCatsStuck(prev => (prev === leftView ? prev : leftView))
       },
       { root: bodyRef.current, threshold: 0 },
     )
     observer.observe(catsSentinel)
     return () => observer.disconnect()
   }, [catsSentinel])
-  /**
-   * Becoming stuck auto-collapses an open row — a REAL `catsOpen` flip, not
-   * a display-only override. An earlier version faked this by computing a
-   * separate "effectively open" value for rendering while leaving `catsOpen`
-   * itself true; the chevron's own click handler only ever toggled the real
-   * `catsOpen`, so while stuck it flipped a value the render path had
-   * already stopped consulting — clicking "expand" did nothing visible
-   * (reported: "吸顶滚动了之后，展开没反应了"). Driving the same state the
-   * chevron drives means the chevron always works, stuck or not.
-   */
-  const catsAutoCollapsedRef = useRef(false)
-  useLayoutEffect(() => {
-    if (catsStuck) {
-      if (catsOpen) { setCatsOpen(false); catsAutoCollapsedRef.current = true }
-    } else if (catsAutoCollapsedRef.current) {
-      setCatsOpen(true)
-      catsAutoCollapsedRef.current = false
-    }
+  // Drop any in-pin expand once the header unpins, so the next pin starts
+  // collapsed without a rising-edge setState in the observer.
+  useEffect(() => {
+    if (!catsStuck) setStuckExpanded(false)
   }, [catsStuck])
+  /** Expanded chips + chevron share one value. Stuck uses `stuckExpanded`
+   * so pinning collapses without rewriting `catsOpen` in a layout effect
+   * (see stuckExpanded state). Leaving stuck falls back to `catsOpen`,
+   * which still holds the pre-pin / in-pin user choice. */
+  const catsExpanded = catsStuck ? stuckExpanded : catsOpen
 
   /**
    * A fresh install (hotUrls/hotNames) and a toggle/group action
@@ -4011,7 +4010,10 @@ export function MarketSection(props: MarketSectionProps) {
       <div
         className={css.body}
         ref={bodyRef}
-        onScroll={e => setShowTop(e.currentTarget.scrollTop > 400)}
+        onScroll={e => {
+          const show = e.currentTarget.scrollTop > 400
+          setShowTop(prev => (prev === show ? prev : show))
+        }}
       >
         {tab === 'backup'
           ? (
@@ -4168,12 +4170,12 @@ export function MarketSection(props: MarketSectionProps) {
                         {(() => {
                           // Collapsed, the selected category is pulled to the front so it never hides.
                           // Whenever collapsed (default, or auto-collapsed by the sticky
-                          // header going stuck — see catsAutoCollapsedRef above), a stuck
+                          // header going stuck — see catsExpanded / stuckExpanded), a stuck
                           // header uses the one-row budget instead of the two-row one so an
                           // already-open list that just got pinned shrinks further.
                           const budget = catsStuck ? visibleCatsOneRow : visibleCats
-                          const ordered = orderedCategories(categories, cat, catsOpen, budget)
-                          const shown = catsOpen || budget === null ? ordered : ordered.slice(0, Math.max(0, budget - 1))
+                          const ordered = orderedCategories(categories, cat, catsExpanded, budget)
+                          const shown = catsExpanded || budget === null ? ordered : ordered.slice(0, Math.max(0, budget - 1))
                           return (
                             <>
                               <Pill data-chip="1" active={cat === 'all'} onClick={() => setCat('all')}>{t('all') + ' (' + formatCount(data!.count) + ')'}</Pill>
@@ -4189,13 +4191,12 @@ export function MarketSection(props: MarketSectionProps) {
                                 variant="ghost"
                                 size="sm"
                                 className={css.catsToggle}
-                                icon={catsOpen ? <IconChevronUpOutline14 size={14} /> : <IconChevronDownOutline14 size={14} />}
-                                aria-label={catsOpen ? t('catsLess') : t('catsMore')}
+                                icon={catsExpanded ? <IconChevronUpOutline14 size={14} /> : <IconChevronDownOutline14 size={14} />}
+                                aria-label={catsExpanded ? t('catsLess') : t('catsMore')}
                                 onClick={() => {
-                                  // An explicit click always wins — don't let the next
-                                  // stuck/unstuck transition second-guess it.
-                                  catsAutoCollapsedRef.current = false
-                                  setCatsOpen(o => !o)
+                                  const next = !catsExpanded
+                                  if (catsStuck) setStuckExpanded(next)
+                                  setCatsOpen(next)
                                 }}
                               />
                             </>

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -3850,20 +3850,19 @@ describe('category row expansion', () => {
       // would use — proves the stuck path swapped budgets, not just re-ran
       // the ordinary collapse.
       expect(chipCount()).toBe(3) // "all" pill + 2 categories
-      // The auto-collapse is a REAL catsOpen flip, so the chevron now reads
-      // "more" (collapsed), not "less" — and, critically, clicking it must
-      // still work. An earlier version computed a display-only "effectively
-      // open" value while leaving catsOpen genuinely true, so the chevron's
-      // click handler toggled a value the render path had stopped
-      // consulting — clicking it while stuck did nothing visible (reported:
-      // "吸顶滚动了之后，展开没反应了").
+      // Auto-collapse is render-derived (`catsExpanded = stuckExpanded` while
+      // pinned, starting false) — not a follow-up catsOpen flip. Chevron still
+      // tracks catsExpanded, and clicking it while stuck must keep working
+      // (earlier display-only overrides left catsOpen true and ignored the
+      // click — "吸顶滚动了之后，展开没反应了").
       const moreButton = screen.getByLabelText(re(en.catsMore))
       fireEvent.click(moreButton)
       await waitFor(() => expect(chipCount()).toBe(openCount))
       expect(screen.getByLabelText(re(en.catsLess))).toBeTruthy()
 
       // An explicit re-open while still stuck must survive scrolling back to
-      // the top — the auto-collapse must not fight the user's own choice.
+      // the top — catsOpen stays aligned with the chevron so unstuck keeps
+      // the open row.
       onChange!({ isIntersecting: true })
       await waitFor(() => expect(chipCount()).toBe(openCount))
       expect(screen.getByLabelText(re(en.catsLess))).toBeTruthy()


### PR DESCRIPTION
## Summary
- 滚动发现页时，设置弹窗偶发整窗灰/白闪（更像主线程 hitch，而不一定是 mask 本身）。
- 吸顶自动收起分类时，原先先 `catsStuck`，再在 `useLayoutEffect` 里二次把 `catsOpen` 关掉，多一次提交、分类行高度再变一截。
- 改为吸顶当帧用派生状态收起（`catsExpanded = catsStuck ? stuckExpanded : catsOpen`），不再延迟翻 `catsOpen`；吸顶后点 chevron 仍可展开，并同步 `catsOpen`。
- 相关：#517

## Test plan
- [x] 设置 → 插件市场 → 发现：展开分类后向下滚到吸顶自动收起，反复 dual 几次
- [x] 吸顶收起后点 chevron 仍能展开；滚回顶部后展开状态保持
- [x] 未展开分类时普通滚动无明显回归
- [x] `npx vitest run tests/client/market-section.client.spec.tsx -t 'shrinks the open, multi-row'`

## Notes
本地改完后暂时很难再复现，但偶发问题不能保证彻底消失；issue 可先保持 open，本 PR 只落地已验证的路径。