### PR TITLE
fix: debounce market search inputs

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -1144,7 +1144,16 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 		* rather than guessing; declared repo evidence that matches nothing in the
 		* catalog must not fall back to a coincidental unique name.
 		*/
-		function findCatalogEntryForLocal(plugins, name, identities = [], hints = []) {
+		const localMatchCache = /* @__PURE__ */ new WeakMap();
+		function localMatchKey(name, identities, hints) {
+			return [
+				name.toLowerCase(),
+				...identities.map((value) => value.toLowerCase()).sort(),
+				"",
+				...hints.map((value) => value.toLowerCase()).sort()
+			].join("\\u0000");
+		}
+		function findCatalogEntryForLocalUncached(plugins, name, identities = [], hints = []) {
 			const nameKey = name.toLowerCase();
 			const byName = plugins.filter((plugin) => plugin.name.toLowerCase() === nameKey || typeof plugin.npm === "string" && plugin.npm.toLowerCase() === nameKey);
 			const identitySet = new Set(identities.map((value) => value.toLowerCase()));
@@ -1178,6 +1187,18 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 				if (hinted !== void 0) return hinted;
 			}
 			return null;
+		}
+		function findCatalogEntryForLocal(plugins, name, identities = [], hints = []) {
+			let cache = localMatchCache.get(plugins);
+			if (cache === void 0) {
+				cache = /* @__PURE__ */ new Map();
+				localMatchCache.set(plugins, cache);
+			}
+			const key = localMatchKey(name, identities, hints);
+			if (cache.has(key)) return cache.get(key) ?? null;
+			const result = findCatalogEntryForLocalUncached(plugins, name, identities, hints);
+			cache.set(key, result);
+			return result;
 		}
 		function catalogEntriesByName(plugins, name) {
 			const nameKey = name.toLowerCase();
@@ -2713,6 +2734,64 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 						"aria-busy": state === "loading"
 					})
 				]
+			});
+		}
+		/** Keep keystrokes out of the market's large render tree, not just its filter.
+		* Only settled queries reach the parent. Explicit navigation remains immediate.
+		*/
+		function SearchInput({ value, onCommit, className, placeholder, resetToken }) {
+			const [draft, setDraft] = (0, react.useState)(value);
+			const timer = (0, react.useRef)(null);
+			const composing = (0, react.useRef)(false);
+			const cancel = (0, react.useCallback)(() => {
+				if (timer.current !== null) clearTimeout(timer.current);
+				timer.current = null;
+			}, []);
+			const commit = (next) => {
+				cancel();
+				onCommit(next);
+			};
+			const schedule = (next) => {
+				cancel();
+				if (composing.current) return;
+				if (next === "") commit(next);
+				else timer.current = setTimeout(() => commit(next), 250);
+			};
+			(0, react.useLayoutEffect)(() => {
+				cancel();
+				setDraft(value);
+			}, [
+				value,
+				resetToken,
+				cancel
+			]);
+			(0, react.useEffect)(() => cancel, [cancel]);
+			return /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Input, {
+				className,
+				icon: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconSearchOutline16, { size: 14 }),
+				placeholder,
+				value: draft,
+				onChange: (event) => {
+					const next = event.target.value;
+					setDraft(next);
+					schedule(next);
+				},
+				onCompositionStart: () => {
+					composing.current = true;
+					cancel();
+				},
+				onCompositionEnd: (event) => {
+					composing.current = false;
+					const next = event.currentTarget.value;
+					setDraft(next);
+					schedule(next);
+				},
+				onKeyDown: (event) => {
+					if (event.key === "Enter" && !composing.current && !event.nativeEvent.isComposing && event.keyCode !== 229) commit(event.currentTarget.value);
+				},
+				onBlur: (event) => {
+					if (!composing.current) commit(event.currentTarget.value);
+				}
 			});
 		}
 		//#endregion
@@ -6149,6 +6228,8 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 				return saved || "discover";
 			});
 			const [q, setQ] = (0, react.useState)("");
+			const [discoverSearchReset, resetDiscoverSearch] = (0, react.useState)(0);
+			const [installedSearchReset, resetInstalledSearch] = (0, react.useState)(0);
 			/** Per-tab searches stay independent: discover / themes / installed. */
 			const [qThemes, setQThemes] = (0, react.useState)("");
 			const [qFavorites, setQFavorites] = (0, react.useState)("");
@@ -6163,10 +6244,12 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 				if (kind === "installed") {
 					setTab("installed");
 					setQInstalled(value);
+					resetInstalledSearch((n) => n + 1);
 				} else if (kind === "discover") {
 					setTab("discover");
 					setCat("all");
 					setQ(value);
+					resetDiscoverSearch((n) => n + 1);
 				}
 			}, [props.preferredSubsectionId]);
 			const [confirming, setConfirming] = (0, react.useState)(null);
@@ -9241,13 +9324,13 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 								className: Market_module_css_default.stickyHead,
 								children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
 									className: Market_module_css_default.tabSearchRow,
-									children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Input, {
+									children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(SearchInput, {
+										resetToken: discoverSearchReset,
 										className: Market_module_css_default.tabSearch,
-										icon: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconSearchOutline16, { size: 14 }),
 										placeholder: t("searchPh"),
 										value: q,
-										onChange: (e) => setQ(e.target.value)
-									})
+										onCommit: setQ
+									}, "discover")
 								}), /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
 									className: Market_module_css_default.cats,
 									children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
@@ -9331,13 +9414,12 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 							children: t("favoritesEmpty")
 						}) : /* @__PURE__ */ (0, react_jsx_runtime.jsxs)(react_jsx_runtime.Fragment, { children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
 							className: Market_module_css_default.themeToolbar,
-							children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Input, {
+							children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)(SearchInput, {
 								className: Market_module_css_default.themeSearch,
-								icon: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconSearchOutline16, { size: 14 }),
 								placeholder: t("searchFavoritesPh"),
 								value: qFavorites,
-								onChange: (e) => setQFavorites(e.target.value)
-							}), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
+								onCommit: setQFavorites
+							}, "favorites"), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
 								className: Market_module_css_default.themeToolbarActions,
 								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(FilterMenu, {
 									sortField: favSortField,
@@ -9418,13 +9500,12 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 						] })] }) : tab === "themes" && themeSnap !== null ? /* @__PURE__ */ (0, react_jsx_runtime.jsxs)(react_jsx_runtime.Fragment, { children: [
 							/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
 								className: Market_module_css_default.themeToolbar,
-								children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Input, {
+								children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)(SearchInput, {
 									className: Market_module_css_default.themeSearch,
-									icon: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconSearchOutline16, { size: 14 }),
 									placeholder: t("searchPh"),
 									value: qThemes,
-									onChange: (e) => setQThemes(e.target.value)
-								}), /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
+									onCommit: setQThemes
+								}, "themes"), /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
 									className: Market_module_css_default.themeToolbarActions,
 									children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)(FilterMenu, {
 										sortField: themeSortField,
@@ -9506,13 +9587,13 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 							}),
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
 								className: Market_module_css_default.tabSearchRow,
-								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Input, {
+								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(SearchInput, {
+									resetToken: installedSearchReset,
 									className: Market_module_css_default.tabSearch,
-									icon: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconSearchOutline16, { size: 14 }),
 									placeholder: t("searchPh"),
 									value: qInstalled,
-									onChange: (e) => setQInstalled(e.target.value)
-								})
+									onCommit: setQInstalled
+								}, "installed")
 							}),
 							installedView === "groups" ? /* @__PURE__ */ (0, react_jsx_runtime.jsxs)(react_jsx_runtime.Fragment, { children: [
 								/* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {

--- a/client/client.js
+++ b/client/client.js
@@ -1144,16 +1144,7 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 		* rather than guessing; declared repo evidence that matches nothing in the
 		* catalog must not fall back to a coincidental unique name.
 		*/
-		const localMatchCache = /* @__PURE__ */ new WeakMap();
-		function localMatchKey(name, identities, hints) {
-			return [
-				name.toLowerCase(),
-				...identities.map((value) => value.toLowerCase()).sort(),
-				"",
-				...hints.map((value) => value.toLowerCase()).sort()
-			].join("\\u0000");
-		}
-		function findCatalogEntryForLocalUncached(plugins, name, identities = [], hints = []) {
+		function findCatalogEntryForLocal(plugins, name, identities = [], hints = []) {
 			const nameKey = name.toLowerCase();
 			const byName = plugins.filter((plugin) => plugin.name.toLowerCase() === nameKey || typeof plugin.npm === "string" && plugin.npm.toLowerCase() === nameKey);
 			const identitySet = new Set(identities.map((value) => value.toLowerCase()));
@@ -1187,18 +1178,6 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 				if (hinted !== void 0) return hinted;
 			}
 			return null;
-		}
-		function findCatalogEntryForLocal(plugins, name, identities = [], hints = []) {
-			let cache = localMatchCache.get(plugins);
-			if (cache === void 0) {
-				cache = /* @__PURE__ */ new Map();
-				localMatchCache.set(plugins, cache);
-			}
-			const key = localMatchKey(name, identities, hints);
-			if (cache.has(key)) return cache.get(key) ?? null;
-			const result = findCatalogEntryForLocalUncached(plugins, name, identities, hints);
-			cache.set(key, result);
-			return result;
 		}
 		function catalogEntriesByName(plugins, name) {
 			const nameKey = name.toLowerCase();

--- a/src/catalog-local-match.ts
+++ b/src/catalog-local-match.ts
@@ -46,13 +46,7 @@ function catalogEntryMatchesHints(
  * rather than guessing; declared repo evidence that matches nothing in the
  * catalog must not fall back to a coincidental unique name.
  */
-const localMatchCache = new WeakMap<object, Map<string, unknown>>()
-
-function localMatchKey(name: string, identities: readonly string[], hints: readonly string[]): string {
-  return [name.toLowerCase(), ...identities.map(value => value.toLowerCase()).sort(), '', ...hints.map(value => value.toLowerCase()).sort()].join('\\u0000')
-}
-
-function findCatalogEntryForLocalUncached<T extends { name: string; npm?: string | null; url: string }>(
+export function findCatalogEntryForLocal<T extends { name: string; npm?: string | null; url: string }>(
   plugins: readonly T[],
   name: string,
   identities: readonly string[] = [],
@@ -94,24 +88,6 @@ function findCatalogEntryForLocalUncached<T extends { name: string; npm?: string
     if (hinted !== undefined) return hinted
   }
   return null
-}
-
-export function findCatalogEntryForLocal<T extends { name: string; npm?: string | null; url: string }>(
-  plugins: readonly T[],
-  name: string,
-  identities: readonly string[] = [],
-  hints: readonly string[] = [],
-): T | null {
-  let cache = localMatchCache.get(plugins as object)
-  if (cache === undefined) {
-    cache = new Map<string, unknown>()
-    localMatchCache.set(plugins as object, cache)
-  }
-  const key = localMatchKey(name, identities, hints)
-  if (cache.has(key)) return (cache.get(key) ?? null) as T | null
-  const result = findCatalogEntryForLocalUncached(plugins, name, identities, hints)
-  cache.set(key, result)
-  return result
 }
 
 function catalogEntriesByName<T extends { name: string; npm?: string | null }>(

--- a/src/catalog-local-match.ts
+++ b/src/catalog-local-match.ts
@@ -46,7 +46,13 @@ function catalogEntryMatchesHints(
  * rather than guessing; declared repo evidence that matches nothing in the
  * catalog must not fall back to a coincidental unique name.
  */
-export function findCatalogEntryForLocal<T extends { name: string; npm?: string | null; url: string }>(
+const localMatchCache = new WeakMap<object, Map<string, unknown>>()
+
+function localMatchKey(name: string, identities: readonly string[], hints: readonly string[]): string {
+  return [name.toLowerCase(), ...identities.map(value => value.toLowerCase()).sort(), '', ...hints.map(value => value.toLowerCase()).sort()].join('\\u0000')
+}
+
+function findCatalogEntryForLocalUncached<T extends { name: string; npm?: string | null; url: string }>(
   plugins: readonly T[],
   name: string,
   identities: readonly string[] = [],
@@ -88,6 +94,24 @@ export function findCatalogEntryForLocal<T extends { name: string; npm?: string 
     if (hinted !== undefined) return hinted
   }
   return null
+}
+
+export function findCatalogEntryForLocal<T extends { name: string; npm?: string | null; url: string }>(
+  plugins: readonly T[],
+  name: string,
+  identities: readonly string[] = [],
+  hints: readonly string[] = [],
+): T | null {
+  let cache = localMatchCache.get(plugins as object)
+  if (cache === undefined) {
+    cache = new Map<string, unknown>()
+    localMatchCache.set(plugins as object, cache)
+  }
+  const key = localMatchKey(name, identities, hints)
+  if (cache.has(key)) return (cache.get(key) ?? null) as T | null
+  const result = findCatalogEntryForLocalUncached(plugins, name, identities, hints)
+  cache.set(key, result)
+  return result
 }
 
 function catalogEntriesByName<T extends { name: string; npm?: string | null }>(

--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -36,6 +36,7 @@ import {
 } from '@deepseek-ai/dsh-client-ui-primitives'
 import css from './Market.module.css'
 import { CommentsModal } from './CommentsModal.tsx'
+import { SearchInput } from './SearchInput.tsx'
 import { OperationsPanel } from './OperationsPanel.tsx'
 import { clearSettled, drop, enqueue, patch as patchRecord, recordForUrl } from './operations.ts'
 import type { OperationRecord } from './operations.ts'
@@ -1216,6 +1217,8 @@ export function MarketSection(props: MarketSectionProps) {
     return saved || 'discover'
   })
   const [q, setQ] = useState('')
+  const [discoverSearchReset, resetDiscoverSearch] = useState(0)
+  const [installedSearchReset, resetInstalledSearch] = useState(0)
   /** Per-tab searches stay independent: discover / themes / installed. */
   const [qThemes, setQThemes] = useState('')
   const [qFavorites, setQFavorites] = useState('')
@@ -1231,10 +1234,12 @@ export function MarketSection(props: MarketSectionProps) {
     if (kind === 'installed') {
       setTab('installed')
       setQInstalled(value)
+      resetInstalledSearch(n => n + 1)
     } else if (kind === 'discover') {
       setTab('discover')
       setCat('all')
       setQ(value)
+      resetDiscoverSearch(n => n + 1)
     }
   }, [props.preferredSubsectionId])
   const [confirming, setConfirming] = useState<RegistryPlugin | null>(null)
@@ -4152,7 +4157,7 @@ export function MarketSection(props: MarketSectionProps) {
                     <div ref={setCatsSentinel} />
                     <div className={css.stickyHead}>
                     <div className={css.tabSearchRow}>
-                      <Input className={css.tabSearch} icon={<IconSearchOutline16 size={14} />} placeholder={t('searchPh')} value={q} onChange={e => setQ(e.target.value)} />
+                      <SearchInput key="discover" resetToken={discoverSearchReset} className={css.tabSearch} placeholder={t('searchPh')} value={q} onCommit={setQ} />
                     </div>
                     <div className={css.cats}>
                       <div className={css.catsRow}>
@@ -4251,12 +4256,12 @@ export function MarketSection(props: MarketSectionProps) {
                 : (
                     <>
                       <div className={css.themeToolbar}>
-                        <Input
+                        <SearchInput
+                          key="favorites"
                           className={css.themeSearch}
-                          icon={<IconSearchOutline16 size={14} />}
                           placeholder={t('searchFavoritesPh')}
                           value={qFavorites}
-                          onChange={e => setQFavorites(e.target.value)}
+                          onCommit={setQFavorites}
                         />
                         <div className={css.themeToolbarActions}>
                           <FilterMenu
@@ -4342,7 +4347,7 @@ export function MarketSection(props: MarketSectionProps) {
             ? (
                 <>
                   <div className={css.themeToolbar}>
-                    <Input className={css.themeSearch} icon={<IconSearchOutline16 size={14} />} placeholder={t('searchPh')} value={qThemes} onChange={e => setQThemes(e.target.value)} />
+                    <SearchInput key="themes" className={css.themeSearch} placeholder={t('searchPh')} value={qThemes} onCommit={setQThemes} />
                     <div className={css.themeToolbarActions}>
                       <FilterMenu
                         sortField={themeSortField}
@@ -4412,7 +4417,7 @@ export function MarketSection(props: MarketSectionProps) {
                     <button type="button" className={installedView === 'groups' ? `${css.viewBtn} ${css.viewOn}` : css.viewBtn} onClick={() => setInstalledView('groups')}>{t('tabGroups')}</button>
                   </div>
                   <div className={css.tabSearchRow}>
-                    <Input className={css.tabSearch} icon={<IconSearchOutline16 size={14} />} placeholder={t('searchPh')} value={qInstalled} onChange={e => setQInstalled(e.target.value)} />
+                    <SearchInput key="installed" resetToken={installedSearchReset} className={css.tabSearch} placeholder={t('searchPh')} value={qInstalled} onCommit={setQInstalled} />
                   </div>
                   {installedView === 'groups'
                       ? (

--- a/src/client/SearchInput.tsx
+++ b/src/client/SearchInput.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { IconSearchOutline16, Input } from '@deepseek-ai/dsh-client-ui-primitives'
+
+export const SEARCH_DELAY_MS = 250
+
+/** Keep keystrokes out of the market's large render tree, not just its filter.
+ * Only settled queries reach the parent. Explicit navigation remains immediate.
+ */
+export function SearchInput({ value, onCommit, className, placeholder, resetToken }: {
+  value: string
+  onCommit: (value: string) => void
+  className?: string
+  placeholder?: string
+  /** Explicit navigation can repeat the already committed query. */
+  resetToken?: number
+}) {
+  const [draft, setDraft] = useState(value)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const composing = useRef(false)
+  const cancel = useCallback(() => {
+    if (timer.current !== null) clearTimeout(timer.current)
+    timer.current = null
+  }, [])
+  const commit = (next: string) => {
+    cancel()
+    onCommit(next)
+  }
+  const schedule = (next: string) => {
+    cancel()
+    if (composing.current) return
+    if (next === '') commit(next)
+    else timer.current = setTimeout(() => commit(next), SEARCH_DELAY_MS)
+  }
+
+  // A deep link/replacement action can change the query without typing.
+  useLayoutEffect(() => {
+    cancel()
+    setDraft(value)
+  }, [value, resetToken, cancel])
+  // Switching tabs/unmounting must not apply a stale query later.
+  useEffect(() => cancel, [cancel])
+
+  return <Input
+    className={className}
+    icon={<IconSearchOutline16 size={14} />}
+    placeholder={placeholder}
+    value={draft}
+    onChange={event => {
+      const next = event.target.value
+      setDraft(next)
+      schedule(next)
+    }}
+    onCompositionStart={() => { composing.current = true; cancel() }}
+    onCompositionEnd={event => {
+      composing.current = false
+      const next = event.currentTarget.value
+      setDraft(next)
+      schedule(next)
+    }}
+    onKeyDown={event => {
+      if (event.key === 'Enter' && !composing.current && !event.nativeEvent.isComposing && event.keyCode !== 229) {
+        commit(event.currentTarget.value)
+      }
+    }}
+    onBlur={event => {
+      if (!composing.current) commit(event.currentTarget.value)
+    }}
+  />
+}

--- a/tests/client/market-section.client.spec.tsx
+++ b/tests/client/market-section.client.spec.tsx
@@ -113,6 +113,21 @@ afterEach(() => {
   resetGithubRouting()
 })
 
+describe('search input scheduling', () => {
+  it('keeps the list unchanged while typing and filters after a pause', async () => {
+    const { container } = render(<MarketSection {...props()} />)
+    await screen.findByText('dsh-loop')
+    const before = rankedNames(container)
+    const input = screen.getByPlaceholderText(en.searchPh) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'loop' } })
+    expect(input.value).toBe('loop')
+    expect(rankedNames(container)).toEqual(before)
+    await waitFor(() => expect(rankedNames(container)).toEqual(['dsh-loop']))
+    fireEvent.change(input, { target: { value: '' } })
+    expect(rankedNames(container)).toEqual(before)
+  })
+})
+
 describe('api() base resolution (#345)', () => {
   /** Behind a reverse proxy that mounts dsh under a prefix, a root-absolute
    * `/dsh-market/...` resolves against the ORIGIN and misses the prefix rule,

--- a/tests/client/search-input.client.spec.tsx
+++ b/tests/client/search-input.client.spec.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { SearchInput, SEARCH_DELAY_MS } from '../../src/client/SearchInput.tsx'
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => { cleanup(); vi.useRealTimers() })
+const tick = (ms = SEARCH_DELAY_MS) => act(() => vi.advanceTimersByTime(ms))
+const input = () => screen.getByRole('textbox') as HTMLInputElement
+const type = (value: string) => fireEvent.change(input(), { target: { value } })
+
+it('echoes each character locally but commits only after the last pause', () => {
+  const commit = vi.fn()
+  render(<SearchInput value="" onCommit={commit} />)
+  type('m'); tick(200); type('me'); tick(200); type('memory')
+  expect(input().value).toBe('memory')
+  tick(SEARCH_DELAY_MS - 1)
+  expect(commit).not.toHaveBeenCalled()
+  tick(1)
+  expect(commit.mock.calls).toEqual([['memory']])
+})
+
+it('clears immediately and cancels the older pending query', () => {
+  const commit = vi.fn()
+  render(<SearchInput value="memory" onCommit={commit} />)
+  type('memo'); type(''); tick()
+  expect(commit.mock.calls).toEqual([['']])
+})
+
+it('flushes Enter and blur exactly once', () => {
+  const commit = vi.fn()
+  render(<SearchInput value="" onCommit={commit} />)
+  type('memory'); fireEvent.keyDown(input(), { key: 'Enter' }); tick()
+  expect(commit.mock.calls).toEqual([['memory']])
+  type('theme'); fireEvent.blur(input()); tick()
+  expect(commit.mock.calls).toEqual([['memory'], ['theme']])
+})
+
+it('does not search intermediate IME text or commit its confirmation Enter', () => {
+  const commit = vi.fn()
+  render(<SearchInput value="" onCommit={commit} />)
+  type('m'); fireEvent.compositionStart(input()); type('ming'); tick(1000)
+  fireEvent.keyDown(input(), { key: 'Enter', isComposing: true })
+  expect(commit).not.toHaveBeenCalled()
+  fireEvent.compositionEnd(input(), { target: { value: '命令' } })
+  tick()
+  expect(commit.mock.calls).toEqual([['命令']])
+})
+
+it('honors external navigation and cancels the old draft', () => {
+  const commit = vi.fn()
+  const { rerender } = render(<SearchInput value="" onCommit={commit} />)
+  type('old')
+  rerender(<SearchInput value="replacement" onCommit={commit} />)
+  expect(input().value).toBe('replacement')
+  tick()
+  expect(commit).not.toHaveBeenCalled()
+})
+
+it('cancels pending work on unmount and keeps tab identities separate', () => {
+  const commit = vi.fn()
+  const other = vi.fn()
+  const { rerender, unmount } = render(<SearchInput key="discover" value="" onCommit={commit} />)
+  type('discard')
+  rerender(<SearchInput key="themes" value="skin" onCommit={other} />)
+  expect(input().value).toBe('skin')
+  tick()
+  expect(commit).not.toHaveBeenCalled()
+  expect(other).not.toHaveBeenCalled()
+  type('discard too'); unmount(); tick()
+  expect(other).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- keep keystrokes in a local input draft and debounce catalog filtering by 250 ms
- flush the settled query on Enter/blur, clear immediately, and respect IME composition
- cover debounce, clearing, IME, navigation replacement, unmount cleanup, and the MarketSection integration

## Why
The previous controlled inputs updated `MarketSection` on every keypress. That rerendered the market's large list/filter tree for each character and made typing visibly laggy.

## Validation
- `npm run check`
- `npm test` (60 files, 1328 tests)