### PR TITLE
docs: record what pnpm 11's release hold does to each add shape (#531)

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2864,6 +2864,31 @@ sendJson(response, 200, { updates })
             // verification against the first fetch rolls back a correct
             // install. Pinning the already-resolved version here makes the
             // boundary a no-op rewrite and keeps one source of truth.
+            //
+            // The pin also decides what pnpm 11's fresh-release hold does,
+            // which is the whole of #531 (@Astro-Han). Measured against real
+            // pnpm 11.7.0 with `minimumReleaseAge: 1440` and a registry whose
+            // publish times the measurement controlled — `latest` moved to a
+            // version published five minutes earlier:
+            //
+            //   add pkg@latest  → exit 0, installs the OLDER version, writes
+            //                     ^older into the manifest, and says NOTHING
+            //                     about having skipped one.
+            //   add pkg@2.0.0   → ERR_PNPM_NO_MATURE_MATCHING_VERSION,
+            //                     nothing installed.
+            //
+            // The first is a silent downgrade the market can only notice
+            // afterwards, by which point its own verification calls the
+            // result a RESOLVED_VERSION_MISMATCH and rolls a real upgrade
+            // back to where the user started — every day, for as long as
+            // releases are daily. The second is an error the market already
+            // recovers from: classifyPnpmFailure reads it as
+            // release-age-violation and withHoistRecovery retries once with
+            // --config.minimumReleaseAge=0 (#39).
+            //
+            // So a version resolved BEFORE the add is not only about the
+            // Desktop boundary; it is what turns a silent skip into a
+            // failure with a name.
             if (usesNpmUpdateTarget) {
               const installedVersion = readInstalledVersion(config.profile, name, activeProfileDir)
               const registryLatest = selfChannel === null


### PR DESCRIPTION
Measurement, not a code change — the fix for #531 is already in 1.42.0+, for a reason that was not written down.

@Astro-Han found a second route to `RESOLVED_VERSION_MISMATCH` with a different cause from #496: on a daily-release cadence, `latest` is always inside pnpm's ~24h fresh-release hold.

Measured against **real pnpm 11.7.0**, `minimumReleaseAge: 1440`, local registry with controlled publish times, `latest` moved to a version published five minutes earlier:

| add shape | result |
|---|---|
| `add pkg@latest` (≤1.41) | **exit 0**, installs the OLDER version, writes `^older` into the manifest, says nothing about skipping one |
| `add pkg@2.0.0` (1.42+, the #496 pin) | `ERR_PNPM_NO_MATURE_MATCHING_VERSION`, nothing installed |

The first is a silent downgrade the market can only notice afterwards — at which point verification calls it a mismatch and rolls a real upgrade back to where the user started. Every day, for as long as releases are daily. The second is an error the market already recovers from: `release-age-violation`, retried once with `--config.minimumReleaseAge=0` (#39).

So #496's pin fixes this too, for a reason that had nothing to do with the Desktop boundary it was written for. Recorded at the pin, because the next person there would otherwise see only half of why it must be there.

**No test, deliberately.** It needs a registry serving controlled publish times *and* a pnpm 11: the e2e lane's host spawns whatever pnpm is on PATH (10.29.3 here — no hold, so the spec passes without exercising anything, which I confirmed by writing it), and a compat-lane version took twelve minutes against the live network. The market's half is already covered by #496's tests and withHoistRecovery's retry test.