### PR TITLE
fix: resolve installed npm plugins by repository evidence

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -307,6 +307,21 @@ export function holdsNativeAddon(profile: string, name: string, explicitDir?: st
 
 const PACKAGE_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/i
 
+/** Registry versions/ranges/tags, optionally under an npm alias. This only
+ * gates manifest discovery; it does not validate npm's full spec grammar.
+ * Paths, archives and other protocols must retain their own source evidence.
+ */
+function isRegistrySpec(spec: string): boolean {
+  let selector = spec.trim()
+  if (selector.startsWith('npm:')) {
+    const alias = /^npm:((?:@[^/]+\/)?[^@]+)(?:@(.*))?$/.exec(selector)
+    if (alias === null || !PACKAGE_NAME_RE.test(alias[1]!)) return false
+    selector = alias[2] ?? '*'
+  }
+  return !/\.(?:tgz|tar|tar\.gz)$/i.test(selector)
+    && /^[a-z0-9~^<>=*|+.\s-]*$/i.test(selector)
+}
+
 function localSpecDirectory(root: string, spec: string): string | null {
   const match = /^(?:link|file):(.+)$/i.exec(spec)
   if (match === null) return null
@@ -408,10 +423,10 @@ function checkoutSubpath(root: string, packageDir: string): string | null {
 }
 
 /**
- * Strong repository identities for a locally linked dependency (#141).
- * Explicit github: specs already carry this evidence; only link:/file: need
- * filesystem discovery. This compatibility wrapper returns only declared
- * package.json identities; Git origins are exposed separately as hints.
+ * Strong repository identities for npm and locally linked dependencies.
+ * Explicit Git/URL specs retain their own source evidence.
+ * This compatibility wrapper returns only declared package.json identities;
+ * Git origins are exposed separately as hints.
  */
 export function readInstalledRepoIdentities(
   profile: string,
@@ -429,8 +444,8 @@ export interface InstalledRepoEvidence {
 
 /**
  * Discover declared repository identities and weaker local-origin hints. A
- * package.json repository declaration is authoritative; Git origin is only a
- * disambiguation hint because a checkout may legitimately point at a fork.
+ * package.json repository declaration identifies npm/local installs. Git
+ * origin is only a hint because a checkout may legitimately point at a fork.
  */
 export function readInstalledRepoEvidence(
   profile: string,
@@ -438,9 +453,11 @@ export function readInstalledRepoEvidence(
   spec: string,
   explicitDir?: string,
 ): InstalledRepoEvidence {
-  if (!PACKAGE_NAME_RE.test(name) || !/^(?:link|file):/i.test(spec)) return { identities: [], hints: [] }
+  if (!PACKAGE_NAME_RE.test(name)) return { identities: [], hints: [] }
+  const local = /^(?:link|file):/i.test(spec)
+  if (!local && !isRegistrySpec(spec)) return { identities: [], hints: [] }
   const root = profileDir(profile, explicitDir)
-  const sourceDir = localSpecDirectory(root, spec)
+  const sourceDir = local ? localSpecDirectory(root, spec) : null
   const installedDir = installedPackageDirectory(root, name)
   const manifestDir = installedDir ?? sourceDir
   const manifest = manifestDir === null ? readInstalledManifest(profile, name, explicitDir) : manifestAt(manifestDir)

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -434,6 +434,38 @@ describe('MarketSection (jsdom)', () => {
     expect(within(otherCard).queryByText(en.alreadyInstalled)).toBeNull()
   })
 
+  it.each([false, true])('keeps same-named npm cards source-specific through filtering (reversed=%s, #544)', async reversed => {
+    const plugins = [
+      { name: 'dsh-mermaid', owner: 'AKS1st', url: 'https://github.com/AKS1st/dsh-mermaid', category: 'tools', npm: null, description: { en: 'Other diagrams' }, install: '' },
+      { name: 'dsh-mermaid', owner: 'MrmoLabs', url: 'https://github.com/MrmoLabs/dsh-mermaid', category: 'skill', npm: 'dsh-mermaid', description: { en: 'Installed diagrams' }, install: '' },
+    ]
+    if (reversed) plugins.reverse()
+    stubFetch({
+      '/dsh-market/registry': { source: 'snapshot', registry: { updated: '', count: 2, categories: REGISTRY.categories, plugins } },
+      '/dsh-market/installed': {
+        profile: 'web', installed: { 'dsh-mermaid': '^0.4.0' },
+        repoIdentities: { 'dsh-mermaid': ['mrmolabs/dsh-mermaid'] }, repoHints: {}, live: ['dsh-mermaid'],
+      },
+    })
+    render(<MarketSection {...props()} />)
+    const own = await screen.findByText('MrmoLabs')
+    expect(within(own.closest('div[class*="card"]') as HTMLElement).getByText(en.alreadyInstalled)).toBeTruthy()
+    const assertOther = () => {
+      const card = screen.getByText('AKS1st').closest('div[class*="card"]') as HTMLElement
+      expect(within(card).getByRole('button', { name: en.install })).toBeTruthy()
+      expect(within(card).queryByText(en.alreadyInstalled)).toBeNull()
+    }
+    assertOther()
+    fireEvent.change(screen.getByPlaceholderText(en.searchPh), { target: { value: 'AKS1st' } })
+    await waitFor(() => expect(screen.queryByText('MrmoLabs')).toBeNull())
+    assertOther()
+    fireEvent.change(screen.getByPlaceholderText(en.searchPh), { target: { value: '' } })
+    await screen.findByText('MrmoLabs')
+    fireEvent.click(screen.getByRole('button', { name: 'Tools' }))
+    await waitFor(() => expect(screen.queryByText('MrmoLabs')).toBeNull())
+    assertOther()
+  })
+
   it('shows shared host dependency findings from the installed snapshot', async () => {
     const findings = Array.from({ length: 7 }, (_, index) => ({
       code: 'shared-host-package-dependency',

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -703,6 +703,33 @@ describe('host-provided profile and package-operation seams', () => {
     expect(cancel).toHaveBeenCalledOnce()
   })
 
+  it('returns installed npm repository evidence from the host profile and refreshes it (#544)', async () => {
+    bed.dispose()
+    const root = join(home, 'npm-evidence-profile')
+    const dir = join(root, 'node_modules', 'dsh-mermaid')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ dependencies: { 'dsh-mermaid': '^0.4.0' } }))
+    const manifest = { name: 'dsh-mermaid', version: '0.4.0', repository: { type: 'git', url: 'git+https://github.com/MrmoLabs/dsh-mermaid.git' } }
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest))
+    fake.profileDir = root
+    bed = createTestbed({ profile: 'web', profileDirectory: root })
+    const response = await bed.dispatch('GET', '/dsh-market/installed')
+    expect(response.status).toBe(200)
+    expect(response.json).toMatchObject({
+      installed: { 'dsh-mermaid': '^0.4.0' },
+      repoIdentities: { 'dsh-mermaid': ['mrmolabs/dsh-mermaid'] },
+      repoHints: {},
+    })
+    manifest.repository.url = 'https://github.com/AKS1st/dsh-mermaid'
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest))
+    expect((await bed.dispatch('GET', '/dsh-market/installed')).json.repoIdentities)
+      .toEqual({ 'dsh-mermaid': ['aks1st/dsh-mermaid'] })
+    writeFileSync(join(dir, 'package.json'), '{')
+    const missing = await bed.dispatch('GET', '/dsh-market/installed')
+    expect(missing.status).toBe(200)
+    expect(missing.json.repoIdentities).toEqual({})
+  })
+
   it('maps a generation-wide Desktop package-operation gate to conflict', async () => {
     bed.dispose()
     bed = createTestbed({}, {

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -4,9 +4,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { entryForDep, isInstalled } from '../src/client/market-data.ts'
 import { resolveDshHome } from '../src/home-paths.ts'
 import {
   addProfileBundle, conflictingEntryIds, dropFromManifest, entryArtifactExists, hasDshManifest, hasLoadableEntry, holdsNativeAddon, isDshProfileName, pluginSubdirs, profileDir,
@@ -15,12 +16,14 @@ import {
 } from '../src/profile.ts'
 
 let home: string
+const originalDshHome = process.env.DSH_HOME
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'dshm-home-'))
   process.env.DSH_HOME = home
 })
 afterEach(() => {
-  delete process.env.DSH_HOME
+  if (originalDshHome === undefined) delete process.env.DSH_HOME
+  else process.env.DSH_HOME = originalDshHome
   rmSync(home, { recursive: true, force: true })
 })
 
@@ -252,6 +255,81 @@ describe('readInstalledRepoEvidence (#141)', () => {
       expect(readInstalledRepoIdentities('web', 'local-plugin', '^1.0.0')).toEqual([])
     } finally {
       rmSync(target, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('installed npm repository evidence (#544)', () => {
+  function install(name: string, manifest: unknown, root = writeProfile({ dependencies: { [name]: '^0.4.0' } })): string {
+    const dir = join(root, 'node_modules', name)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest))
+    return dir
+  }
+
+  it.each(['^0.4.0', '0.4.0', '~0.4.0', 'latest', 'next', '*', '>=0.4.0 <1', '0.4.0 || 1.x', 'npm:dsh-mermaid@^0.4.0', 'npm:@scope/mermaid@next'])(
+    'reads the actually installed manifest for %s', spec => {
+      install('dsh-mermaid', { name: 'dsh-mermaid', version: '0.4.0', repository: { type: 'git', url: 'git+https://github.com/MrmoLabs/dsh-mermaid.git' } })
+      expect(readInstalledRepoEvidence('web', 'dsh-mermaid', spec))
+        .toEqual({ identities: ['mrmolabs/dsh-mermaid'], hints: [] })
+    },
+  )
+
+  it('resolves a scoped alias through a pnpm symlink in the explicit profile and refreshes changed metadata', () => {
+    const root = join(home, 'desktop-profile')
+    const target = install('actual-name', { name: 'actual-name', repository: 'https://github.com/Owner/Repo' }, join(root, 'node_modules', '.pnpm', 'actual-name@1'))
+    mkdirSync(join(root, 'node_modules', '@scope'), { recursive: true })
+    symlinkSync(target, join(root, 'node_modules', '@scope', 'alias'), 'junction')
+    const read = () => readInstalledRepoEvidence('web', '@scope/alias', 'npm:actual-name@1', root)
+    expect(read()).toEqual({ identities: ['owner/repo'], hints: [] })
+    writeFileSync(join(target, 'package.json'), JSON.stringify({ repository: { url: 'https://github.com/Other/Collection', directory: 'packages/actual-name' } }))
+    expect(read()).toEqual({ identities: ['other/collection', 'other/collection#path:/packages/actual-name'], hints: [] })
+    expect(readInstalledRepoEvidence('web', '@scope/alias', 'npm:actual-name@1')).toEqual({ identities: [], hints: [] })
+  })
+
+  it.each([
+    'github:fork/plugin', 'fork/plugin', 'git+https://github.com/fork/plugin.git',
+    'git+https://gitlab.com/fork/plugin.git', 'git@gitlab.com:fork/plugin.git',
+    'https://github.com/fork/plugin', 'https://example.com/plugin.tgz',
+    './plugin.tgz', 'plugin.tgz', 'workspace:*', 'patch:plugin@1#patch',
+    'npm:plugin@github:fork/plugin',
+  ])('does not override an explicit non-registry source: %s', spec => {
+    install('plugin', { repository: 'https://github.com/upstream/plugin' })
+    expect(readInstalledRepoEvidence('web', 'plugin', spec)).toEqual({ identities: [], hints: [] })
+  })
+
+  it('matches only the declared monorepo subpackage, and keeps ambiguous missing evidence unmatched', () => {
+    const plugins = ['packages/one', 'packages/two'].map(path => ({
+      name: 'plugin', owner: 'owner', npm: null, category: 'tools', description: {}, install: '',
+      url: `https://github.com/owner/collection/tree/main/${path}`,
+    }))
+    install('plugin', { repository: { url: 'https://github.com/owner/collection', directory: 'packages/one' } })
+    const evidence = readInstalledRepoEvidence('web', 'plugin', '^1')
+    for (const catalog of [plugins, [...plugins].reverse()]) {
+      expect(isInstalled(plugins[0]!, { plugin: '^1' }, { plugin: evidence.identities }, catalog)).toBe(true)
+      expect(isInstalled(plugins[1]!, { plugin: '^1' }, { plugin: evidence.identities }, catalog)).toBe(false)
+      expect(entryForDep(catalog, 'plugin', '^1', evidence.identities)).toBe(plugins[0])
+      for (const plugin of catalog) expect(isInstalled(plugin, { plugin: '^1' }, {}, catalog)).toBe(false)
+    }
+    expect(isInstalled(plugins[0]!, { plugin: '^1' }, {}, [plugins[0]!])).toBe(true)
+  })
+
+  it('ignores missing, corrupt and invalid manifests without borrowing the surrounding Git origin', () => {
+    const root = writeProfile({})
+    mkdirSync(join(root, '.git'))
+    writeFileSync(join(root, '.git', 'config'), '[remote "origin"]\nurl = https://github.com/parent/repo.git\n')
+    const empty = { identities: [], hints: [] }
+    expect(readInstalledRepoEvidence('web', 'plugin', '^1')).toEqual(empty)
+    const dir = install('plugin', {}, root)
+    for (const contents of ['{', 'null', '{}', '{"repository":42}', '{"repository":{"url":false}}', '{"repository":"https://example.com/o/r"}', '{"repository":{"url":"https://github.com/o/r","directory":"../sibling"}}']) {
+      writeFileSync(join(dir, 'package.json'), contents)
+      expect(readInstalledRepoEvidence('web', 'plugin', '^1'), contents).toEqual(empty)
+    }
+    // Without the package-name guard, ../outside would read this manifest.
+    mkdirSync(join(root, 'outside'))
+    writeFileSync(join(root, 'outside', 'package.json'), JSON.stringify({ repository: 'https://github.com/outside/repo' }))
+    for (const name of ['../../outside', '../outside', '@scope/../../outside', '/outside', 'bad\\name', '']) {
+      expect(readInstalledRepoEvidence('web', name, '^1')).toEqual(empty)
     }
   })
 })


### PR DESCRIPTION
An npm-installed `dsh-mermaid@^0.4.0` could leave both same-named Discover cards showing Install, even though its installed manifest declares MrmoLabs/dsh-mermaid. The evidence reader rejected every non-local spec before reading that manifest.

Read repository declarations from the active profile's installed packages for registry versions, ranges, tags and npm aliases. Keep explicit Git/URL sources excluded and preserve local link/file evidence and Git hints. Existing matching now marks the correct repository's card as installed, including after search or category filtering. No client production changes are needed. This does not implement #432's URL-tarball sidecar lookup.

Closes #544.

Validation:

- Regression tests failed against the original helper and real installed route with missing repository identities, then passed. An isolated copy with the original production code reproduced 13 failing assertions.
- Full suite: 59 files / 1349 tests passed (28 added); focused profile, matching, sources, routes and component tests: 485 passed. The clean main baseline passed 1321 tests. Used a child-process environment without ambient proxy variables so existing mocked-network tests use their fetch stubs.
- `npm run check`, preflight, registry validation, spawn smoke and `git diff --check` passed. pnpm compatibility: 14 passed. Client rebuild matches the committed artifact; no version, dependency or artifact changes.
- Real DSH 0.1.0-rc.8 and 0.1.2-alpha.2 + Chromium on Linux/WSL: one targeted check passed on each, without skips. Used temporary profile manifest fixtures and a fixed catalog, with the real installed endpoint and production client; verified correct card identity after search/category filtering. This does not test installing or activating the third-party Mermaid plugin. No trace/HAR capture. No macOS hardware validation.
- The same rc.8 scenario was also demonstrated in a visible local Chromium window. Fork/upstream CI is pending.

### For code changes

- [x] `npm test` and `npm run check` pass locally.
- [x] Tests cover the change, including regressions that fail without it.
- [x] No version bump.
- [x] Client rebuild verified unchanged; no `src/client/` changes.
