### PR TITLE
fix: skip disabled plugins in update-all

### DIFF
--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -2958,7 +2958,11 @@ export function MarketSection(props: MarketSectionProps) {
   // mid-run, which would strand the remaining items.
   const selfName = installed['dshmarket'] !== undefined ? 'dshmarket' : 'dsh-market'
   const updatableNames = Object.keys(installed).filter(
-    name => name !== selfName && !updatedNames.includes(name) && updates[name] && updates[name].updateAvailable,
+    name => name !== selfName
+      && !updatedNames.includes(name)
+      && !effectiveDisabledSet.has(name)
+      && updates[name]
+      && updates[name].updateAvailable,
   )
   // Replacing a local source with its catalog source is deliberately not a
   // batch update: every such plugin has an existing, explicit confirmation

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -2664,6 +2664,33 @@ describe('local-dev restore', () => {
     expect(fetchCalls.some(call => call.body?.restore === true)).toBe(false)
   })
 
+  it('skips disabled plugins from Update all', async () => {
+    stubFetch({
+      '/dsh-market/installed': {
+        profile: 'web',
+        installed: { 'dsh-loop': '^1.0.0', 'dsh-notify': '^1.0.0', 'dsh-third': '^1.0.0' },
+        live: [],
+        disabled: ['dsh-third'],
+      },
+      '/dsh-market/updates': {
+        updates: {
+          'dsh-loop': { kind: 'npm', version: '1.0.0', latest: '1.1.0', updateAvailable: true },
+          'dsh-notify': { kind: 'npm', version: '1.0.0', latest: '1.1.0', updateAvailable: true },
+          'dsh-third': { kind: 'npm', version: '1.0.0', latest: '1.1.0', updateAvailable: true },
+        },
+      },
+      '/dsh-market/update': { ok: true },
+    })
+    render(<MarketSection {...props()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Update all \(2\)/ }))
+    await waitFor(() => {
+      expect(fetchCalls.filter(call => call.path === '/dsh-market/update')).toHaveLength(2)
+    })
+    expect(fetchCalls.filter(call => call.path === '/dsh-market/update').map(call => call.body?.name).sort())
+      .toEqual(['dsh-loop', 'dsh-notify'])
+  })
+
   it('says a name-only catalog match is unverified, and names whose plugin it is (#485)', async () => {
     // The local copy declares no repository, so the catalog row below agreed
     // on nothing but the package name — and its owner may be a stranger.


### PR DESCRIPTION
## Summary
- exclude disabled plugins from the Update all queue
- keep explicit per-plugin updates unchanged
- link this behavior to the profile-migration failure reported in #537

Closes #537

## Verification
- `npm run typecheck` passes
- `npm test` passes: 58 files, 1292 tests
- `npm ci` and the package build completed successfully

## Scope
This prevents known-disabled plugins from being selected by batch update. It does not suppress an explicit update click, and it does not replace host-side peer validation diagnostics.