### PR TITLE
fix: stop declaring two client seams the market never uses (#554)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     },
     "client": {
       "inject": [
-        "@deepseek-ai/dsh-client-connection",
-        "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-locale",
         "@deepseek-ai/dsh-client-ui-settings",
         "@deepseek-ai/dsh-client-ui-theme"

--- a/tests/client-inject.spec.ts
+++ b/tests/client-inject.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * What the market's client declares it needs, against what it touches.
+ *
+ * `dsh.client.inject` is a HARD gate: the host holds the client entry back
+ * until every listed seam exists. A seam that is listed but never used is
+ * therefore not free — it is a version of the host the market refuses to
+ * run on, bought for nothing.
+ *
+ * That is not hypothetical. @MarchLiu found (#554) that on dsh 0.1.2-rc.1
+ * the market's presence silently stopped `dsh-context` from registering its
+ * commands, and traced it by binary search to the market's entry alone. The
+ * market listed `@deepseek-ai/dsh-client-runtime` — a seam that release
+ * ships incompletely, and that had already hard-failed another plugin's
+ * boot — and `@deepseek-ai/dsh-client-connection`, and used NEITHER. Both
+ * had been in the manifest since 0.1.0 and never removed when the code that
+ * might have needed them was not written.
+ *
+ * This test is the thing that was missing: a declaration and its use, kept
+ * next to each other. It reads the client source rather than a hand-written
+ * list, so adding `ctx.something` without declaring its seam fails too.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/** The host services the client entry actually reaches for. */
+function servicesUsed(): Set<string> {
+  const source = readFileSync(resolve('src/client/index.ts'), 'utf8')
+  const used = new Set<string>()
+  // `ctx.locale`, `ctx.theme`, `ctx.slots`, … — the property access IS the
+  // dependency, which is why this is read from the source and not declared.
+  for (const match of source.matchAll(/\bctx\.([a-zA-Z][a-zA-Z0-9]*)/g)) used.add(match[1]!)
+  // Nested injects name their service as a string instead.
+  for (const match of source.matchAll(/\.inject\(\[([^\]]*)\]/g)) {
+    for (const name of match[1]!.split(',')) {
+      const clean = name.trim().replace(/^['"`]|['"`]$/g, '')
+      if (clean !== '') used.add(clean)
+    }
+  }
+  return used
+}
+
+/**
+ * Which service each declared seam provides.
+ *
+ * Only the seams the market has ever listed need an entry; an unknown one
+ * fails the test below, which is the point — a new inject has to be
+ * justified by naming what it provides.
+ */
+const SEAM_PROVIDES: Record<string, string> = {
+  '@deepseek-ai/dsh-client-locale': 'locale',
+  '@deepseek-ai/dsh-client-ui-settings': 'slots',
+  '@deepseek-ai/dsh-client-ui-theme': 'theme',
+  '@deepseek-ai/dsh-client-connection': 'connection',
+  '@deepseek-ai/dsh-client-runtime': 'runtime',
+}
+
+const declared: string[] = (JSON.parse(readFileSync(resolve('package.json'), 'utf8')) as {
+  dsh: { client: { inject: string[] } }
+}).dsh.client.inject
+
+describe('dsh.client.inject', () => {
+  it('declares only seams the client entry actually uses (#554)', () => {
+    const used = servicesUsed()
+    const unused = declared.filter(seam => {
+      const service = SEAM_PROVIDES[seam]
+      expect(service, `unknown seam ${seam}: add what it provides to SEAM_PROVIDES`).toBeDefined()
+      return !used.has(service!)
+    })
+    // Every entry here is a host version the market will not start on, in
+    // exchange for nothing.
+    expect(unused).toEqual([])
+  })
+
+  it('declares every seam the client entry depends on at module level', () => {
+    // The other direction: reaching for `ctx.locale` without declaring the
+    // locale seam means the entry runs before the service exists.
+    const used = servicesUsed()
+    const provided = new Set(declared.map(seam => SEAM_PROVIDES[seam]))
+    // `effect` and `on` are cordis's own, not seams; `settingsScope` is
+    // injected nested precisely so its absence does not gate the entry.
+    const ownedByCordis = new Set(['effect', 'on', 'settingsScope'])
+    const missing = [...used].filter(service => !provided.has(service) && !ownedByCordis.has(service))
+    expect(missing).toEqual([])
+  })
+
+  it('does not gate the whole entry on a service that is optional in practice', () => {
+    // settingsScope is the standing example: it exists only on rc.7+, and a
+    // module-level inject would have taken the market's own page away on
+    // rc.6 to gain a card rc.6 cannot render. It stays nested.
+    expect(declared).not.toContain('@deepseek-ai/dsh-client-ui-settings-scope')
+    expect(readFileSync(resolve('src/client/index.ts'), 'utf8')).toContain("inject(['settingsScope']")
+  })
+})


### PR DESCRIPTION
Addresses the market's half of #554.

@MarchLiu found that with the market enabled, `dsh-context`'s `/context` command silently stopped registering on dsh 0.1.2-rc.1 — no host error, no console output, no failed boot entry — and isolated it by binary search to the market's entry alone.

**`dsh.client.inject` is a hard gate.** The host holds the client entry back until every listed seam exists. The market listed five and used three:

| declared | used by `src/client/index.ts` |
|---|---|
| `dsh-client-locale` | `ctx.locale` ✓ |
| `dsh-client-ui-settings` | `ctx.slots` ✓ |
| `dsh-client-ui-theme` | `ctx.theme` ✓ |
| `dsh-client-connection` | **nothing** |
| `dsh-client-runtime` | **nothing** |

The second dead entry is the seam 0.1.2-rc.1 ships incompletely, and which had already hard-failed another plugin's boot outright. Both have been in the manifest since 0.1.0 — never removed when the code that might have needed them was not written.

**Not a 1.45.0 regression**, despite the report's title; that is just the version the reporter is on.

Whether this fully fixes what they saw depends on how the host propagates a never-satisfied inject to later client modules, which I cannot settle from here. What it does settle is the market's contribution: **a seam it never used is a host version it refused to run on, bought for nothing.**

## The test

The thing that was missing: the declaration and its use kept next to each other. It reads the client source rather than a hand-written list, so it fails in both directions — a listed seam nothing uses, and a `ctx.` service nothing declares. Verified by putting `dsh-client-runtime` back:

```
AssertionError: expected [ '@deepseek-ai/dsh-client-runtime' ] to deeply equal []
```

For context, rc.8 ships both dropped seams — which is why the e2e lane never saw this, and why the gap only appears on hosts that do not.

1324 unit, 40 e2e against a real host.
