### PR TITLE
fix(hot): resolve hot-mount rows to profile-anchored file URLs and clean up on failure

### DIFF
--- a/src/hot.ts
+++ b/src/hot.ts
@@ -17,11 +17,13 @@
  */
 
 import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { asChannel, type Channel } from './channels.ts'
 import { asRegion, normalizeGithubProxy, type Region } from './regions.ts'
 import { logEvent } from './log.ts'
+import { entryArtifactExists } from './profile.ts'
 
 interface HotRow {
   id: string
@@ -36,6 +38,54 @@ interface PluginHandle {
 interface HotContext {
   plugin(plugin: unknown, config: unknown): PluginHandle
   logger?: { info?(message: string): void; warn(message: string): void }
+}
+
+/**
+ * Profile-scoped resolution for hot-mount rows: turn a bare package name into
+ * the absolute `file://` entry URL of the package just installed into
+ * `profileDir`.
+ *
+ * Include-tree rows reach `Include.import` as BARE names (`name:
+ * '@scope/pkg'`), and the base class resolves them against the LOADER's own
+ * location — the host closure
+ * (`closures/<fp>/node_modules/…/cordis-plugin-loader`), whose parent walk
+ * can never reach `home/profiles/<profile>/node_modules/`. Under a host whose
+ * loader sits in an immutable dependency closure, EVERY market hot mount dies
+ * with `Cannot find module '<pkg>' from '…/cordis-plugin-loader/…'` and falls
+ * back to "restart required", blaming the plugin for what is a resolution
+ * anchor problem.
+ *
+ * Resolving the row name HERE, against the profile the package was actually
+ * installed into, is anchor-independent: `require.resolve` walks
+ * `profileDir/node_modules` natively, so the tree hands the loader a
+ * `file://` URL needing no further resolution. Non-bare specifiers (relative
+ * paths, `file://`, `cordis:` builtins) and names that do not resolve under
+ * the profile pass through unchanged, preserving base-class semantics for
+ * every shape this fix does not own.
+ *
+ * The fallback keeps the name bare rather than synthesising a URL: a package
+ * whose entry cannot be located via `require.resolve` (no `main`/exports —
+ * the market's own `entryArtifactExists` heuristic covers those shapes before
+ * an install is accepted) is not something this resolver should guess about.
+ * Client-only shims never reach this function (their rows are replaced by a
+ * no-op host module before the file is written).
+ */
+export function resolveProfileEntry(profileDir: string, name: string): string {
+  if (!name || name.startsWith('.') || name.startsWith('cordis:') || name.startsWith('file://')) return name
+  const packageDir = join(profileDir, 'node_modules', ...name.split('/'))
+  try {
+    return pathToFileURL(createRequire(join(profileDir, 'package.json')).resolve(name)).href
+  } catch {
+    // require.resolve needs a resolvable package entry; the market's install
+    // validation accepts a broader artifact set (exports objects, index.js).
+    // Fall back to the index.js artifact so a valid mount is not refused over
+    // resolver strictness — and keep the bare name when no checkable entry
+    // exists, letting the loader produce its own (accurate) error.
+    if (entryArtifactExists(packageDir)) {
+      return pathToFileURL(join(packageDir, 'index.js')).href
+    }
+    return name
+  }
 }
 
 const HOT_DIR = '.dsh-market'
@@ -505,21 +555,33 @@ export async function hotMount(ctx: HotContext, profileDir: string, packageName:
     mkdirSync(dir, { recursive: true, mode: 0o700 })
     hotSequence += 1
     const file = join(dir, `hot-${String(hotSequence)}.yml`)
+    // Rows carry ABSOLUTE file:// entry URLs, resolved against this profile:
+    // the loader's own parent-walk (from the host closure) can never reach
+    // `profileDir/node_modules`, so bare names in the file would fail to
+    // import on closure-hosted loaders. The file remains a faithful record —
+    // `cleanHotDir` wipes it on every boot and the bundle layer owns
+    // persistence, so nothing reads these files back.
     const yml = rows
-      .map(row => `- id: 'mkt-${row.id}'\n  name: '${row.name}'\n`)
+      .map(row => `- id: 'mkt-${row.id}'\n  name: '${resolveProfileEntry(profileDir, row.name)}'\n`)
       .join('')
     writeFileSync(file, yml)
     const handle = ctx.plugin(HotTree, { path: pathToFileURL(file).href })
     try {
       await raceActivationTimeout(handle.await())
     } catch (error) {
+      // A failed or wedged mount must leave NOTHING behind: the disposed
+      // subtree stops retrying the import, and the input file is removed so
+      // it cannot be re-imported by a later boot or replay (a leftover file
+      // re-throwing the same resolve error on every composition replay
+      // produced unbounded error-log growth on a closure-hosted loader).
+      try { Promise.resolve(handle.dispose()).catch(() => {}) } catch { /* best effort */ }
+      try { rmSync(file, { force: true }) } catch { /* best effort */ }
       if (error instanceof ActivationTimeout) {
         // A wedged activation would otherwise hold this request open forever:
         // the route's `finally { installing = false }` never runs, so every
         // later install/update/uninstall gets 409'd until a host restart.
         // Unwind the half-mounted subtree best-effort; disposal never blocks
         // the reply, and the caller falls back to restart activation.
-        try { Promise.resolve(handle.dispose()).catch(() => {}) } catch { /* best effort */ }
       }
       throw error
     }

--- a/tests/hot.spec.ts
+++ b/tests/hot.spec.ts
@@ -8,10 +8,10 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { hotMount, hotUnmount, listHotMounts, mountClientOnlyDeps, parseSimplePatch } from '../src/hot.ts'
+import { hotMount, hotUnmount, listHotMounts, mountClientOnlyDeps, parseSimplePatch, resolveProfileEntry } from '../src/hot.ts'
 
 // The harness-vendored Include class is not importable in the unit lane;
 // a minimal stand-in lets hotMount succeed so the skip logic is observable.
@@ -235,5 +235,117 @@ describe('parseSimplePatch — hot-mountable or restart-only', () => {
     expect(parseSimplePatch('')).toBeNull()
     expect(parseSimplePatch('# only a comment\n\n')).toBeNull()
     expect(parseSimplePatch('- insert:\n')).toBeNull()
+  })
+})
+
+/**
+ * Hot-mount rows must reach the loader as absolute file:// URLs resolved
+ * against the profile the package was installed into.
+ *
+ * The include tree's base class resolves bare names against the LOADER's own
+ * location — the host closure — whose parent walk can never reach
+ * `home/profiles/<profile>/node_modules`. On any closure-hosted loader
+ * (Ellamaka, DSH Desktop sidecar) every market hot mount died with
+ * `Cannot find module '<pkg>' from '…/cordis-plugin-loader/…'` and fell back
+ * to a restart the host did not even need: the bundle layer + a composition
+ * replay had usually already mounted the plugin.
+ */
+describe('resolveProfileEntry — hot-mount rows are anchored at the profile', () => {
+  /** A bundle-plugin package shape: main + lib/index.js on disk (the shape
+   * every hot-mountable plugin carries — install validation, which runs
+   * before hotMount, requires a checkable entry artifact). */
+  function bundlePkg(dir: string, name: string): void {
+    const pkgDir = join(dir, 'node_modules', name)
+    mkdirSync(join(pkgDir, 'lib'), { recursive: true })
+    writeFileSync(join(pkgDir, 'package.json'),
+      JSON.stringify({ name, main: 'lib/index.js', dsh: { bundle: { patch: './cordis.patch.yml' } } }))
+    writeFileSync(join(pkgDir, 'lib', 'index.js'), 'export default {}')
+  }
+
+  it('resolves a bare package name to the profile-installed entry URL', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-hot-'))
+    try {
+      bundlePkg(dir, 'dsh-real-plugin')
+      const resolved = resolveProfileEntry(dir, 'dsh-real-plugin')
+      expect(resolved.startsWith('file://')).toBe(true)
+      expect(resolved).toContain('dsh-real-plugin')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves a scoped package name the same way', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-hot-'))
+    try {
+      bundlePkg(dir, join('@scope', 'pkg'))
+      const resolved = resolveProfileEntry(dir, '@scope/pkg')
+      expect(resolved.startsWith('file://')).toBe(true)
+      expect(resolved).toContain('@scope')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('passes through specifiers the base class owns', () => {
+    expect(resolveProfileEntry('/any', '')).toBe('')
+    expect(resolveProfileEntry('/any', './relative.js')).toBe('./relative.js')
+    expect(resolveProfileEntry('/any', 'cordis:include')).toBe('cordis:include')
+    expect(resolveProfileEntry('/any', 'file:///already/absolute.js')).toBe('file:///already/absolute.js')
+  })
+
+  it('keeps the bare name when the package is not installed under the profile', () => {
+    // Base-class semantics for shapes this fix does not own: an unresolvable
+    // name reaches the loader unchanged and its error surfaces as before.
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-hot-'))
+    try {
+      expect(resolveProfileEntry(dir, 'dsh-not-installed')).toBe('dsh-not-installed')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+/**
+ * A failed hot mount must leave NOTHING behind. The dispose covers the
+ * subtree; the input file removal matters because `cleanHotDir` only runs at
+ * market START — a file left by a mid-session failure stays on disk until
+ * the next restart, and on a closure-hosted loader it re-throws the same
+ * resolve error on every later composition replay that imports it. On the
+ * reporting host this grew the plugin log by millions of repeated errors
+ * between restarts.
+ */
+describe('failed hotMount cleanup — no leftover file, no wedged fiber', () => {
+  it('removes the hot input file when the import fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-hot-'))
+    try {
+      // A package whose host half exists but fails to load: the stand-in
+      // Include.import throws for anything not pre-registered.
+      vi.doMock('@deepseek-ai/cordis-plugin-include', () => ({
+        Include: class {
+          write(): void {}
+          import(name: string): unknown {
+            if (name.includes('dsh-doomed-plugin')) throw new Error('Cannot find module')
+            return { name, apply: () => {} }
+          }
+        },
+      }))
+      vi.resetModules()
+      const { hotMount: freshHotMount, listHotMounts: freshList } = await import('../src/hot.ts')
+      mkdirSync(join(dir, 'node_modules', 'dsh-doomed-plugin'), { recursive: true })
+      writeFileSync(join(dir, 'node_modules', 'dsh-doomed-plugin', 'package.json'),
+        JSON.stringify({ name: 'dsh-doomed-plugin', dsh: { bundle: { patch: './cordis.patch.yml' } } }))
+      writeFileSync(join(dir, 'node_modules', 'dsh-doomed-plugin', 'cordis.patch.yml'),
+        '- insert:\n    - id: doomed\n      name: dsh-doomed-plugin\n')
+      const failCtx = { plugin: () => ({ await: () => Promise.reject(new Error('Cannot find module')), dispose: () => {} }) }
+      const result = await freshHotMount(failCtx, dir, 'dsh-doomed-plugin')
+      expect(result.ok).toBe(false)
+      const hotFiles = readdirSync(join(dir, '.dsh-market')).filter(f => f.startsWith('hot-'))
+      expect(hotFiles).toEqual([])
+      expect(freshList()).not.toContain('dsh-doomed-plugin')
+    } finally {
+      vi.doUnmock('@deepseek-ai/cordis-plugin-include')
+      vi.resetModules()
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
### Summary
- resolve bare package names against the profile's `package.json` into absolute `file://` URLs via `resolveProfileEntry()` before writing hot-mount files
- dispose the active handle and remove the temporary `.dsh-market/hot-*.yml` file on hotMount failure or timeout
- cover standard and scoped profile-anchored resolution, pass-through specifiers, and failed-mount file cleanup

### Why
1. In external closures or packaged desktop sidecars, the loader cannot reach `home/profiles/<profile>/node_modules` via parent-walk from its own location. Bare package names fail to import with `Cannot find module` and unnecessarily fall back to restart prompts.
2. Failed or timed-out hot mounts previously left the input YAML on disk, causing every subsequent composition replay to re-import the failing file and produce continuous error logs.

### Validation
- npm run typecheck
- npx vitest run tests/hot.spec.ts (14 tests passed)
- npm test (59 files, 1328 tests passed)