### PR TITLE
feat(routes): support host-owned activation acknowledgement via desktopProfiles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
 
 import type { Context } from '@deepseek-ai/cordis'
 import { createDesktopPluginRuntime, type DesktopPnpmLike } from './dsh-cli.ts'
-import { mountMarketRoutes, type MarketConfig, type MarketHost } from './routes.ts'
+import { mountMarketRoutes, type HostPluginActivation, type MarketConfig, type MarketHost } from './routes.ts'
 import { installMarketSettings } from './settings.ts'
 import type { AgentsServiceLike } from './agents.ts'
 
@@ -20,6 +20,12 @@ interface DesktopProfilesLike {
     readonly name: string
     readonly dir: string
   }
+  /**
+   * Present on Ellamaka's bun-hmr host. The host watcher owns activation and
+   * returns the completed composition replay instead of letting the market
+   * create a second temporary loader entry for the same package.
+   */
+  readonly pluginActivation?: HostPluginActivation
 }
 
 interface MarketEffectHost extends MarketHost {
@@ -98,7 +104,7 @@ export function apply(ctx: Context, config?: Config): void {
       }
       const desktopHost = desktopCtx as unknown as MarketEffectHost
       desktopHost.effect(() => {
-        const disposeRoutes = mountMarketRoutes(host, resolved, runtime, agentsLookupOf(ctx))
+        const disposeRoutes = mountMarketRoutes(host, resolved, runtime, agentsLookupOf(ctx), desktopProfiles.pluginActivation)
         return async () => {
           disposeRoutes()
           await runtime.dispose()

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -28,7 +28,7 @@ import {
   BOOT_ID, cancelActive, probePnpm, progress, provisionPnpm, runDshPlugin, TARGET_RE,
   type PluginCommandRuntime,
 } from './dsh-cli.ts'
-import { addProfileBundle, dropFromManifest, hasLoadableEntry, holdsNativeAddon, INBOX_BUNDLES, isDshProfileName, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readProfileBundles, readProfileManifestSnapshot, removeProfileBundle, restoreProfileManifest, setAllowBuilds, type ProfileManifestSnapshot } from './profile.ts'
+import { addProfileBundle, bundlePatchInsertedIds, dropFromManifest, hasLoadableEntry, holdsNativeAddon, INBOX_BUNDLES, isDshProfileName, profileDir, readInstalled, readInstalledManifest, readInstalledRepoEvidence, readInstalledVersion, readLockCommits, readProfileBundles, readProfileManifestSnapshot, removeProfileBundle, restoreProfileManifest, setAllowBuilds, type ProfileManifestSnapshot } from './profile.ts'
 import { assessProfile, classifyPeer, introducedDuplicateNames, introducedRisks, type CompatibilityRisk } from './compatibility.ts'
 import { runningAgentIds, type AgentsLookup } from './agents.ts'
 import { analyzeProfile, corePackageNames, type DuplicateName } from './check.ts'
@@ -103,6 +103,15 @@ export interface MarketHost {
   plugin(plugin: unknown, config: unknown): { await(): Promise<unknown>; dispose(): Promise<unknown> | void }
   on?(event: string, callback: (fiber: { entry?: { options?: { name?: string } } }) => void): () => void
   logger?: { info?(message: string): void; warn(message: string): void }
+}
+
+/**
+ * Optional Ellamaka host capability. Its composition watcher is the single
+ * activation owner, so a successful install is acknowledged by one full-stack
+ * replay rather than a second dsh-market loader entry.
+ */
+export interface HostPluginActivation {
+  activate(): Promise<{ ok: true } | { ok: false; error: string }>
 }
 
 export interface MarketConfig {
@@ -234,6 +243,7 @@ export function mountMarketRoutes(
   config: MarketConfig,
   commandRuntime?: PluginCommandRuntime,
   agentsLookup?: AgentsLookup,
+  hostActivation?: HostPluginActivation,
 ): () => void {
   let disposed = false
   // An ordinary profile must resolve under DSH_HOME by the same rules as the
@@ -903,12 +913,15 @@ export function mountMarketRoutes(
     if (result.exitCode !== 0 || result.timedOut || result.cancelled) {
       return { ok: false, hot: false, detail: failureDetail(result) }
     }
-    // Both cleanups run — see the uninstall route's note on #213: a package
-    // with two activation sources must not have the second one skipped
-    // because the first succeeded.
-    const unmounted = await hotUnmount(name)
-    const entryDisabled = await themes.setEntryDisabled(name, true)
+    // Ellamaka's composition watcher is the sole activation source. It owns
+    // removal too: calling market hotUnmount here would look only in the
+    // .dsh-market temporary tree, miss the host root entry, and falsely tell
+    // the user to restart even after the watcher unmounted the plugin.
+    const hostResult = hostActivation ? await hostActivation.activate() : undefined
+    const unmounted = hostActivation ? hostResult!.ok : await hotUnmount(name)
+    const entryDisabled = hostActivation ? false : await themes.setEntryDisabled(name, true)
     const hot = (unmounted || entryDisabled) && !native
+    if (hostResult && !hostResult.ok) logEvent('warn', 'host-activation', `${name}: ${hostResult.error}`)
     if (native) {
       logEvent('info', 'uninstall', `${name} ships or depends on a native addon; a restart is needed before it can be installed again`)
     }
@@ -4014,24 +4027,35 @@ sendJson(response, 200, { updates })
             let hot = false
             if (ok || halfGone) {
               invalidateUpdates()
-              hot = await hotUnmount(name)
-              // Bundle-layer plugins never hot-mount, but their loader entry
-              // is still LIVE in this process — after the remove deleted the
-              // package, the next refresh would 404 on its client bundle and
-              // wedge the whole page until a dsh restart (#37 by
-              // @1123762794). Live-disable the entry so the refresh composes
-              // without it; after a real restart the entry is gone anyway.
-              //
-              // Both run, unconditionally. This used to short-circuit on the
-              // hot unmount, which is right only while a package has ONE
-              // activation source — a package that is both hot-mounted AND
-              // reachable through the bundle layer got half its cleanup, and
-              // the surviving half is exactly the 404-on-refresh wedge above
-              // (#213). setEntryDisabled just scans entries by name and
-              // returns false when none match, so calling it after a
-              // successful unmount costs a lookup and nothing else.
-              const entryDisabled = await themes.setEntryDisabled(name, true)
-              hot = hot || entryDisabled
+              if (hostActivation) {
+                // Ellamaka's watcher owns the bundle-layer entry. Await its
+                // full-stack replay instead of asking the market's temporary
+                // tree to unmount an entry it never created. A successful
+                // replay removes both the server fiber and the client module
+                // source before the response reaches the browser.
+                const result = await hostActivation.activate()
+                hot = result.ok
+                if (!result.ok) logEvent('warn', 'host-activation', `${name}: ${result.error}`)
+              } else {
+                hot = await hotUnmount(name)
+                // Bundle-layer plugins never hot-mount, but their loader entry
+                // is still LIVE in this process — after the remove deleted the
+                // package, the next refresh would 404 on its client bundle and
+                // wedge the whole page until a dsh restart (#37 by
+                // @1123762794). Live-disable the entry so the refresh composes
+                // without it; after a real restart the entry is gone anyway.
+                //
+                // Both run, unconditionally. This used to short-circuit on the
+                // hot unmount, which is right only while a package has ONE
+                // activation source — a package that is both hot-mounted AND
+                // reachable through the bundle layer got half its cleanup, and
+                // the surviving half is exactly the 404-on-refresh wedge above
+                // (#213). setEntryDisabled just scans entries by name and
+                // returns false when none match, so calling it after a
+                // successful unmount costs a lookup and nothing else.
+                const entryDisabled = await themes.setEntryDisabled(name, true)
+                hot = hot || entryDisabled
+              }
               if (heldNativeAddon && hot) {
                 logEvent('info', 'uninstall', `${name} ships or depends on a native addon, which this process cannot release — reporting the uninstall as needing a restart`)
               }
@@ -4367,12 +4391,36 @@ sendJson(response, 200, { updates })
                 writeMarketState(activeProfileDir, { disabled, groups, groupOrder })
                 // Theme installs auto-activate (and deactivate the previous
                 // theme) so the result is visible right after the refresh.
-                hot = true
-                for (const name of added) {
-                  const live = pluginCategories(entry).includes('theme')
-                    ? await themes.activateTheme(name)
-                    : (await hotMount(host, activeProfileDir, name)).ok
-                  if (!live) hot = false
+                if (hostActivation) {
+                  // Ellamaka's watcher owns the entire composition. Waiting
+                  // for its replay result gives the market a real live/fail
+                  // verdict without creating the second .dsh-market loader
+                  // entry that races it and double-registers plugin routes.
+                  const result = await hostActivation.activate()
+                  hot = result.ok
+                  if (!result.ok) logEvent('warn', 'host-activation', `${added.join(', ')}: ${result.error}`)
+                } else {
+                  hot = true
+                  for (const name of added) {
+                    // Some hosts activate the install themselves — a
+                    // composition watcher replays the profile the moment the
+                    // manifest lands (Ellamaka's bun-hmr), so the install
+                    // command can return AFTER the plugin is already mounted.
+                    // Hot-mounting again would insert a second loader entry for
+                    // an id the live composition already serves. An entry whose
+                    // fiber is already up is adopted, not re-mounted: the
+                    // loader inventory (live names + `#<id>`) is the fact
+                    // "already active this session", the same source
+                    // verifyActivation reads below.
+                    const live = liveNames().has(name)
+                      || liveNames().has(`#${name}`)
+                      || bundlePatchInsertedIds(join(activeProfileDir, 'node_modules', name))
+                        .some(id => liveNames().has(`#${id}`))
+                      || (pluginCategories(entry).includes('theme')
+                        ? await themes.activateTheme(name)
+                        : (await hotMount(host, activeProfileDir, name)).ok)
+                    if (!live) hot = false
+                  }
                 }
                 activation = {}
                 const live = liveNames()

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -516,6 +516,7 @@ type Handler = (request: unknown, response: unknown) => void | Promise<void>
 interface Testbed {
   dispatch(method: string, path: string, body?: unknown, options?: { crossOrigin?: boolean; remoteAddress?: string; forwarded?: boolean }): Promise<{ status: number; json: any }>
   loaderEntries: { options: { name: string; disabled?: boolean | null }; fiber?: unknown; update(o: { disabled: boolean | null }): Promise<void> }[]
+  hostPluginCalls: unknown[]
   dispose(): void
 }
 
@@ -523,9 +524,11 @@ function createTestbed(
   config: { profile?: string; allowRestart?: boolean; profileDirectory?: string; region?: 'global' | 'china' } = {},
   runtime?: Parameters<typeof mountMarketRoutes>[2],
   agents?: AgentsServiceLike,
+  activation?: Parameters<typeof mountMarketRoutes>[4],
 ): Testbed {
   const routes = new Map<string, Handler>()
   const loaderEntries: Testbed['loaderEntries'] = []
+  const hostPluginCalls: unknown[] = []
   const host = {
     webServer: {
       register(route: { path: string; handler: Handler }) {
@@ -534,7 +537,10 @@ function createTestbed(
       },
     },
     loader: { entries: () => loaderEntries },
-    plugin: () => ({ await: () => Promise.resolve(), dispose: () => {} }),
+    plugin: (plugin: unknown) => {
+      hostPluginCalls.push(plugin)
+      return { await: () => Promise.resolve(), dispose: () => {} }
+    },
     on: () => () => {},
   }
   // Pinned so no test reaches the network to decide one. An unpinned region
@@ -542,7 +548,7 @@ function createTestbed(
   // every install assertion depend on which registry answered first —
   // and, as this suite proved once, would let a spec resolve a REAL commit
   // through a REAL proxy. Specs that care about the mirrors set it.
-  const dispose = mountMarketRoutes(host as never, { profile: 'web', region: 'global', ...config }, runtime, () => agents)
+  const dispose = mountMarketRoutes(host as never, { profile: 'web', region: 'global', ...config }, runtime, () => agents, activation)
   async function dispatch(method: string, path: string, body?: unknown, options?: { crossOrigin?: boolean }) {
     const handler = routes.get(path.split('?')[0])
     if (handler === undefined) throw new Error(`no route: ${path}`)
@@ -568,7 +574,7 @@ function createTestbed(
     try { json = JSON.parse(payload) } catch { /* non-JSON (logs route) */ }
     return { status, json, text: payload }
   }
-  return { dispatch, loaderEntries, dispose }
+  return { dispatch, loaderEntries, hostPluginCalls, dispose }
 }
 
 // ---------------------------------------------------------------- suite
@@ -974,6 +980,38 @@ describe('install flow', () => {
     const listed = await bed.dispatch('GET', '/dsh-market/installed')
     expect(listed.json.installed['dsh-loop']).toBe('^1.0.0')
     expect(listed.json.activation['dsh-loop'].state).toBe('live')
+  })
+
+  it('uses the host activation acknowledgement and never creates a second market loader entry', async () => {
+    bed.dispose()
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    const activate = vi.fn().mockResolvedValue({ ok: true as const })
+    bed = createTestbed({}, undefined, undefined, { activate })
+    const before = bed.hostPluginCalls.length
+
+    const r = await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+
+    expect(r.status).toBe(200)
+    expect(r.json.hot).toBe(true)
+    expect(activate).toHaveBeenCalledOnce()
+    // `hotMount()` uses host.plugin() to create the .dsh-market loader entry.
+    // In host-owned mode it must not run at all: one plugin, one activation source.
+    expect(bed.hostPluginCalls).toHaveLength(before)
+  })
+
+  it('reports restart only when the sole host activation replay fails', async () => {
+    bed.dispose()
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    const activate = vi.fn().mockResolvedValue({ ok: false as const, error: 'plugin composition replay failed' })
+    bed = createTestbed({}, undefined, undefined, { activate })
+    const before = bed.hostPluginCalls.length
+
+    const r = await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+
+    expect(r.status).toBe(200)
+    expect(r.json.hot).toBe(false)
+    expect(activate).toHaveBeenCalledOnce()
+    expect(bed.hostPluginCalls).toHaveLength(before)
   })
 
   it('reports host contracts declared as normal dependencies without rejecting the plugin', async () => {
@@ -3073,6 +3111,23 @@ describe('uninstall flow', () => {
 
     expect((await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'dshmarket' })).status).toBe(400)
     expect((await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'ghost' })).status).toBe(400)
+  })
+
+  it('uses host activation for uninstall and never asks the market hot tree to remove a host entry', async () => {
+    bed.dispose()
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    const activate = vi.fn().mockResolvedValue({ ok: true as const })
+    bed = createTestbed({}, undefined, undefined, { activate })
+    await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })
+    activate.mockClear()
+    expect(hot.mounts).toEqual([])
+
+    const r = await bed.dispatch('POST', '/dsh-market/uninstall', { name: 'dsh-loop' })
+
+    expect(r.status).toBe(200)
+    expect(r.json.hot).toBe(true)
+    expect(activate).toHaveBeenCalledOnce()
+    expect(hot.mounts).toEqual([])
   })
 
   it('refuses to remove a package still inserted by the user patch (#165)', async () => {

--- a/tests/index-desktop.spec.ts
+++ b/tests/index-desktop.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const state = vi.hoisted(() => ({
-  mounts: [] as { host: unknown; config: Record<string, unknown>; runtime?: unknown }[],
+  mounts: [] as { host: unknown; config: Record<string, unknown>; runtime?: unknown; activation?: unknown }[],
   routeDisposals: 0,
   runtimeDisposals: 0,
   runtime: {
@@ -25,8 +25,8 @@ vi.mock('../src/dsh-cli.ts', () => ({
 }))
 
 vi.mock('../src/routes.ts', () => ({
-  mountMarketRoutes: (host: unknown, config: Record<string, unknown>, runtime?: unknown) => {
-    state.mounts.push({ host, config, runtime })
+  mountMarketRoutes: (host: unknown, config: Record<string, unknown>, runtime?: unknown, _agents?: unknown, activation?: unknown) => {
+    state.mounts.push({ host, config, runtime, activation })
     return () => { state.routeDisposals += 1 }
   },
 }))
@@ -108,6 +108,22 @@ describe('host adaptation', () => {
     await ctx.effects[0].dispose()
     expect(state.routeDisposals).toBe(1)
     expect(state.runtimeDisposals).toBe(1)
+  })
+
+  it('forwards an Ellamaka host activation capability so routes never create a second loader entry', () => {
+    const desktopPnpm = { runPlugin: vi.fn() }
+    const activation = { activate: vi.fn().mockResolvedValue({ ok: true }) }
+    const ctx = new FakeContext({
+      webServer: {},
+      loader: {},
+      desktopProfiles: { current: { name: 'web', dir: '/private/dsh/web' }, pluginActivation: activation },
+      desktopPnpm,
+    })
+
+    apply(ctx as never)
+
+    expect(state.mounts).toHaveLength(1)
+    expect(state.mounts[0].activation).toBe(activation)
   })
 
   it('uses the documented pre-Loader desktopProfiles discriminator and never falls back to ambient CLI', () => {


### PR DESCRIPTION
### Summary
- extend the `desktopProfiles` contract with an optional `pluginActivation?: HostPluginActivation` bridge
- delegate install, uninstall, and rollback activation to `hostActivation.activate()` when present, awaiting the host watcher replay instead of mounting a second loader entry
- cover desktopProfiles capability forwarding and host-activation install/uninstall flow behavior

### Why
Hosts with declarative composition watchers (such as bun-hmr or profile file watchers) automatically reload the full profile upon manifest modification. When dsh-market simultaneously calls internal hotMount/hotUnmount, both activate the same plugin at once. This causes duplicate prefix route collisions (e.g. `webserver: duplicate prefix route "/..."`) and false-negative "restart required" UI warnings for plugins that are already live.

### Validation
- npm run typecheck
- npx vitest run tests/index-desktop.spec.ts tests/flows.spec.ts (7 focused tests passed)
- npm test (59 files, 1328 tests passed)