### PR TITLE
fix: hide Windows child process consoles

### DIFF
--- a/src/dsh-cli.ts
+++ b/src/dsh-cli.ts
@@ -258,20 +258,21 @@ type SpawnShimOptions = SpawnOptions & { viaShell?: boolean }
  * combination (DEP0190). Windows `.cmd` shims cannot start without a shell,
  * so the shim path routes through `cmd.exe /d /s /c` with an explicitly
  * built, quoted command line; every other invocation spawns directly with
- * `shell: false`.
+ * `shell: false`. Hide consoles when the host itself has no console (#530).
  */
 function spawnShim(file: string, args: readonly string[], options: SpawnShimOptions): ChildProcess {
   const { viaShell = false, ...spawnOptions } = options
   if (!viaShell) {
-    return spawn(file, [...args], { ...spawnOptions, shell: false })
+    return spawn(file, [...args], { ...spawnOptions, shell: false, windowsHide: true })
   }
   if (process.platform !== 'win32') {
-    return spawn(file, [...args], { ...spawnOptions, shell: false })
+    return spawn(file, [...args], { ...spawnOptions, shell: false, windowsHide: true })
   }
   return spawn(COMSPEC, ['/d', '/s', '/c', `"${cmdCommandLine([file, ...args])}"`], {
     ...spawnOptions,
     shell: false,
     windowsVerbatimArguments: true,
+    windowsHide: true,
   })
 }
 
@@ -482,7 +483,7 @@ export interface DesktopPluginRuntime extends PluginCommandRuntime {
 export function killChild(child: ChildProcess): void {
   if (process.platform === 'win32' && child.pid !== undefined) {
     try {
-      spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore' })
+      spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore', windowsHide: true })
       return
     } catch { /* fall through */ }
   }
@@ -511,7 +512,7 @@ let activeDesktopOperation: ActiveDesktopOperation | null = null
 function killTree(child: ChildProcess): void {
   if (process.platform === 'win32' && child.pid !== undefined) {
     try {
-      spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore' })
+      spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore', windowsHide: true })
       return
     } catch { /* fall through */ }
   }

--- a/tests/dsh-cli-spawn.spec.ts
+++ b/tests/dsh-cli-spawn.spec.ts
@@ -1,0 +1,203 @@
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const childProcess = vi.hoisted(() => ({ spawn: vi.fn() }))
+vi.mock('node:child_process', () => ({ spawn: childProcess.spawn }))
+
+// Exercise the real callers and shim, mocking only the OS process boundary.
+// Explicit close/data events keep cancellation and timeout tests deterministic.
+function fakeChild() {
+  return Object.assign(new EventEmitter(), {
+    pid: 530,
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    kill: vi.fn(),
+  })
+}
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+const originalArgv = process.argv
+const originalExecArgv = process.execArgv
+let home: string
+let child: ReturnType<typeof fakeChild>
+
+function platform(value: string) {
+  Object.defineProperty(process, 'platform', { ...originalPlatform, value })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  childProcess.spawn.mockReset()
+  child = fakeChild()
+  childProcess.spawn.mockImplementation(() => childProcess.spawn.mock.calls.length === 1 ? child : fakeChild())
+  home = mkdtempSync(join(tmpdir(), 'dsh-market-spawn-'))
+  vi.stubEnv('DSH_HOME', home)
+  vi.stubEnv('ComSpec', 'cmd.exe')
+  vi.stubEnv('DSH_MARKET_INSTALL_TIMEOUT_MS', '1000')
+  process.argv = [process.execPath, 'desktop-host.js']
+  process.execArgv = []
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+})
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', originalPlatform)
+  process.argv = originalArgv
+  process.execArgv = originalExecArgv
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  rmSync(home, { recursive: true, force: true })
+})
+
+// Keep inherited environment values out of assertion diffs (they can hold
+// credentials), while checking the caller's environment still reaches spawn.
+function expectSpawn(index: number, file: string, args: string[], extra = {}) {
+  const [actualFile, actualArgs, { env, ...options }] = childProcess.spawn.mock.calls[index]!
+  expect([actualFile, actualArgs]).toEqual([file, args])
+  expect(options).toEqual({
+    stdio: ['ignore', 'pipe', 'pipe'], shell: false, windowsHide: true, ...extra,
+  })
+  expect(env.CI).toBe('true')
+  expect(env.DSH_HOME === home).toBe(true)
+  expect(typeof env.PATH).toBe('string')
+}
+
+function expectTaskkill(index: number) {
+  expect(childProcess.spawn.mock.calls[index]).toEqual([
+    'taskkill', ['/pid', '530', '/t', '/f'], { stdio: 'ignore', windowsHide: true },
+  ])
+  expect(child.kill).not.toHaveBeenCalled()
+}
+
+describe('background process consoles (#530)', () => {
+  describe.each(['win32', 'linux'])('%s', (os) => {
+    describe.each(['node', 'fallback'])('%s launcher', (launcher) => {
+      it.each([
+        ['install', ['add', '@scope/plugin@^1.0.0']],
+        ['update', ['add', '--force', '@scope/plugin@2.0.0']],
+        ['uninstall', ['remove', '@scope/plugin']],
+      ])('hides the %s process without changing argv or spawn semantics', async (_operation, args) => {
+        platform(os)
+        const entry = join(home, 'DSH with spaces', 'bin.js')
+        if (launcher === 'node') {
+          process.argv = [process.execPath, entry]
+          process.execArgv = ['--no-warnings']
+        }
+        const { runDshPlugin, nodeExecutable } = await import('../src/dsh-cli.ts')
+        const result = runDshPlugin('工作 profile', args)
+        child.stdout.emit('data', Buffer.from('progress\n'))
+        child.stderr.emit('data', Buffer.from('diagnostic\n'))
+        child.emit('close', 0)
+        await expect(result).resolves.toMatchObject({
+          exitCode: 0, timedOut: false, cancelled: false,
+          stdout: 'progress\n', stderr: 'diagnostic\n',
+        })
+        expect(childProcess.spawn).toHaveBeenCalledTimes(1)
+        const options = { cwd: launcher === 'node' ? dirname(entry) : undefined, detached: os !== 'win32' }
+        if (launcher === 'node') {
+          expectSpawn(0, nodeExecutable(), [
+            '--no-warnings', entry, 'plugin', '--profile', '工作 profile', ...args, '--reporter=ndjson',
+          ], options)
+        } else if (os === 'win32') {
+          // Independent expected command lines also pin quoting of spaces
+          // and the caret-bearing semver range at the actual spawn boundary.
+          const tail = args[1] === '@scope/plugin@^1.0.0'
+            ? 'add "@scope/plugin@^1.0.0"' : args.join(' ')
+          expectSpawn(0, 'cmd.exe', [
+            '/d', '/s', '/c', `"dsh plugin --profile "工作 profile" ${tail} --reporter=ndjson"`,
+          ], { ...options, windowsVerbatimArguments: true })
+        } else {
+          expectSpawn(0, 'dsh', ['plugin', '--profile', '工作 profile', ...args, '--reporter=ndjson'], options)
+        }
+        expect(vi.getTimerCount()).toBe(0)
+      })
+    })
+
+    it('hides the pnpm availability probe', async () => {
+      platform(os)
+      const { probePnpm } = await import('../src/dsh-cli.ts')
+      const result = probePnpm()
+      child.emit('close', 0)
+      await expect(result).resolves.toBe(true)
+      if (os === 'win32') {
+        expectSpawn(0, 'cmd.exe', ['/d', '/s', '/c', '"pnpm --version"'], { windowsVerbatimArguments: true })
+      } else {
+        expectSpawn(0, 'pnpm', ['--version'])
+      }
+    })
+  })
+
+  it('keeps the defensive non-Windows shim branch hidden and shell-free', async () => {
+    platform('win32')
+    const { probePnpm } = await import('../src/dsh-cli.ts')
+    // winCmdShim is captured on import; change the platform afterwards to
+    // exercise spawnShim's defensive viaShell-on-non-Windows branch.
+    platform('linux')
+    const result = probePnpm()
+    child.emit('close', 0)
+    await expect(result).resolves.toBe(true)
+    expectSpawn(0, 'pnpm', ['--version'])
+  })
+
+  it('hides provisioning and its timeout cleanup before falling back to npm', async () => {
+    platform('win32')
+    const { provisionPnpm } = await import('../src/dsh-cli.ts')
+    const result = provisionPnpm()
+    vi.advanceTimersByTime(59_999)
+    expect(childProcess.spawn).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1)
+    child.emit('close', 1)
+    // Let provisionPnpm enter each awaited probe/command before closing it.
+    await Promise.resolve()
+    childProcess.spawn.mock.results[2]!.value.emit('close', 1)
+    await Promise.resolve()
+    childProcess.spawn.mock.results[3]!.value.emit('close', 0)
+    await Promise.resolve()
+    childProcess.spawn.mock.results[4]!.value.emit('close', 0)
+    await expect(result).resolves.toEqual({ ok: true })
+    expect(childProcess.spawn).toHaveBeenCalledTimes(5)
+    expectSpawn(0, 'cmd.exe', ['/d', '/s', '/c', '"corepack enable pnpm"'], { windowsVerbatimArguments: true })
+    expectTaskkill(1)
+    expectSpawn(2, 'cmd.exe', ['/d', '/s', '/c', '"pnpm --version"'], { windowsVerbatimArguments: true })
+    expectSpawn(3, 'cmd.exe', ['/d', '/s', '/c', '"npm install -g pnpm"'], { windowsVerbatimArguments: true })
+    expectSpawn(4, 'cmd.exe', ['/d', '/s', '/c', '"pnpm --version"'], { windowsVerbatimArguments: true })
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each(['cancel', 'timeout'])('hides taskkill during plugin %s and preserves the result', async (reason) => {
+    platform('win32')
+    const { runDshPlugin, cancelActive, progress } = await import('../src/dsh-cli.ts')
+    const result = runDshPlugin('web', ['add', '@scope/plugin'])
+    if (reason === 'cancel') {
+      expect(cancelActive()).toBe(true)
+      expect(progress.cancelling).toBe(true)
+    } else {
+      vi.advanceTimersByTime(999)
+      expect(childProcess.spawn).toHaveBeenCalledTimes(1)
+      vi.advanceTimersByTime(1)
+    }
+    child.emit('close', 1)
+    await expect(result).resolves.toMatchObject({
+      exitCode: 1, cancelled: reason === 'cancel', timedOut: reason === 'timeout',
+    })
+    expect(childProcess.spawn).toHaveBeenCalledTimes(2)
+    expectTaskkill(1)
+    expect(cancelActive()).toBe(false)
+    expect(progress.active).toBe(false)
+    expect(progress.cancelling).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each([
+    ['%USERPROFILE%', '@scope/plugin'],
+    ['web', '@scope/plugin&whoami'],
+  ])('still rejects unsafe shim input: %s / %s', async (profile, target) => {
+    platform('win32')
+    const { runDshPlugin } = await import('../src/dsh-cli.ts')
+    await expect(runDshPlugin(profile, ['add', target])).resolves.toMatchObject({ exitCode: 1 })
+    expect(childProcess.spawn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #530

When `dsh web` is started by a console-less Windows host (such as Task Scheduler, wscript, or a desktop launcher), plugin operations can open blank console windows. Closing one interrupts the operation's process tree.

Set `windowsHide: true` on all three `spawnShim` branches and the `taskkill` calls in `killChild` and `killTree`. This covers plugin add/update/remove, pnpm probing/provisioning, cancellation, and timeout cleanup. Existing argv/quoting, shell, stdio, env, cwd, detached, safety checks, and termination behavior are preserved.

The new regression suite drives the production entry points and inspects the actual calls to `node:child_process.spawn`. It covers Windows and POSIX launch selection, direct Node and cmd shims, output collection, provisioning fallback, cancellation/timeout results, and unsafe-input rejection.

- Red: on the original implementation, 18 tests failed because `windowsHide` was missing; the two unsafe-input tests passed.
- Green: all 20 new tests passed after the fix. Removing the fix reproduced the 18 failures. Removing each of the five additions individually also failed the suite (10 / 1 / 5 / 1 / 2 failures respectively).

Local validation (WSL, Node 24):

```sh
without-proxy npm test -- tests/dsh-cli-spawn.spec.ts tests/dsh-cli.spec.ts tests/provision.spec.ts
without-proxy npm test
without-proxy npm run check
without-proxy node scripts/preflight.mjs
without-proxy node scripts/validate-registry.mjs
without-proxy node scripts/smoke-spawn.mjs
without-proxy npm run test:compat
without-proxy npm run test:web
```

The focused suite passed 52 tests; the full unit suite passed 1,312 tests across 59 files; the real pnpm compatibility suite passed all 14 tests. Typecheck, build, restart smoke, preflight, registry validation, and spawn smoke passed. Local Web E2E skipped all 40 tests because no DSH CLI is installed; the real DSH Web checks run in CI.

GitHub CI on the exact PR commit (`b3713f35c201c0c7e3918911227d70071d2aae3b`): the [unchanged CI workflow dispatched on the fork](https://github.com/bulingbuling688/dsh-market/actions/runs/34098461283) passed all six executable jobs: Ubuntu/Windows check, pnpm compatibility, Ubuntu Web E2E on DSH rc.8 and alpha.2, and Windows Web E2E on DSH rc.8. The PR-only `wrong-repo-guard` was skipped for workflow_dispatch; the catalog snapshot is untouched.

Automated regression coverage was added and the Windows CI lane passed.
Manual verification under a console-less Windows host was not performed locally.

The [upstream PR workflow](https://github.com/dsh-market/dsh-market/actions/runs/34098351984) is still `action_required` with no jobs started, pending maintainer approval for this external contribution. The successful fork run does not replace that upstream approval/check.

- [x] `npm test` and `npm run check` pass locally.
- [x] Regression tests fail without the fix.
- [x] No version bump or unrelated changes.
- [x] No `src/client/` changes; the check rebuilt the client bundle without a diff. No `lib/` output is committed.
