### PR TITLE
fix: read the repository of an ordinary npm install (#544)

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -431,6 +431,17 @@ export interface InstalledRepoEvidence {
  * Discover declared repository identities and weaker local-origin hints. A
  * package.json repository declaration is authoritative; Git origin is only a
  * disambiguation hint because a checkout may legitimately point at a fork.
+ *
+ * Read for EVERY spec kind, not only `link:`/`file:` (#544 by @QinYupan).
+ * Two same-named catalog entries and an ordinary npm install: the manifest's
+ * `repository` — `git+https://github.com/MrmoLabs/dsh-mermaid.git` — is the
+ * one fact that says WHICH of the two is installed, and it sits in the same
+ * package.json for an npm install as for a local one. This used to return
+ * empty for anything not `link:`/`file:`, so the client fell back to name
+ * matching, found two candidates, and matched NEITHER — the Discover card
+ * kept showing Install on a plugin that was running. What stays local-only:
+ * the git-origin hint (there is no checkout to read) and the local source
+ * directory walk.
  */
 export function readInstalledRepoEvidence(
   profile: string,
@@ -438,9 +449,9 @@ export function readInstalledRepoEvidence(
   spec: string,
   explicitDir?: string,
 ): InstalledRepoEvidence {
-  if (!PACKAGE_NAME_RE.test(name) || !/^(?:link|file):/i.test(spec)) return { identities: [], hints: [] }
+  if (!PACKAGE_NAME_RE.test(name)) return { identities: [], hints: [] }
   const root = profileDir(profile, explicitDir)
-  const sourceDir = localSpecDirectory(root, spec)
+  const sourceDir = /^(?:link|file):/i.test(spec) ? localSpecDirectory(root, spec) : null
   const installedDir = installedPackageDirectory(root, name)
   const manifestDir = installedDir ?? sourceDir
   const manifest = manifestDir === null ? readInstalledManifest(profile, name, explicitDir) : manifestAt(manifestDir)

--- a/tests/market-data.spec.ts
+++ b/tests/market-data.spec.ts
@@ -48,6 +48,30 @@ describe('installedForCatalog', () => {
 })
 
 describe('matchInstalledName / isInstalled', () => {
+  it('a same-named entry is matched through manifest repo evidence; the other same-named entry is not (#544)', () => {
+    // @QinYupan's shape: two catalog entries named dsh-mermaid, an ordinary
+    // npm install, and the installed manifest's repository naming the
+    // MrmoLabs one. Without the evidence the client found two name
+    // candidates and matched neither, so Discover kept showing Install on a
+    // running plugin.
+    const mrmolabs = plugin({ name: 'dsh-mermaid', npm: 'dsh-mermaid', url: 'https://github.com/MrmoLabs/dsh-mermaid' })
+    const aks = plugin({ name: 'dsh-mermaid', url: 'https://github.com/AKS1st/dsh-mermaid' })
+    const catalog = [mrmolabs, aks]
+    const installed = { 'dsh-mermaid': '^0.4.0' }
+    const identities = { 'dsh-mermaid': ['mrmolabs/dsh-mermaid'] }
+
+    expect(matchInstalledName(mrmolabs, installed, identities, catalog)).toBe('dsh-mermaid')
+    expect(matchInstalledName(aks, installed, identities, catalog)).toBeNull()
+    // With no evidence at all — the pre-fix answer for an npm install —
+    // NEITHER matches, which is exactly the reported symptom: the running
+    // plugin's card keeps offering Install.
+    expect(matchInstalledName(mrmolabs, installed, {}, catalog)).toBeNull()
+    expect(matchInstalledName(aks, installed, {}, catalog)).toBeNull()
+    // The same evidence carries into entryForDep, which the Installed tab
+    // and restore dialogs use.
+    expect(entryForDep(catalog, 'dsh-mermaid', '^0.4.0', identities['dsh-mermaid'])?.url).toBe(mrmolabs.url)
+  })
+
   it('matches through each identity path exclusively; never by prefix', () => {
     // NAME path (scoped, registry npm field unset; url points elsewhere).
     expect(matchInstalledName(

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -202,6 +202,27 @@ describe('holdsNativeAddon (#441)', () => {
 })
 
 describe('readInstalledRepoEvidence (#141)', () => {
+  it('reads the repository of an ordinary npm install, which is the only tie-breaker between same-named entries (#544)', () => {
+    // @QinYupan: dsh-mermaid installed from npm, two same-named catalog
+    // entries, and the Discover card still said Install. The manifest's
+    // repository declaration names which of the two is on disk, and it sits
+    // in node_modules/<pkg>/package.json for an npm install exactly as it
+    // does for a local one — this used to return empty for any spec that
+    // was not link:/file:, so the client found two name candidates and
+    // matched neither.
+    const dir = writeProfile({ dependencies: { 'dsh-mermaid': '^0.4.0' } })
+    const installedDir = join(dir, 'node_modules', 'dsh-mermaid')
+    mkdirSync(installedDir, { recursive: true })
+    writeFileSync(join(installedDir, 'package.json'), JSON.stringify({
+      name: 'dsh-mermaid',
+      version: '0.4.0',
+      repository: { type: 'git', url: 'git+https://github.com/MrmoLabs/dsh-mermaid.git' },
+    }))
+
+    expect(readInstalledRepoEvidence('web', 'dsh-mermaid', '^0.4.0'))
+      .toEqual({ identities: ['mrmolabs/dsh-mermaid'], hints: [] })
+  })
+
   it('reads package.json repository metadata, including monorepo directories', () => {
     const target = mkdtempSync(join(tmpdir(), 'dshm-link-'))
     try {


### PR DESCRIPTION
Fixes #544 — your diagnosis was exactly right, both halves of it.

**What was wrong.** `readInstalledRepoEvidence` bailed out for any spec that was not `link:`/`file:`. So an ordinary npm install carried no repo identity, the client fell back to name matching, found **two** candidates for `dsh-mermaid` — and matched **neither**. The Discover card kept saying Install on a plugin that was running.

**The fix is one boundary change.** The manifest's `repository` is read for every spec kind now — it sits in `node_modules/<pkg>/package.json` for an npm install exactly as it does for a local one, and it is the one fact that says which of the two same-named entries is on disk. What stays local-only, deliberately:

- the **git-origin hint** — there is no checkout to read for an npm install;
- the **local source directory walk** — `link:`/`file:` only.

**Tests pin the exact shape you reported:**

- the MrmoLabs entry matches through manifest evidence;
- the AKS1st entry does **not** (not mislabelled installed);
- `entryForDep` agrees, so the Installed tab and restore dialogs resolve the same way;
- and with no evidence at all — the pre-fix answer for an npm install — **neither** matches, which is the symptom as it looked from the card.

Also worth noting for the future: this was the third bug in this family, and each had the same shape — #485 (a name-only restore guess), #474 (same-name entries and a stale snapshot), now #544 (same-name entries and missing evidence). Same-named catalog entries are legitimate by design; the market's job is to stop treating the name as the identity when something better is available.

1326 tests.
