### PR TITLE
fix: do not treat private git installs as npm on update (#525)

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -477,6 +477,47 @@ export function readLockCommits(profile: string, explicitDir?: string): Map<stri
   return commits
 }
 
+/**
+ * Commit recorded for a non-codeload git resolution (`type: git` in pnpm's
+ * lockfile). Matched against the install spec so a Gitea/GitLab URL can
+ * compare HEAD without mistaking a same-named npm package (#525).
+ */
+export function readGitResolutionCommit(
+  profile: string,
+  spec: string,
+  explicitDir?: string,
+): string | null {
+  const want = normalizeGitRepoKey(spec)
+  if (want === null) return null
+  try {
+    const lock = readFileSync(join(profileDir(profile, explicitDir), 'pnpm-lock.yaml'), 'utf8')
+    for (const m of lock.matchAll(
+      /resolution:\s*\{([^}]*)\}/g,
+    )) {
+      const body = m[1]!
+      const commit = /\bcommit:\s*([0-9a-f]{40})\b/i.exec(body)
+      const repo = /\brepo:\s*([^\s,}]+)/.exec(body)
+      if (commit === null || repo === null) continue
+      if (normalizeGitRepoKey(repo[1]!) === want) return commit[1]!.toLowerCase()
+    }
+  } catch { /* no lockfile */ }
+  return null
+}
+
+/** Lowercased transport-agnostic key for comparing two git remote spellings. */
+function normalizeGitRepoKey(spec: string): string | null {
+  let remote = spec.trim().replace(/^git\+/i, '')
+  const scp = /^git@([^:]+):(.+)$/.exec(remote)
+  if (scp !== null) remote = `https://${scp[1]}/${scp[2]!.replace(/^\/*/, '')}`
+  const hash = remote.indexOf('#')
+  if (hash !== -1) remote = remote.slice(0, hash)
+  const query = remote.indexOf('?')
+  if (query !== -1) remote = remote.slice(0, query)
+  remote = remote.replace(/\/+$/, '').toLowerCase()
+  if (!/^https?:\/\//.test(remote) && !remote.includes('.git')) return null
+  return remote
+}
+
 /** True when the installed package's manifest declares a dsh plugin surface. */
 export function hasDshManifest(dir: string): boolean {
   try {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -36,7 +36,7 @@ import { applyBundleOrder, mergeOrder, readBundleRules, readBundleStack, validat
 import { applyPreset, deletePreset, listPresets, previewPreset, savePreset } from './presets.ts'
 import { createProfileSnapshot, DEFAULT_MAX_SNAPSHOTS, deleteSnapshot, listSnapshots, restoreSnapshot } from './snapshot.ts'
 import { trialValidate } from './trial.ts'
-import { codeloadAllowBuildsKey, findCatalogEntryForLocal, findInstalledAlias, githubCommitOfTarget, githubTargetAtCommit, gitAllowBuildsKey, installTargetFor, isLocalSpec, NPM_NAME_RE, repoOfTarget, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps } from './sources.ts'
+import { codeloadAllowBuildsKey, findCatalogEntryForLocal, findInstalledAlias, githubCommitOfTarget, githubTargetAtCommit, gitAllowBuildsKey, gitUpdateTarget, installTargetFor, isLocalSpec, NPM_NAME_RE, repoOfTarget, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps } from './sources.ts'
 import { failureDetail, groupConflictsByOwner, isStaleUpdate, parseIgnoredBuilds, parsePrepareNotAllowed, pnpmNeverStarted, RELEASE_AGE_OVERRIDE, retargetCollections, validateAddedPlugins, withHoistRecovery } from './install.ts'
 import { asChannel, CHANNELS, DIST_TAG, resolveChannel, type Channel } from './channels.ts'
 import {
@@ -2838,7 +2838,11 @@ sendJson(response, 200, { updates })
             const gitSpec = spec.startsWith('github:')
               ? githubUpdateTarget(spec)
               : codeloadRepo === null ? null : `github:${codeloadRepo}`
-            const isGit = gitSpec !== null
+            // Non-GitHub git remotes (Gitea / git+https): keep the remote URL
+            // as the add target. Falling through to name@latest is what #525
+            // reported — a colliding npm package replaced the private install.
+            const genericGitTarget = gitSpec === null ? gitUpdateTarget(spec) : null
+            const isGit = gitSpec !== null || genericGitTarget !== null
             const isReleaseTarball = !restore && isGitHubReleaseTarballSpec(spec)
             const isNpmRollbackSource = !restore && !isGit && !isReleaseTarball
               // Market-managed npm installs persist only a range, version, or
@@ -2981,9 +2985,11 @@ sendJson(response, 200, { updates })
             // nothing where one does not.
             const target = restore
               ? (NPM_NAME_RE.test(spec) ? `${spec}@${tag}` : await acceleratedTarget(spec, region))
-              : gitSpec === null
+              : usesNpmUpdateTarget
                 ? (expectedNpmVersion !== null ? `${name}@${expectedNpmVersion}` : `${name}@${tag}`)
-                : await acceleratedTarget(gitSpec, region)
+                : genericGitTarget !== null
+                  ? genericGitTarget
+                  : await acceleratedTarget(gitSpec!, region)
             const repoIdentity = isGit ? repoOfTarget(spec) : null
             const repoKey = repoIdentity?.split('#')[0] ?? null
             // dsh-cli's deliberately narrow target grammar rejects the `&`

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -343,6 +343,70 @@ export function isLocalSpec(spec: string): boolean {
   return /^(?:link|file):/i.test(spec)
 }
 
+/**
+ * True when the install came from a git remote — GitHub shortcuts, codeload
+ * tarballs, and any other host (Gitea, GitLab self-host, raw `git+https://…`).
+ *
+ * Update detection used to ask only `repoOfTarget` (GitHub spellings). A
+ * private-host URL then fell through to the npm branch and was looked up by
+ * package name; a colliding registry package read as an "update" and
+ * `name@latest` replaced the git install (#525).
+ */
+export function isGitHostedSpec(spec: string): boolean {
+  const s = spec.trim()
+  if (s === '' || isLocalSpec(s)) return false
+  if (s.startsWith('github:')) return true
+  if (repoFromTarget(s) !== null) return true
+  if (/^git\+/i.test(s) || /^git:\/\//i.test(s) || /^ssh:\/\//i.test(s)) return true
+  if (/^git@[^/\s:]+:\S+/.test(s)) return true
+  // https://host/…/repo.git with optional fragment / query — not a Release
+  // archive and not a bare registry name.
+  if (/^https?:\/\/[^\s]+\/[^\s]+?\.git(?:[#?].*)?$/i.test(s)) return true
+  return false
+}
+
+/**
+ * Immutable commit already carried by a non-shortcut git URL (`…git#<sha>`).
+ * GitHub shortcuts keep using `githubCommitOfTarget`.
+ */
+export function gitCommitOfTarget(spec: string): string | null {
+  const github = githubCommitOfTarget(spec)
+  if (github !== null) return github
+  const hash = spec.indexOf('#')
+  if (hash === -1) return null
+  const frag = spec.slice(hash + 1).split(/[?&]/)[0] ?? ''
+  return /^[0-9a-f]{40}$/i.test(frag) ? frag.toLowerCase() : null
+}
+
+/**
+ * pnpm add target for updating a non-GitHub git install: drop a full-SHA
+ * pin so the remote re-resolves to HEAD, keep any branch/tag fragment.
+ */
+export function gitUpdateTarget(spec: string): string | null {
+  if (!isGitHostedSpec(spec) || spec.startsWith('github:') || repoFromTarget(spec) !== null) return null
+  const hash = spec.indexOf('#')
+  if (hash === -1) return spec
+  const frag = spec.slice(hash + 1).split(/[?&]/)[0] ?? ''
+  return /^[0-9a-f]{40}$/i.test(frag) ? spec.slice(0, hash) : spec
+}
+
+/**
+ * Smart-HTTP info/refs URL for a git-hosted install target, or null when the
+ * transport cannot be probed with `fetch` (scp / git:// / ssh://).
+ */
+export function gitUploadPackUrl(spec: string): string | null {
+  let remote = spec.trim().replace(/^git\+/i, '')
+  const scp = /^git@([^:]+):(.+)$/.exec(remote)
+  if (scp !== null) remote = `https://${scp[1]}/${scp[2]!.replace(/^\/*/, '')}`
+  const hash = remote.indexOf('#')
+  if (hash !== -1) remote = remote.slice(0, hash)
+  const query = remote.indexOf('?')
+  if (query !== -1) remote = remote.slice(0, query)
+  if (!/^https?:\/\//i.test(remote)) return null
+  const base = remote.replace(/\/+$/, '')
+  return `${base}/info/refs?service=git-upload-pack`
+}
+
 export { findCatalogEntryForLocal, resolveCatalogRestore } from './catalog-local-match.ts'
 
 /**

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -362,7 +362,35 @@ export function isGitHostedSpec(spec: string): boolean {
   // https://host/…/repo.git with optional fragment / query — not a Release
   // archive and not a bare registry name.
   if (/^https?:\/\/[^\s]+\/[^\s]+?\.git(?:[#?].*)?$/i.test(s)) return true
+  // Same shape without the `.git` suffix (Gitea/GitLab often omit it).
+  if (looksLikeHttpsGitRemote(s)) return true
   return false
+}
+
+/**
+ * `https://host/owner/repo` (optional `.git`, fragment, query) that is not an
+ * npm registry, Release archive, or codeload tarball.
+ */
+function looksLikeHttpsGitRemote(spec: string): boolean {
+  const bare = spec.trim().split(/[?#]/)[0] ?? ''
+  let url: URL
+  try {
+    url = new URL(bare)
+  } catch {
+    return false
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+  const host = url.hostname.toLowerCase()
+  if (host === 'registry.npmjs.org' || host.endsWith('.npmjs.org')) return false
+  if (host === 'registry.npmmirror.com' || host === 'cdn.npmmirror.com') return false
+  if (host === 'codeload.github.com') return false
+  if (/\.(?:tgz|tar\.gz|zip)$/i.test(url.pathname)) return false
+  if (/\/(?:releases|archive)\//i.test(url.pathname)) return false
+  // Exactly owner/repo — deeper paths are too ambiguous to treat as git.
+  const segments = url.pathname.split('/').filter(seg => seg !== '')
+  if (segments.length !== 2) return false
+  const repo = segments[1]!.replace(/\.git$/i, '')
+  return /^[A-Za-z0-9_.-]+$/.test(segments[0]!) && /^[A-Za-z0-9_.-]+$/.test(repo)
 }
 
 /**
@@ -379,11 +407,30 @@ export function gitCommitOfTarget(spec: string): string | null {
 }
 
 /**
- * pnpm add target for updating a non-GitHub git install: drop a full-SHA
+ * pnpm add target for updating a non-shortcut git install: drop a full-SHA
  * pin so the remote re-resolves to HEAD, keep any branch/tag fragment.
+ * GitHub-hosted `git+https://github.com/…` is rewritten to `github:` — the
+ * market's canonical spelling — so a successful update rematerializes the
+ * dependency that way and later check/update/rollback can use the first-class
+ * GitHub path. This turn still installs through the generic-git target slot
+ * (no region acceleration on the rewritten shortcut itself).
  */
 export function gitUpdateTarget(spec: string): string | null {
   if (!isGitHostedSpec(spec) || spec.startsWith('github:') || repoFromTarget(spec) !== null) return null
+  const github = parseGitHubRemote(spec)
+  if (github !== null) {
+    const hash = spec.indexOf('#')
+    if (hash === -1) return `github:${github.repo}`
+    const frag = spec.slice(hash + 1).split(/[?&]/)[0] ?? ''
+    if (/^[0-9a-f]{40}$/i.test(frag)) return `github:${github.repo}`
+    // Preserve branch/tag / path selectors the same way githubUpdateTarget does
+    // for shortcuts — only full-SHA pins are dropped.
+    if (frag.startsWith('path:/') || frag.startsWith('semver:')) {
+      return `github:${github.repo}#${frag}`
+    }
+    if (frag !== '') return `github:${github.repo}#${frag}`
+    return `github:${github.repo}`
+  }
   const hash = spec.indexOf('#')
   if (hash === -1) return spec
   const frag = spec.slice(hash + 1).split(/[?&]/)[0] ?? ''
@@ -393,6 +440,7 @@ export function gitUpdateTarget(spec: string): string | null {
 /**
  * Smart-HTTP info/refs URL for a git-hosted install target, or null when the
  * transport cannot be probed with `fetch` (scp / git:// / ssh://).
+ * Userinfo is stripped so update checks do not resend embedded credentials.
  */
 export function gitUploadPackUrl(spec: string): string | null {
   let remote = spec.trim().replace(/^git\+/i, '')
@@ -402,8 +450,16 @@ export function gitUploadPackUrl(spec: string): string | null {
   if (hash !== -1) remote = remote.slice(0, hash)
   const query = remote.indexOf('?')
   if (query !== -1) remote = remote.slice(0, query)
-  if (!/^https?:\/\//i.test(remote)) return null
-  const base = remote.replace(/\/+$/, '')
+  let url: URL
+  try {
+    url = new URL(remote)
+  } catch {
+    return null
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+  url.username = ''
+  url.password = ''
+  const base = url.toString().replace(/\/+$/, '')
   return `${base}/info/refs?service=git-upload-pack`
 }
 

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -8,8 +8,8 @@ import { DIST_TAG, type Channel } from './channels.ts'
 import { resolveHeadCommit } from './accelerate.ts'
 import { marketFetch } from './net.ts'
 import { activeRegion } from './regions.ts'
-import { profileDir, readInstalled, readInstalledVersion, readLockCommits } from './profile.ts'
-import { githubCommitOfTarget, githubRefOfTarget, repoOfTarget } from './sources.ts'
+import { profileDir, readGitResolutionCommit, readInstalled, readInstalledVersion, readLockCommits } from './profile.ts'
+import { gitCommitOfTarget, gitUploadPackUrl, githubCommitOfTarget, githubRefOfTarget, isGitHostedSpec, repoOfTarget } from './sources.ts'
 
 export interface UpdateStatus {
   kind: 'github' | 'npm' | 'linked'
@@ -46,10 +46,50 @@ export interface UpdateStatus {
 }
 
 const UPDATES_TTL_MS = 30 * 60 * 1000
+const GIT_REMOTE_HEAD_TIMEOUT_MS = 6000
 let updatesCache: { key: string; at: number; data: Record<string, UpdateStatus> } | null = null
 
-const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+/**
+ * HEAD for an arbitrary smart-HTTP git remote (Gitea, GitLab, …). Same
+ * advertisement format as GitHub's info/refs; kept here so accelerate.ts
+ * does not need to import sources.ts.
+ */
+async function resolveGitRemoteHead(spec: string, ref?: string): Promise<string | null> {
+  const url = gitUploadPackUrl(spec)
+  if (url === null) return null
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), GIT_REMOTE_HEAD_TIMEOUT_MS)
+  try {
+    const res = await marketFetch(url, {
+      signal: controller.signal,
+      headers: { 'user-agent': 'git/2.40.0' },
+    })
+    if (!res.ok) return null
+    const body = await res.text()
+    const contentType = res.headers?.get?.('content-type')?.toLowerCase() ?? ''
+    if (contentType.includes('text/html')
+      || !body.includes('# service=git-upload-pack')
+      || !/[0-9a-f]{40} (?:HEAD|refs\/(?:heads|tags)\/)/u.test(body)) {
+      return null
+    }
+    if (ref === undefined) {
+      const found = /([0-9a-f]{40}) HEAD/.exec(body)
+      return found === null ? null : found[1]!
+    }
+    const quoted = ref.replace(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`)
+    for (const namespace of ['heads', 'tags']) {
+      const found = new RegExp(String.raw`([0-9a-f]{40}) refs/${namespace}/${quoted}(?![^\s])`, 'u').exec(body)
+      if (found !== null) return found[1]!
+    }
+    return null
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
 
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
 function parseSemver(v: string): { core: number[]; pre: string[] } | null {
   const m = SEMVER.exec(v.trim())
   if (m === null) return null
@@ -322,6 +362,19 @@ export async function checkUpdates(
           kind: 'github', version, current, latest,
           updateAvailable: current !== null && latest !== null && current !== latest,
         }
+      } else if (isGitHostedSpec(spec)) {
+        // Private / self-hosted git (Gitea, GitLab, raw git+https). Never ask
+        // npm by package name — a colliding registry package would be offered
+        // as an update and then installed over the git source (#525).
+        // Reuse kind `github` as "git-sourced" so the existing Installed UI
+        // keeps treating the row as a VCS install without a client change.
+        const current = gitCommitOfTarget(spec)
+          ?? readGitResolutionCommit(profile, spec, activeProfileDir)
+        const latest = await resolveGitRemoteHead(spec)
+        result[name] = {
+          kind: 'github', version, current, latest,
+          updateAvailable: current !== null && latest !== null && current !== latest,
+        }
       } else {
         const meta = (await fetchJson(npmUrl(`${encodeURIComponent(name)}/latest`))) as { version?: string }
         const stable = typeof meta.version === 'string' ? meta.version : null
@@ -339,7 +392,7 @@ export async function checkUpdates(
         }
       }
     } catch {
-      result[name] = { kind: spec.startsWith('github:') ? 'github' : 'npm', version, current: null, latest: null, updateAvailable: false }
+      result[name] = { kind: (spec.startsWith('github:') || isGitHostedSpec(spec)) ? 'github' : 'npm', version, current: null, latest: null, updateAvailable: false }
     }
   }))
   updatesCache = { key: cacheKey, at: Date.now(), data: result }

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -264,6 +264,23 @@ vi.mock('../src/dsh-cli.ts', () => {
       }
       return ok
     }
+    // Private-host / git+https remotes (#525). Same write path as github:;
+    // without this branch FakeDsh fell through to npm name parsing and the
+    // update-route regression could not prove the Gitea URL was kept.
+    if (/^git\+/i.test(target) || /^git@[^/\s:]+:\S+/.test(target)) {
+      const bare = target.split(/[#?]/)[0]!
+      const repo = fake.repos[target] ?? fake.repos[bare]
+      if (repo === undefined) {
+        return { exitCode: 1, timedOut: false, stdout: '', stderr: `fake dsh: unknown git remote ${target}`, cancelled: false }
+      }
+      writeDep(repo.name, target)
+      writePkg(repo.name, repo.manifest, repo.artifacts)
+      if (fake.profileBundleOnNextAdd !== null) {
+        appendProfileBundle(fake.profileBundleOnNextAdd)
+        fake.profileBundleOnNextAdd = null
+      }
+      return ok
+    }
     if (/^https?:/.test(target)) {
       const prebuilt = fake.tarballs[target]
       if (prebuilt === undefined) {
@@ -1686,6 +1703,44 @@ describe('update flow — no npm publishing required', () => {
     // And not the pin it already had: an update that reinstalls the commit
     // on disk is an update that can never move.
     expect(ran).not.toContain(sha)
+  })
+
+  it('updates a Gitea git+https install from the git URL, not a same-named npm package (#525)', async () => {
+    // Same silent failure mode as the codeload case above, for self-hosted
+    // remotes: repoOfTarget only knows github:/codeload, so a Gitea URL used
+    // to fall through to name@latest when the package name collided.
+    const gitea = 'git+https://gitea.example.com/me/themer.git'
+    fake.npm.themer = {
+      versions: {
+        '0.1.0': { manifest: { dsh: {}, main: 'index.js' }, artifacts: ['index.js'] },
+        '9.9.9': { manifest: { dsh: {}, main: 'index.js' }, artifacts: ['index.js'] },
+      },
+      latest: '9.9.9',
+    }
+    fake.repos[gitea] = {
+      name: 'themer', manifest: { dsh: {}, main: 'index.js' }, artifacts: ['index.js'],
+    }
+    // Seed a profile that already has the private-git spelling on disk.
+    const manifestPath = join(profileDir('web'), 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    manifest.dependencies = { ...(manifest.dependencies ?? {}), themer: gitea }
+    writeFileSync(manifestPath, JSON.stringify(manifest))
+    mkdirSync(join(profileDir('web'), 'node_modules', 'themer'), { recursive: true })
+    writeFileSync(
+      join(profileDir('web'), 'node_modules', 'themer', 'package.json'),
+      JSON.stringify({ name: 'themer', version: '0.1.0', dsh: {}, main: 'index.js' }),
+    )
+    writeFileSync(join(profileDir('web'), 'node_modules', 'themer', 'index.js'), 'export {}\n')
+
+    fake.calls = []
+    const updated = await bed.dispatch('POST', '/dsh-market/update', { name: 'themer' })
+    expect(updated.status).toBe(200)
+    const add = fake.calls.find(call => call[0] === 'add')
+    const ran = add?.join(' ') ?? ''
+    expect(ran, 'the update must keep the Gitea remote').toContain(gitea)
+    expect(ran).not.toContain('themer@latest')
+    expect(ran).not.toContain('themer@9.9.9')
+    expect(fake.calls.some(call => call.some(arg => /themer@(latest|9\.9\.9)/.test(arg)))).toBe(false)
   })
 
   it('keeps a github subpath while dropping revision selectors during update (#281)', async () => {

--- a/tests/sources.spec.ts
+++ b/tests/sources.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest'
 import {
   githubRefOfTarget,
   findCatalogEntryForLocal, findInstalledAlias, gitAllowBuildsKey, githubRemoteIdentities, githubRepoIdentities, githubRepoIdentity, githubTargetAtCommit,
-  gitCommitOfTarget, gitUpdateTarget, installTargetFor, isGitHostedSpec, isLocalSpec, lookupRepoFromUrl, parseGitHubRemote, parseGitHubRepository, parseSourceUrl, repoOf, resolveCatalogRestore, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps,
+  gitCommitOfTarget, gitUpdateTarget, gitUploadPackUrl, installTargetFor, isGitHostedSpec, isLocalSpec, lookupRepoFromUrl, parseGitHubRemote, parseGitHubRepository, parseSourceUrl, repoOf, resolveCatalogRestore, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps,
 } from '../src/sources.ts'
 
 describe('parseSourceUrl', () => {
@@ -353,6 +353,7 @@ describe('isGitHostedSpec / gitUpdateTarget (#525)', () => {
   it('recognizes private-host git transports that repoOfTarget rejects', () => {
     expect(isGitHostedSpec('git+https://gitea.example.com/me/plug.git')).toBe(true)
     expect(isGitHostedSpec('https://gitea.example.com/me/plug.git')).toBe(true)
+    expect(isGitHostedSpec('https://gitea.example.com/me/plug')).toBe(true)
     expect(isGitHostedSpec(`git+https://gitea.example.com/me/plug.git#${SHA}`)).toBe(true)
     expect(isGitHostedSpec('git@gitea.example.com:me/plug.git')).toBe(true)
     expect(isGitHostedSpec('github:owner/repo')).toBe(true)
@@ -365,6 +366,8 @@ describe('isGitHostedSpec / gitUpdateTarget (#525)', () => {
     expect(isGitHostedSpec('link:../themer')).toBe(false)
     expect(isGitHostedSpec('file:/tmp/themer.tgz')).toBe(false)
     expect(isGitHostedSpec('^1.2.3')).toBe(false)
+    expect(isGitHostedSpec('https://registry.npmjs.org/themer/-/themer-1.0.0.tgz')).toBe(false)
+    expect(isGitHostedSpec('https://github.com/o/r/releases/latest/download/p.tgz')).toBe(false)
   })
 
   it('strips a commit pin so update re-resolves HEAD, and reads the pin back', () => {
@@ -373,5 +376,17 @@ describe('isGitHostedSpec / gitUpdateTarget (#525)', () => {
     expect(gitUpdateTarget(pinned)).toBe('git+https://gitea.example.com/me/plug.git')
     expect(gitUpdateTarget('git+https://gitea.example.com/me/plug.git'))
       .toBe('git+https://gitea.example.com/me/plug.git')
+    expect(gitUpdateTarget('https://gitea.example.com/me/plug'))
+      .toBe('https://gitea.example.com/me/plug')
+  })
+
+  it('rewrites github.com git+https installs back to github: for update', () => {
+    expect(gitUpdateTarget('git+https://github.com/o/r.git')).toBe('github:o/r')
+    expect(gitUpdateTarget(`git+https://github.com/o/r.git#${SHA}`)).toBe('github:o/r')
+  })
+
+  it('strips userinfo from the smart-HTTP probe URL', () => {
+    expect(gitUploadPackUrl('git+https://user:secret@gitea.example.com/me/plug.git'))
+      .toBe('https://gitea.example.com/me/plug.git/info/refs?service=git-upload-pack')
   })
 })

--- a/tests/sources.spec.ts
+++ b/tests/sources.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest'
 import {
   githubRefOfTarget,
   findCatalogEntryForLocal, findInstalledAlias, gitAllowBuildsKey, githubRemoteIdentities, githubRepoIdentities, githubRepoIdentity, githubTargetAtCommit,
-  installTargetFor, isLocalSpec, lookupRepoFromUrl, parseGitHubRemote, parseGitHubRepository, parseSourceUrl, repoOf, resolveCatalogRestore, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps,
+  gitCommitOfTarget, gitUpdateTarget, installTargetFor, isGitHostedSpec, isLocalSpec, lookupRepoFromUrl, parseGitHubRemote, parseGitHubRepository, parseSourceUrl, repoOf, resolveCatalogRestore, restoreBlockedByWorkspace, restoreTargetForLocal, workspaceProtocolDeps,
 } from '../src/sources.ts'
 
 describe('parseSourceUrl', () => {
@@ -344,5 +344,34 @@ describe('lookupRepoFromUrl (display/lookup only — NOT for install/rollback)',
     expect(lookupRepoFromUrl('https://codeload.github.com/owner/repo/tar.gz/' + 'a'.repeat(40))).toBeNull()
     expect(lookupRepoFromUrl('dsh-loop')).toBeNull()
     expect(lookupRepoFromUrl('@scope/pkg')).toBeNull()
+  })
+})
+
+describe('isGitHostedSpec / gitUpdateTarget (#525)', () => {
+  const SHA = 'a'.repeat(40)
+
+  it('recognizes private-host git transports that repoOfTarget rejects', () => {
+    expect(isGitHostedSpec('git+https://gitea.example.com/me/plug.git')).toBe(true)
+    expect(isGitHostedSpec('https://gitea.example.com/me/plug.git')).toBe(true)
+    expect(isGitHostedSpec(`git+https://gitea.example.com/me/plug.git#${SHA}`)).toBe(true)
+    expect(isGitHostedSpec('git@gitea.example.com:me/plug.git')).toBe(true)
+    expect(isGitHostedSpec('github:owner/repo')).toBe(true)
+  })
+
+  it('does not treat registry names or local checkouts as git-hosted', () => {
+    expect(isGitHostedSpec('themer')).toBe(false)
+    expect(isGitHostedSpec('@scope/themer')).toBe(false)
+    expect(isGitHostedSpec('owner/themer')).toBe(false)
+    expect(isGitHostedSpec('link:../themer')).toBe(false)
+    expect(isGitHostedSpec('file:/tmp/themer.tgz')).toBe(false)
+    expect(isGitHostedSpec('^1.2.3')).toBe(false)
+  })
+
+  it('strips a commit pin so update re-resolves HEAD, and reads the pin back', () => {
+    const pinned = `git+https://gitea.example.com/me/plug.git#${SHA}`
+    expect(gitCommitOfTarget(pinned)).toBe(SHA)
+    expect(gitUpdateTarget(pinned)).toBe('git+https://gitea.example.com/me/plug.git')
+    expect(gitUpdateTarget('git+https://gitea.example.com/me/plug.git'))
+      .toBe('git+https://gitea.example.com/me/plug.git')
   })
 })

--- a/tests/updates.spec.ts
+++ b/tests/updates.spec.ts
@@ -196,6 +196,85 @@ describe('checkUpdates — github pins', () => {
   })
 })
 
+describe('checkUpdates — private git hosts (#525)', () => {
+  const HEAD = 'a'.repeat(40)
+  const OLD = 'b'.repeat(40)
+  let home: string
+  const proxyKeys = [
+    'http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY',
+    'npm_config_proxy', 'npm_config_https_proxy',
+  ] as const
+  const savedProxy: Record<string, string | undefined> = {}
+
+  function profileWith(spec: string, lockCommit: string | null, version = '1.0.0'): string {
+    const dir = join(mkdtempSync(join(tmpdir(), 'dshm-gitea-')), 'profiles', 'web')
+    mkdirSync(join(dir, 'node_modules', 'themer'), { recursive: true })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { themer: spec } }))
+    writeFileSync(join(dir, 'node_modules', 'themer', 'package.json'), JSON.stringify({ name: 'themer', version }))
+    // pnpm's non-GitHub git resolution shape — not a codeload tarball.
+    writeFileSync(join(dir, 'pnpm-lock.yaml'), lockCommit === null ? 'lockfileVersion: 9\n'
+      : `lockfileVersion: 9\npackages:\n  themer@${spec}:\n    resolution: {commit: ${lockCommit}, repo: ${spec}, type: git}\n`)
+    return dir
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'dshm-giteahome-'))
+    // marketFetch uses undici when a proxy is set, which bypasses stubGlobal('fetch').
+    for (const key of proxyKeys) {
+      savedProxy[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    for (const key of proxyKeys) {
+      if (savedProxy[key] === undefined) delete process.env[key]
+      else process.env[key] = savedProxy[key]
+    }
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  it('does not treat a Gitea git+https install as an npm package, even when the name collides (#525)', async () => {
+    // The failure mode: repoOfTarget only knows github:/codeload, so a Gitea
+    // URL fell through to fetchNpmLatest(name). A same-named registry package
+    // then read as "an update", and update-all installed name@latest.
+    const gitea = 'git+https://gitea.example.com/me/themer.git'
+    let npmHits = 0
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      const href = String(url)
+      if (href.includes('registry.npmjs.org') || href.includes('/themer/latest')) {
+        npmHits += 1
+        return { ok: true, status: 200, json: async () => ({ version: '9.9.9' }), text: async () => '' }
+      }
+      // git advertisement for the private host
+      return {
+        ok: true, status: 200,
+        headers: { get: () => 'application/x-git-upload-pack-advertisement' },
+        json: async () => ({}),
+        text: async () => `001e# service=git-upload-pack\n00000155${HEAD} HEAD\0multi_ack\n`,
+      }
+    }))
+    const result = await checkUpdates('web', true, profileWith(gitea, OLD))
+    expect(npmHits, 'must not ask the npm registry by package name').toBe(0)
+    expect(result.themer?.kind).not.toBe('npm')
+    expect(result.themer).toMatchObject({
+      kind: 'github',
+      current: OLD,
+      latest: HEAD,
+      updateAvailable: true,
+    })
+  })
+
+  it('still treats a bare owner/repo registry shorthand as npm', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, json: async () => ({ version: '1.0.0' }), text: async () => '',
+    })))
+    const result = await checkUpdates('web', true, profileWith('owner/themer', OLD))
+    expect(result.themer).toMatchObject({ kind: 'npm' })
+  })
+})
+
 describe('preferBeta (release channel)', () => {
   it('offers the prerelease only when it is actually newer', async () => {
     // The trap: a `beta` dist-tag is NOT automatically ahead. Once 1.14.0

--- a/tests/updates.spec.ts
+++ b/tests/updates.spec.ts
@@ -266,6 +266,27 @@ describe('checkUpdates — private git hosts (#525)', () => {
     })
   })
 
+  it('treats a bare https Gitea remote (no .git suffix) as git, not npm (#525)', async () => {
+    const gitea = 'https://gitea.example.com/me/themer'
+    let npmHits = 0
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      const href = String(url)
+      if (href.includes('registry.npmjs.org') || /\/themer\/latest/.test(href)) {
+        npmHits += 1
+        return { ok: true, status: 200, json: async () => ({ version: '9.9.9' }), text: async () => '' }
+      }
+      return {
+        ok: true, status: 200,
+        headers: { get: () => 'application/x-git-upload-pack-advertisement' },
+        json: async () => ({}),
+        text: async () => `001e# service=git-upload-pack\n00000155${HEAD} HEAD\0multi_ack\n`,
+      }
+    }))
+    const result = await checkUpdates('web', true, profileWith(gitea, OLD))
+    expect(npmHits).toBe(0)
+    expect(result.themer?.kind).not.toBe('npm')
+  })
+
   it('still treats a bare owner/repo registry shorthand as npm', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       ok: true, status: 200, json: async () => ({ version: '1.0.0' }), text: async () => '',


### PR DESCRIPTION
## Summary
- `repoOfTarget` 只认 `github:` / codeload，因此 Gitea、`git+https`，或无 `.git` 的 `https://host/owner/repo` 安装会掉进 npm 路径。若包名与 registry 撞车，会被当成「有更新」，并用 `name@latest` 盖掉原来的 git 源（#525）。
- 识别 git 托管规格，用 smart HTTP 比对 HEAD（不再 `fetchNpmLatest`），更新时重新 add git URL；`git+https://github.com/…` 规范化为 `github:`，便于后续走一等公民的 GitHub 路径。
- HEAD 探测时去掉 URL userinfo，避免更新检查把嵌入的凭据再发出去。
- 单测 + update 路由 flow：断言 add 目标仍是 Gitea URL，而不是 `name@latest`。

## Test plan
- [x] `npx vitest run tests/sources.spec.ts tests/updates.spec.ts -t '#525|isGitHostedSpec|private git|Gitea'`
- [x] `npx vitest run tests/flows.spec.ts -t 'Gitea git+https|#525|mirror-installed'`
- [x] 手动：profile 里是 `git+https://<gitea>/owner/repo.git`，且包名在 npm 上也存在 →「已安装」不应出现 npm「更新」；点更新应保留 git remote
- [x] 同样测无 `.git` 的 `https://<gitea>/owner/repo`
- [x] 确认普通 npm 插件和 `github:owner/repo` 插件更新行为无回归

## Notes
- 私有 git 的回滚 / 区域加速仍弱于一等公民的 `github:` 路径；本 PR 只堵住静默换成 npm 的问题。
- 嵌套路径远端（如 `group/sub/repo`）仍需带 `.git` 或 `git+` 才会被识别为 git。