### PR TITLE
fix: restore market settings card in Desktop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import { createDesktopPluginRuntime, type DesktopPnpmLike } from './dsh-cli.ts'
 import { mountMarketRoutes, type MarketConfig, type MarketHost } from './routes.ts'
-import { installMarketSettings } from './settings.ts'
+import { installDesktopMarketSettings, installMarketSettings } from './settings.ts'
 import type { AgentsServiceLike } from './agents.ts'
 
 export const name = 'dsh-market'
@@ -70,10 +70,8 @@ export function apply(ctx: Context, config?: Config): void {
         allowRestart: config?.allowRestart,
         maxSnapshots: config?.maxSnapshots,
       }
-      // Offer allowRestart as a switch on the settings page. Deliberately
-      // NOT in the Desktop branch below: there the shell owns the process
-      // lifecycle and the value is forced false, so it is not the user's to
-      // choose. No-ops on a host without a settings service.
+      // Web settings may control restart; Desktop only registers the card's
+      // namespace below. Both no-op on a host without a settings service.
       installMarketSettings(ctx, resolved)
       host.effect(() => mountMarketRoutes(host, resolved, undefined, agentsLookupOf(ctx)), 'dsh-market: http routes')
       return
@@ -97,6 +95,7 @@ export function apply(ctx: Context, config?: Config): void {
         maxSnapshots: config?.maxSnapshots,
       }
       const desktopHost = desktopCtx as unknown as MarketEffectHost
+      installDesktopMarketSettings(desktopCtx)
       desktopHost.effect(() => {
         const disposeRoutes = mountMarketRoutes(host, resolved, runtime, agentsLookupOf(ctx))
         return async () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,8 @@
  * instance manages: it is decided at mount from the composition or the
  * command line, and a running instance cannot switch to another one, so
  * offering it as a field would promise something the write cannot deliver.
+ * Desktop registers an empty schema instead: the namespace still admits its
+ * card, but the shell owns restart and no settings value feeds its routes.
  *
  * The release channel is NOT here either, and that is a correction rather
  * than an omission. It was, briefly, and it made this namespace a second
@@ -77,16 +79,16 @@ if (!NAMESPACE_PATTERN.test(MARKET_SETTINGS_NS)) {
  * a type for it on every supported host, and naming only what is called
  * keeps this from breaking again when a neighbouring field moves.
  */
-interface SettingsScope {
-  get: () => MarketSettings
+interface SettingsScope<T> {
+  get: () => T
   watch: (listener: () => void) => void
 }
 interface SettingsService {
-  register: (
+  register: <T>(
     ns: string,
-    schema: z<MarketSettings>,
-    options: { base: MarketSettings },
-  ) => SettingsScope
+    schema: z<T>,
+    options: { base: T },
+  ) => SettingsScope<T>
 }
 
 /** The market settings a user may edit at runtime. */
@@ -97,6 +99,17 @@ export interface MarketSettings {
 export const MarketSettings: z<MarketSettings> = z.object({
   allowRestart: z.boolean().default(true),
 })
+
+/** Serve the Desktop card without claiming settings-controlled restart. */
+export function installDesktopMarketSettings(ctx: Context): void {
+  ctx.inject(['settings'], (scopedCtx: Context) => {
+    const scoped = scopedCtx as unknown as Context & { settings: SettingsService }
+    // The host dispatches cards only for registered namespaces. An empty
+    // schema offers no fields; old stored allowRestart values stay untouched
+    // and are never read or watched into the shell-owned runtime config.
+    scoped.settings.register(MARKET_SETTINGS_NS, z.object({}), { base: {} })
+  })
+}
 
 /**
  * Wire the namespace so a saved change reaches the routes immediately.

--- a/tests/client/primitives-guard.spec.ts
+++ b/tests/client/primitives-guard.spec.ts
@@ -5,7 +5,7 @@
  * must detect the gap and skip registration instead of throwing mid-render.
  */
 import { describe, expect, it } from 'vitest'
-import { missingPrimitives, REQUIRED_PRIMITIVES } from '../../src/client/index.ts'
+import { apply, missingPrimitives, REQUIRED_PRIMITIVES } from '../../src/client/index.ts'
 
 describe('missingPrimitives', () => {
   it('reports no gaps when every required export exists', () => {
@@ -26,4 +26,25 @@ describe('missingPrimitives', () => {
   it('accepts a custom requirement list', () => {
     expect(missingPrimitives({ A: 1 }, ['A', 'B', 'C'])).toEqual(['B', 'C'])
   })
+})
+
+it('keeps the main market on hosts without settingsScope (#516)', () => {
+  const registrations: Record<string, unknown>[] = []
+  const injections: string[][] = []
+  apply({
+    effect: (run: () => unknown) => { run() },
+    on: () => () => {},
+    locale: {
+      register: () => () => {}, bind: () => (key: string) => key,
+      subscribe: () => () => {}, getSnapshot: () => ({ active: 'en' }),
+    },
+    theme: { getTheme: () => null, setTheme: () => {} },
+    slots: {
+      inject: (_slot: string, register: () => unknown) => { register() },
+      register: (options: Record<string, unknown>) => { registrations.push(options); return () => {} },
+    },
+    inject: (services: string[]) => { injections.push(services) },
+  } as Parameters<typeof apply>[0])
+  expect(injections).toEqual([['settingsScope']])
+  expect(registrations.map(entry => entry.name)).toEqual(['settings.section', 'shell.overlay'])
 })

--- a/tests/index-desktop.spec.ts
+++ b/tests/index-desktop.spec.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import { SettingsProvider, type SettingsNamespace } from '@deepseek-ai/dsh-settings'
 
 const state = vi.hoisted(() => ({
   mounts: [] as { host: unknown; config: Record<string, unknown>; runtime?: unknown }[],
@@ -92,7 +94,7 @@ describe('host adaptation', () => {
     })
     apply(ctx as never, { profile: 'must-not-win', allowRestart: true })
 
-    expect(ctx.injectCalls).toEqual([['webServer', 'loader'], ['desktopPnpm']])
+    expect(ctx.injectCalls).toEqual([['webServer', 'loader'], ['desktopPnpm'], ['settings']])
     expect(state.factoryArgs).toEqual([[desktopPnpm, '/private/dsh/desktop']])
     expect(state.mounts).toHaveLength(1)
     expect(state.mounts[0]).toMatchObject({
@@ -145,5 +147,130 @@ describe('unconfigured allowRestart stays undefined so detection can decide (#22
       apply(ctx as never, { allowRestart })
       expect(state.mounts[0].config.allowRestart).toBe(allowRestart)
     }
+  })
+})
+
+// Only storage is substituted: namespace resolution, describe, writes and
+// scoped disposal all run through the host's real SettingsProvider/Cordis.
+describe('host settings registration (#516)', () => {
+  const ns = 'dsh-market' as SettingsNamespace
+  let root: Context
+  let document: Record<string, unknown>
+
+  class MemorySettings extends SettingsProvider {
+    readonly writable = true
+    async load() { return document }
+    async persist(namespace: SettingsNamespace, section: Record<string, unknown>) {
+      document = { ...document, [namespace]: structuredClone(section) }
+    }
+  }
+
+  beforeEach(() => {
+    document = { [ns]: { allowRestart: true }, unrelated: { keep: 'me' } }
+    root = new Context()
+    root.provide('webServer', {})
+    root.provide('loader', {})
+  })
+  afterEach(async () => { await root.fiber.dispose() })
+
+  async function settings() {
+    await vi.waitFor(() => { expect(root.get('settings')).toBeDefined() })
+    return root.get('settings') as SettingsProvider
+  }
+
+  function desktop() {
+    root.provide('desktopProfiles', { current: { name: 'desktop', dir: '/isolated/desktop' } })
+    return root.provide('desktopPnpm', { runPlugin: vi.fn() })
+  }
+
+  it('serves a Desktop namespace without offering or enabling restart, including reloads', async () => {
+    desktop()
+    let provider = root.plugin(MemorySettings)
+    const service = await settings()
+    let market = root.plugin(ctx => apply(ctx, { allowRestart: true, profile: 'ignored' }))
+    await vi.waitFor(() => { expect(state.mounts).toHaveLength(1) })
+    const config = state.mounts[0].config
+    expect(service.describe().map(view => view.ns)).toEqual([ns])
+    const schema = service.describe()[0].schema as { refs: Record<string, { dict: object }> }
+    expect(Object.values(schema.refs).map(ref => ref.dict)).toEqual([{}])
+    expect(config).toMatchObject({ allowRestart: false, profile: 'desktop', profileDirectory: '/isolated/desktop' })
+
+    for (const allowRestart of [false, true]) {
+      await service.update(ns, { allowRestart })
+      expect(config.allowRestart).toBe(false)
+    }
+    expect(document.unrelated).toEqual({ keep: 'me' })
+    await provider.dispose()
+    expect(service.describe()).toEqual([])
+    expect(config.allowRestart).toBe(false)
+    expect(state.routeDisposals).toBe(0)
+    expect(state.runtimeDisposals).toBe(0)
+
+    provider = root.plugin(MemorySettings)
+    const reloaded = await settings()
+    await vi.waitFor(() => { expect(reloaded.describe().map(view => view.ns)).toEqual([ns]) })
+    expect(config.allowRestart).toBe(false)
+    await market.dispose()
+    expect(reloaded.describe()).toEqual([])
+    expect(state.routeDisposals).toBe(1)
+    expect(state.runtimeDisposals).toBe(1)
+
+    market = root.plugin(ctx => apply(ctx, { allowRestart: true }))
+    await vi.waitFor(() => { expect(state.mounts).toHaveLength(2) })
+    expect(reloaded.describe().map(view => view.ns)).toEqual([ns])
+    expect(state.mounts[1].config.allowRestart).toBe(false)
+    await market.dispose()
+    expect(reloaded.describe()).toEqual([])
+    expect(state.routeDisposals).toBe(2)
+    expect(state.runtimeDisposals).toBe(2)
+  })
+
+  it('preserves Web saved values, live updates and the entry fallback on settings unload', async () => {
+    const provider = root.plugin(MemorySettings)
+    const service = await settings()
+    root.plugin(ctx => apply(ctx, { allowRestart: false }))
+    await vi.waitFor(() => { expect(state.mounts).toHaveLength(1) })
+    const config = state.mounts[0].config
+    expect(service.describe().map(view => view.ns)).toEqual([ns])
+    expect(config.allowRestart).toBe(true)
+    await service.update(ns, { allowRestart: false })
+    await vi.waitFor(() => { expect(config.allowRestart).toBe(false) })
+    await service.update(ns, { allowRestart: true })
+    await vi.waitFor(() => { expect(config.allowRestart).toBe(true) })
+    await provider.dispose()
+    expect(config.allowRestart).toBe(false)
+    expect(state.routeDisposals).toBe(0)
+  })
+
+  it('retires the namespace with desktopPnpm and mounts it once on recovery', async () => {
+    const removePnpm = desktop()
+    root.plugin(MemorySettings)
+    const service = await settings()
+    root.plugin(ctx => apply(ctx))
+    await vi.waitFor(() => { expect(service.describe().map(view => view.ns)).toEqual([ns]) })
+    removePnpm()
+    await vi.waitFor(() => {
+      expect(service.describe()).toEqual([])
+      expect(state.routeDisposals).toBe(1)
+      expect(state.runtimeDisposals).toBe(1)
+    })
+    root.provide('desktopPnpm', { runPlugin: vi.fn() })
+    await vi.waitFor(() => { expect(state.mounts).toHaveLength(2) })
+    expect(service.describe().map(view => view.ns)).toEqual([ns])
+    expect(state.mounts[1].config).toMatchObject({
+      allowRestart: false, profile: 'desktop', profileDirectory: '/isolated/desktop',
+    })
+  })
+
+  it.each([false, true])('mounts without settings and registers when the service arrives (desktop=%s)', async (isDesktop) => {
+    if (isDesktop) desktop()
+    root.plugin(ctx => apply(ctx, { allowRestart: true }))
+    await vi.waitFor(() => { expect(state.mounts).toHaveLength(1) })
+    expect(state.mounts[0].config.allowRestart).toBe(!isDesktop)
+    root.plugin(MemorySettings)
+    const service = await settings()
+    await vi.waitFor(() => { expect(service.describe().map(view => view.ns)).toEqual([ns]) })
+    expect(state.mounts).toHaveLength(1)
+    expect(state.mounts[0].config.allowRestart).toBe(!isDesktop)
   })
 })

--- a/tests/web/desktop-settings.e2e.ts
+++ b/tests/web/desktop-settings.e2e.ts
@@ -1,0 +1,73 @@
+/** Real host describe -> plugin tab -> production market card (#516).
+ * Desktop services are a non-operational fixture, not an Electron test.
+ */
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { chromium, type Browser, type Page } from 'playwright'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { dshAvailable, launchMarketScaffold, openMarketPage, watchConsole } from './scaffold.ts'
+import type { WebScaffold } from './scaffold.ts'
+
+describe.skipIf(!dshAvailable())('host dispatches the market settings card (#516)', () => {
+  let scaffold: WebScaffold
+  let browser: Browser
+
+  beforeAll(async () => {
+    scaffold = await launchMarketScaffold()
+    browser = await chromium.launch()
+  }, 300_000)
+  afterAll(async () => { await browser?.close(); await scaffold?.close() })
+
+  async function checkCard(page: Page, mode: 'web' | 'desktop') {
+    const console = watchConsole(page)
+    await openMarketPage(page, scaffold)
+    for (let i = 0; i < 6; i++) {
+      const button = page.getByRole('button', { name: /^(Continue|继续|Configure later|稍后配置)$/ }).first()
+      try { await button.waitFor({ timeout: i === 0 ? 30_000 : 1500 }); await button.click() } catch { break }
+    }
+    await page.getByRole('button', { name: /^(设置|Settings)$/ }).first().click()
+    await page.getByText(/^(插件|Plugins)$/).last().click()
+    await page.getByText(/^(插件配置|Plugin configuration)$/).last().click()
+    const card = page.locator('button[aria-expanded]').filter({ hasText: /插件市场|Plugin Market/ })
+    await card.waitFor({ timeout: 15_000 })
+    expect(await card.count()).toBe(1)
+    await card.click()
+    await page.getByText(/^(下载区域|Download region)$/).waitFor()
+    const artifacts = process.env.DSHM_SETTINGS_ARTIFACTS
+    if (artifacts) await card.locator('..').screenshot({ path: join(artifacts, `${mode}-card.png`) })
+    await page.getByText(/^(插件市场|Plugin Market)$/).first().click()
+    await page.getByPlaceholder(/搜索插件|Search plugins/).waitFor()
+    if (artifacts) await page.screenshot({ path: join(artifacts, `${mode}-market.png`) })
+    expect(console.errors().filter(text => !/net::|Failed to load resource/.test(text))).toEqual([])
+  }
+
+  it('keeps the Web card and dispatches the Desktop card with persisted restart=true', async () => {
+    let page = await browser.newPage({ viewport: { width: 1400, height: 900 } })
+    try { await checkCard(page, 'web') } finally { await page.close() }
+
+    const dir = join(scaffold.home, 'profiles', 'web')
+    // An explicit loader dependency orders the fixture services before the
+    // real market entry. Package operations cannot run in this fixture.
+    writeFileSync(join(dir, 'desktop-settings-fixture.mjs'), `
+export function apply(ctx) {
+  ctx.provide('desktopProfiles', { current: { name: 'desktop-test', dir: ${JSON.stringify(dir)} } })
+  ctx.provide('desktopPnpm', { runPlugin() { throw new Error('package operations forbidden in settings test') } })
+}
+`)
+    writeFileSync(join(dir, 'cordis.patch.yml'), JSON.stringify([
+      { insert: [{ id: 'desktop-services-test', name: './desktop-settings-fixture.mjs' }] },
+      { id: 'dsh-market', inject: ['desktopProfiles', 'desktopPnpm'], config: { allowRestart: true } },
+    ]))
+    writeFileSync(join(scaffold.home, 'settings.yaml'), 'dsh-market:\n  allowRestart: true\n')
+    await scaffold.restart()
+    const status = await (await fetch(`${scaffold.baseUrl}/dsh-market/status`)).json() as { restart: boolean }
+    expect(status.restart).toBe(false)
+    const capabilities = await (await fetch(`${scaffold.baseUrl}/dsh-market/api/v1/capabilities`)).json()
+    expect(capabilities).toMatchObject({
+      profile: 'desktop-test', runtime: 'desktop',
+      restart: { supported: false, managedBy: 'desktop-host' },
+    })
+    page = await browser.newPage({ viewport: { width: 1400, height: 900 } })
+    try { await checkCard(page, 'desktop') } finally { await page.close() }
+  }, 300_000)
+})


### PR DESCRIPTION
Fixes #516

## Summary

- Register the `dsh-market` settings namespace in the Desktop entry so the host can dispatch the existing market configuration card.
- Use an empty schema and never read or watch settings into Desktop runtime configuration. Restart remains forced off and owned by the Desktop shell, even with persisted `allowRestart: true`.
- Tie registration to the desktopPnpm-scoped context. Preserve Web settings behavior and optional-service compatibility on older hosts.

## Root Cause

The host's plugin configuration tab intersects served settings namespaces with registered `settings.plugin.item` cards. The market client already registers its card, but the Desktop entry skipped settings registration entirely. This suppressed the card along with the restart setting.

The new registration separates card discoverability from restart authority. Historical stored values are not deleted; they are simply never used to configure Desktop restart. No host filtering or frontend production code is changed.

## Regression Evidence

Baseline: `ecbd26957130bb43c37d05e3ae9b2bc94cb5ecf1` (market 1.45.0).
Candidate: `1db21cda05393c8842790938119d9f614e34a873` (version unchanged).

- The final host-registration tests on the unmodified baseline fail in 3 Desktop cases because `describe()` lacks `dsh-market`; 2 Web cases pass. Five unrelated tests are excluded by the name filter.
- The same final browser test on baseline host 0.1.2-rc.1 passes the Web card and Desktop capability checks, then fails because the Desktop configuration card is absent.
- Both regressions pass with this change.
- On the actual Windows Desktop 2.0.5 application, the baseline has zero market cards, while the candidate has exactly one expandable card; the main market remains usable in both. Reopening the candidate with persisted `allowRestart: true` also passes with restart disabled.

The integration tests use real Cordis and SettingsProvider with only persistence substituted. They cover saved values, updates, service reload, market remount, desktopPnpm removal/recovery, profile selection, and missing/late settings. A client test preserves the main market registration without settingsScope.

## Validation

Local environment: WSL2 Linux, Node 24.20.0, npm 11.19.0, pnpm 10.34.5.

| Check | Result |
| --- | --- |
| `npm test` | 59 files, 1327 tests passed |
| Focused entry/settings/client regression tests | 4 files, 52 tests passed |
| `npm run check` | Typechecks, builds, restart smoke passed |
| `node scripts/preflight.mjs` | Passed |
| `npm run validate:registry` | Passed; 98 existing display-name collision warnings |
| `node scripts/smoke-spawn.mjs` | Passed on Linux |
| `npm run test:compat` | 14 passed, real pnpm 9/10/11 |
| Full `npm run test:web`, host 0.1.0-rc.8 | 9 files, 41 tests passed, no skips |
| New card E2E, hosts 0.1.2-rc.1 and 0.1.2-alpha.2 | Passed on each |
| Actual Windows Desktop 2.0.5 / host 0.1.2-rc.1 / Electron 43.3.0 | Baseline reproduced; candidate and reopen passed |
| `git diff --check` | Passed |

The E2E uses the real host and production market client in isolated temporary DSH_HOME directories, first in Web mode and then with non-operational Desktop services to exercise the production Desktop entry. It checks exactly one expandable card, the main market UI, and shell-owned restart capabilities. Package operations are forbidden by the fixture. No host implementation is patched.

## Windows Desktop Acceptance

Completed on Windows OS build 26200 using the official Desktop 2.0.5 release executable with host 0.1.2-rc.1 and Electron 43.3.0. The installer was extracted, not installed; its SHA256 matches the release asset digest. The application and host implementations were not patched.

Separate temporary userData, DSH_HOME and desktop profiles were used for baseline and candidate. The bundled pnpm installed explicit local tarballs. Installed entry/settings file hashes match the corresponding source builds before launch and after reopening, avoiding accidental validation of the bundled market or a registry replacement. The Desktop-bundled older market remains on disk; only the profile candidate is active.

Playwright connected to the real Electron renderer and checked:

- Baseline: no market card, main market usable.
- Candidate: exactly one card, expanded download-region content visible, main market usable.
- Candidate reopen without resetting saved settings: still one card and a usable main market.
- All runs: Desktop 2.0.5/Electron 43.3.0 UA, market 1.45.0, `runtime=desktop`, `profile=desktop`, `restart.supported=false`, `managedBy=desktop-host`, and no captured page errors.

Screenshots, JSON results and logs were saved locally. The screenshots have not received manual visual review; acceptance is based on automated DOM/API assertions. No market update, uninstall, or restart operation was invoked, and all isolated Desktop processes were closed. This is local Windows acceptance, not a claim of Windows or remote CI success.

The reporter's September 8 follow-up script was also reviewed without executing it. Its missing-namespace diagnosis agrees with the reproduction. This change deliberately does not reuse the Web get/watch path or suppress duplicate-registration errors.

## Checklist

- [x] `npm test` and `npm run check` pass locally.
- [x] Regression tests fail without the fix.
- [x] No version bump, dependency changes, lockfile changes, or registry refresh.
- [x] No production `src/client/` changes; client rebuild has no tracked diff.
- [x] Validate on isolated Windows Desktop 2.0.5 with host 0.1.2-rc.1.
