### PR TITLE
fix: recover from unavailable host peer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dshmarket",
   "description": "Visual plugin market inside DeepSeek Harness — browse, search, and one-click install community plugins. · DSH 可视化插件市场：逛一逛，点一下，装好。",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -367,8 +367,9 @@ export function classifyPnpmFailure(output: string, exitCode?: number | null): P
   // before it finishes), or a private-registry package without credentials.
   // pnpm re-resolves EVERY direct dependency on any add, so one ghost entry
   // blocks all later installs, of anything.
-  if (output.includes('ERR_PNPM_FETCH_404')) {
+  if (output.includes('ERR_PNPM_FETCH_404') || output.includes('ERR_PNPM_NO_MATCHING_VERSION')) {
     const pkg = /GET\s+\S*\/([^/\s]+):/.exec(output)?.[1].replace(/%2[Ff]/g, '/')
+      ?? /No matching version found for\s+((?:@[^/\s]+\/)?[^@\s]+)@/.exec(output)?.[1]
     const zh = pkg === undefined ? '' : `（${pkg}）`
     const en = pkg === undefined ? '' : ` (${pkg})`
     return {


### PR DESCRIPTION
## Problem

When a profile contains DSH prerelease host peers, pnpm can report `ERR_PNPM_NO_MATCHING_VERSION` for an unavailable stable `@deepseek-ai/dsh-*` version. The market only retried `ERR_PNPM_FETCH_404`, so installing an unrelated plugin failed even though the missing package was supplied by the Harness runtime.

## Changes

Treat the no-matching-version diagnostic like the existing unpublished-host-peer case, extract the package name, and retry once with `--config.auto-install-peers=false`.

Bump the package version to 1.44.1.
