### PR TITLE
fix: discover flat Desktop hosts with corroborated runtime versions

### DIFF
--- a/src/dsh-install.ts
+++ b/src/dsh-install.ts
@@ -1,7 +1,7 @@
 /** Locate the DSH host package in CLI and packaged Desktop runtimes. */
 
 import { readFileSync, realpathSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 /** The entry with symlinks resolved, or unchanged when it cannot be read. */
 function realpathOf(entry: string): string {
@@ -16,31 +16,78 @@ function realpathOf(entry: string): string {
 }
 
 const DSH_PACKAGE = '@deepseek-ai/dsh'
+const DESKTOP_PACKAGE = '@deepseek-ai/dsh-desktop'
+const APPLICATION_ROOTS = ['app.asar.unpacked', 'app.asar', 'app']
+// The split runtime reported in #553. Only these local, identity-checked
+// packages corroborate the shell; never resolve witnesses from a profile.
+const DESKTOP_RUNTIME_PACKAGES = ['dsh-base', 'dsh-web-app', 'dsh-web', 'dsh-settings']
 
 /**
- * The host package's own manifest, or null when `directory` is not it.
- * @returns the parsed manifest of `@deepseek-ai/dsh`, or null.
+ * A package's own manifest, or null when its identity cannot be confirmed.
  */
-function readDshManifest(directory: string): { name: string; version?: unknown } | null {
+function readDshManifest(directory: string, name = DSH_PACKAGE): { name: string; version?: unknown } | null {
   try {
     const manifest = JSON.parse(
       readFileSync(join(directory, 'package.json'), 'utf8'),
     ) as { name?: unknown; version?: unknown }
-    return manifest.name === DSH_PACKAGE ? { name: DSH_PACKAGE, version: manifest.version } : null
+    return manifest.name === name ? { name, version: manifest.version } : null
   } catch {
     return null
   }
 }
 
-function isDshPackage(directory: string): boolean {
-  return readDshManifest(directory) !== null
+function entryDirectories(entry: string | undefined): string[] {
+  if (entry === undefined) return []
+  const directories: string[] = []
+  let directory = resolve(dirname(realpathOf(entry)))
+  for (let depth = 0; depth < 10; depth += 1) {
+    directories.push(directory)
+    const parent = dirname(directory)
+    if (parent === directory) break
+    directory = parent
+  }
+  return directories
+}
+
+function desktopDirectories(): string[] {
+  const { resourcesPath } = process as NodeJS.Process & { resourcesPath?: unknown }
+  if (typeof resourcesPath !== 'string' || resourcesPath.length === 0) return []
+  return APPLICATION_ROOTS.map(root => join(resourcesPath, root))
+}
+
+function declaredVersion(manifest: { version?: unknown } | null): string {
+  return typeof manifest?.version === 'string' && manifest.version !== '' ? manifest.version : 'unknown'
+}
+
+function flatDesktopHost(directory: string): { version: string; directory: string } | null {
+  const shell = readDshManifest(directory, DESKTOP_PACKAGE)
+  if (shell === null) return null
+  const runtime = DESKTOP_RUNTIME_PACKAGES.map(name => {
+    const candidate = join(directory, 'node_modules', '@deepseek-ai', name)
+    // Bundled pnpm links are fine; a link to a mutable profile/global package
+    // is not evidence about the version of the embedded runtime.
+    const path = relative(realpathOf(directory), realpathOf(join(candidate, 'package.json')))
+    if (isAbsolute(path) || path === '..' || path.startsWith(`..${sep}`)) return null
+    return readDshManifest(candidate, `@deepseek-ai/${name}`)
+  })
+  // A shell alone is not a dependency anchor. Either in-box bundle can
+  // establish the directory even if the other version witnesses are broken.
+  if (runtime[0] === null && runtime[1] === null) return null
+  const version = declaredVersion(shell)
+  // DSH split packages share a release line, but a desktop shell need not.
+  // Require agreement from every witness; missing/conflicting evidence is
+  // unknown, not the shell version or a majority vote among split packages.
+  const parsed = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(version)
+  const corroborated = parsed !== null && !(parsed[1]?.split('.').some(part => /^0\d+$/.test(part)) ?? false)
+    && runtime.every(manifest => manifest?.version === version)
+  return { directory, version: corroborated ? version : 'unknown' }
 }
 
 /**
  * The version of the DSH host this market is running inside.
  *
- * Read from the same manifest `findDshInstallDir` already parses to identify
- * the package — the version was sitting in that object and being discarded.
+ * CLI versions come from the host manifest. Flat Desktop shells additionally
+ * require agreement with their bundled split runtime, never profile packages.
  *
  * Worth reporting because the host version has repeatedly been the thing
  * neither side could see. #293 turned on it (the reporter was on
@@ -57,16 +104,18 @@ function isDshPackage(directory: string): boolean {
  * legitimately land here).
  */
 export function dshHostInfo(entry = process.argv[1]): { version: string; directory: string } | null {
-  const directory = findDshInstallDir(entry)
-  if (directory === null) return null
-  const manifest = readDshManifest(directory)
-  // Located but unversioned: report the directory anyway. "The host is here
-  // and declares no version" is a fact worth carrying, and it is not the
-  // same fact as "no host found".
-  const version = typeof manifest?.version === 'string' && manifest.version !== ''
-    ? manifest.version
-    : 'unknown'
-  return { version, directory }
+  const ancestors = entryDirectories(entry)
+  const applications = desktopDirectories()
+  // Keep the entire legacy search order ahead of newly supported shells.
+  for (const directory of [...ancestors, ...applications.map(root => join(root, 'node_modules', '@deepseek-ai', 'dsh'))]) {
+    const manifest = readDshManifest(directory)
+    if (manifest !== null) return { directory, version: declaredVersion(manifest) }
+  }
+  for (const directory of [...ancestors, ...applications]) {
+    const host = flatDesktopHost(directory)
+    if (host !== null) return host
+  }
+  return null
 }
 
 /**
@@ -90,29 +139,5 @@ export function dshHostInfo(entry = process.argv[1]): { version: string; directo
  * why this survived: the case that worked is the one that gets tested.
  */
 export function findDshInstallDir(entry = process.argv[1]): string | null {
-  if (entry !== undefined) {
-    let directory = resolve(dirname(realpathOf(entry)))
-    for (let depth = 0; depth < 10; depth += 1) {
-      if (isDshPackage(directory)) return directory
-      const parent = dirname(directory)
-      if (parent === directory) break
-      directory = parent
-    }
-  }
-
-  const electronProcess = process as NodeJS.Process & { resourcesPath?: unknown }
-  if (typeof electronProcess.resourcesPath !== 'string'
-    || electronProcess.resourcesPath.length === 0) return null
-
-  for (const applicationRoot of ['app.asar.unpacked', 'app.asar', 'app']) {
-    const candidate = join(
-      electronProcess.resourcesPath,
-      applicationRoot,
-      'node_modules',
-      '@deepseek-ai',
-      'dsh',
-    )
-    if (isDshPackage(candidate)) return candidate
-  }
-  return null
+  return dshHostInfo(entry)?.directory ?? null
 }

--- a/tests/check.spec.ts
+++ b/tests/check.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '../src/check.ts'
 import { dshHostInfo } from '../src/dsh-install.ts'
 import { readBundleRules } from '../src/order.ts'
+import { trialValidate } from '../src/trial.ts'
 
 let tmp: string
 const originalResourcesPath = Object.getOwnPropertyDescriptor(process, 'resourcesPath')
@@ -1077,6 +1078,150 @@ describe('Desktop host discovery (#405)', () => {
     expect(report.summary.warnings).not.toContain(
       'dsh-vision-router: attachment-local — patch target not found',
     )
+  })
+})
+
+describe('flat Desktop host discovery (#553)', () => {
+  // Report-derived layout, not an extracted rc.12 installer. In particular,
+  // app.asar below is an ordinary directory, NOT Electron's virtual fs.
+  const packages = ['dsh-base', 'dsh-web-app', 'dsh-web', 'dsh-settings']
+  const version = '0.1.0-rc.12'
+  function desktop(applicationRoot = 'app'): string {
+    const resources = join(tmp, 'flat-resources')
+    const app = join(resources, applicationRoot)
+    writeProfile(app, { name: '@deepseek-ai/dsh-desktop', version })
+    for (const name of packages) {
+      writePackage(app, `@deepseek-ai/${name}`, { name: `@deepseek-ai/${name}`, version })
+    }
+    Object.defineProperty(process, 'resourcesPath', { value: resources, configurable: true })
+    return app
+  }
+
+  it('finds the flat dependency anchor from the process entry without resourcesPath', () => {
+    const app = desktop()
+    delete (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+    expect(findDshInstallDir(join(app, 'lib', 'main.js'))).toBe(app)
+    expect(dshHostInfo(join(app, 'lib', 'main.js'))).toEqual({ directory: app, version })
+  })
+
+  it.each(['app', 'app.asar', 'app.asar.unpacked'])(
+    'falls back to resources/%s with an unhelpful entry (filesystem fixture)', root => {
+      const app = desktop(root)
+      expect(dshHostInfo(join(tmp, 'unrelated', 'main.js'))).toEqual({ directory: app, version })
+    },
+  )
+
+  it('preserves legacy nested-host priority over a flat shell reached by argv', () => {
+    const app = desktop()
+    const cli = writePackage(app, '@deepseek-ai/dsh', { name: '@deepseek-ai/dsh', version: '0.1.1-rc.2' })
+    expect(dshHostInfo(join(app, 'lib', 'main.js'))).toEqual({ directory: cli, version: '0.1.1-rc.2' })
+  })
+
+  it.each([undefined, '', ' ', 'not-a-version', '0.1', 12, null, '9.9.9'])(
+    'retains the dependency anchor but not an uncorroborated shell version %j', shellVersion => {
+      const app = desktop()
+      writeProfile(app, { name: '@deepseek-ai/dsh-desktop', version: shellVersion })
+      expect(dshHostInfo(join(app, 'lib', 'main.js'))).toEqual({ directory: app, version: 'unknown' })
+    },
+  )
+
+  it.each(packages)('does not choose a version when %s disagrees', name => {
+    const app = desktop()
+    writePackage(app, `@deepseek-ai/${name}`, { name: `@deepseek-ai/${name}`, version: '0.1.1-rc.2' })
+    expect(dshHostInfo(join(app, 'lib', 'main.js'))).toEqual({ directory: app, version: 'unknown' })
+  })
+
+  it.each(['garbage', '01.2.3', '1.2.3-01', '1.2.3-rc..1'])(
+    'does not report an invalid version even if every manifest agrees: %s', invalidVersion => {
+      const app = desktop()
+      writeProfile(app, { name: '@deepseek-ai/dsh-desktop', version: invalidVersion })
+      for (const name of packages) {
+        writePackage(app, `@deepseek-ai/${name}`, { name: `@deepseek-ai/${name}`, version: invalidVersion })
+      }
+      expect(dshHostInfo(join(app, 'lib', 'main.js'))).toEqual({ directory: app, version: 'unknown' })
+    },
+  )
+
+  it.each([false, true])('accepts bundled package links but not profile links (external=%s)', external => {
+    const app = desktop()
+    const name = '@deepseek-ai/dsh-web'
+    const target = writePackage(external ? pdir() : join(app, 'node_modules', '.pnpm', 'runtime'), name, { name, version })
+    const link = join(app, 'node_modules', name)
+    rmSync(link, { recursive: true })
+    symlinkSync(target, link, process.platform === 'win32' ? 'junction' : 'dir')
+    expect(dshHostInfo(join(app, 'lib', 'main.js'))).toEqual({ directory: app, version: external ? 'unknown' : version })
+  })
+
+  it('uses resources when argv has no entry', () => {
+    const app = desktop()
+    const argv = process.argv
+    try {
+      process.argv = [argv[0]!]
+      expect(dshHostInfo()).toEqual({ directory: app, version })
+    } finally {
+      process.argv = argv
+    }
+  })
+
+  it.each(['missing', 'unreadable', 'json', 'identity', 'version'])(
+    'keeps a confirmed bundle anchor when another witness is %s', defect => {
+      const app = desktop()
+      const manifest = join(app, 'node_modules', '@deepseek-ai', 'dsh-web-app', 'package.json')
+      if (defect === 'missing' || defect === 'unreadable') {
+        rmSync(manifest)
+        // A directory at the file path produces a read failure on both OSes.
+        if (defect === 'unreadable') mkdirSync(manifest)
+      } else {
+        writeFileSync(manifest, defect === 'json' ? '{' : JSON.stringify(
+          defect === 'identity' ? { name: 'impostor', version } : { name: '@deepseek-ai/dsh-web-app' },
+        ))
+      }
+      expect(dshHostInfo(join(app, 'lib', 'main.js'))).toEqual({ directory: app, version: 'unknown' })
+    },
+  )
+
+  it.each(['null', '{', '{"name":"other-desktop","version":"0.1.0-rc.12"}'])(
+    'rejects a malformed or wrong shell manifest: %s', content => {
+      const app = desktop()
+      writeFileSync(join(app, 'package.json'), content)
+      expect(dshHostInfo(join(app, 'lib', 'main.js'))).toBeNull()
+    },
+  )
+
+  it('does not treat a shell-only directory or profile packages as a bundled runtime', () => {
+    const app = desktop()
+    rmSync(join(app, 'node_modules'), { recursive: true })
+    for (const name of packages) {
+      writePackage(pdir(), `@deepseek-ai/${name}`, { name: `@deepseek-ai/${name}`, version })
+      // Node's ancestor search must not supply version evidence either.
+      writePackage(tmp, `@deepseek-ai/${name}`, { name: `@deepseek-ai/${name}`, version })
+    }
+    expect(dshHostInfo(join(app, 'lib', 'main.js'))).toBeNull()
+  })
+
+  it('resolves built-in bundle composition, inventory, ordering and trial from the flat anchor', () => {
+    const app = desktop()
+    const base = writeBundle(app, '@deepseek-ai/dsh-base', version, [
+      { insert: [{ id: 'attachment-local', name: '@deepseek-ai/dsh-attachment-local' }] },
+    ], { before: ['community'] })
+    const dir = pdir()
+    writeProfile(dir, {
+      dependencies: { community: '1.0.0' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'community'] } },
+    })
+    writeBundle(dir, 'community', '1.0.0', [{ id: 'attachment-local', config: { local: true } }])
+    writeBundle(dir, '@deepseek-ai/dsh-base', '9.9.9', [])
+
+    const report = analyzeProfile(dir, { homeDir: join(tmp, 'empty-home') })
+    expect(report.bundles[0]).toMatchObject({ directory: base, entries: ['attachment-local'] })
+    expect(report.orphans).toEqual([])
+    expect(report.overrides).toContainEqual({
+      id: 'attachment-local', layer: 'community', overriddenLayers: ['@deepseek-ai/dsh-base'],
+    })
+    expect(corePackageNames(findDshInstallDir())).toContain('@deepseek-ai/dsh-web')
+    expect(readBundleRules(dir)).toContainEqual({ name: '@deepseek-ai/dsh-base', before: ['community'], after: [] })
+    expect(trialValidate(dir, ['community'], { homeDir: join(tmp, 'empty-home') })).toMatchObject({ ok: true })
+    expect(dshHostInfo()).toEqual({ directory: app, version })
   })
 })
 

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -651,6 +651,64 @@ function npmLockFixture(name: string, spec: string, version: string): string {
   ].join('\n')
 }
 
+describe('flat Desktop host consumers (#553)', () => {
+  const resourcesDescriptor = Object.getOwnPropertyDescriptor(process, 'resourcesPath')
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    if (resourcesDescriptor === undefined) delete (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+    else Object.defineProperty(process, 'resourcesPath', resourcesDescriptor)
+  })
+
+  it.each([false, true])('propagates host evidence through registry, discovery and update (conflict=%s)', async conflict => {
+    for (const key of ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY', 'npm_config_proxy', 'npm_config_https_proxy']) {
+      vi.stubEnv(key, '')
+    }
+    // Report-derived filesystem fixture, not a real Electron installation.
+    const resources = join(home, 'resources')
+    const app = join(resources, 'app')
+    mkdirSync(app, { recursive: true })
+    writeFileSync(join(app, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh-desktop', version: '0.1.0-rc.12' }))
+    for (const name of ['dsh-base', 'dsh-web-app', 'dsh-web', 'dsh-settings']) {
+      const dir = join(app, 'node_modules', '@deepseek-ai', name)
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({
+        name: `@deepseek-ai/${name}`, version: conflict && name === 'dsh-web' ? '0.1.1-rc.2' : '0.1.0-rc.12',
+      }))
+    }
+    Object.defineProperty(process, 'resourcesPath', { value: resources, configurable: true })
+    const expectedVersion = conflict ? 'unknown' : '0.1.0-rc.12'
+    fake.npm['dsh-loop'] = { latest: '1.0.0', versions: { '1.0.0': { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] } } }
+    expect((await bed.dispatch('POST', '/dsh-market/install', { url: 'https://github.com/o/dsh-loop' })).status).toBe(200)
+    fake.npm['dsh-loop'].latest = '2.0.0'
+    fake.npm['dsh-loop'].versions['2.0.0'] = { manifest: { dsh: {}, main: 'lib/index.js' }, artifacts: ['lib/index.js'] }
+    vi.stubGlobal('fetch', async () => new Response(JSON.stringify({
+      name: 'dsh-loop', version: '2.0.0', engines: { dsh: '>=0.1.1-rc.2' },
+      'dist-tags': { latest: '2.0.0' },
+    }), { status: 200 }))
+
+    const registry = await bed.dispatch('GET', '/dsh-market/registry')
+    expect(registry.json.hostVersion).toBe(expectedVersion)
+    const logs = await bed.dispatch('GET', '/dsh-market/logs')
+    expect(logs.status).toBe(200)
+    expect(logs.text).toContain(`dsh host: ${expectedVersion} (`)
+    expect(logs.text).not.toContain('dsh host: not locatable')
+    const discovery = await bed.dispatch('POST', '/dsh-market/discovery-compatibility', { packages: ['dsh-loop'] })
+    expect(discovery.json.hostVersion).toBe(expectedVersion)
+    expect(discovery.json.plugins['dsh-loop'].status).toBe(conflict ? 'unknown' : 'incompatible')
+    const callsBeforeUpdate = fake.calls.length
+    const updated = await bed.dispatch('POST', '/dsh-market/update', { name: 'dsh-loop' })
+    if (conflict) {
+      expect(updated.status).toBe(200)
+      expect(updated.json.hostIncompatible).toBeUndefined()
+    } else {
+      expect(updated.status).toBe(400)
+      expect(updated.json.hostIncompatible).toMatchObject({ hostVersion: expectedVersion, requirement: '>=0.1.1-rc.2' })
+      expect(fake.calls.slice(callsBeforeUpdate).filter(args => args.includes('add'))).toEqual([])
+      expect(installedSpec('dsh-loop')).toBe('^1.0.0')
+    }
+  })
+})
+
 describe('host-provided profile and package-operation seams', () => {
   it('mounts ordinary routes for a dotted, Unicode, spaced DSH profile name (#260)', async () => {
     bed.dispose()


### PR DESCRIPTION
Refs #553

## Summary

- Recognize the flat `@deepseek-ai/dsh-desktop` layout from the process entry or Electron's resources directory, after all existing CLI and nested Desktop candidates.
- Return the application root as the dependency-resolution anchor only when a local, identity-checked in-box bundle is present.
- Report a Desktop version only when the shell and all four local runtime witnesses (`dsh-base`, `dsh-web-app`, `dsh-web`, `dsh-settings`) agree on a well-formed version. Missing, unreadable or conflicting evidence retains a confirmed directory with `version: 'unknown'`.
- Do not use profile/ancestor packages or links escaping the bundled tree as version evidence. Preserve internal pnpm links, global CLI entry symlinks, existing lookup priorities and public return types.

## Why

The existing locator accepts only `@deepseek-ai/dsh`. The layout described in #553 has the Desktop manifest at `resources/app/package.json` and split runtime packages directly under that root's `node_modules`, without a nested `dsh` package. Consequently both host reporting and the dependency anchor are lost.

Accepting the Desktop package name alone would substitute a shell version for a host version and could select a shell-only directory. The new path requires local runtime evidence and keeps location distinct from version certainty.

## Tests

- Added 36 regression cases across `tests/check.spec.ts` and `tests/flows.spec.ts`.
- Red first: 24 assertions failed against unchanged upstream production code (missing directory/version, unresolved built-in bundle, null HTTP host version). Additional boundary tests caught three failures for invalid versions and an escaping package link before those were fixed.
- Related check/flow/order/trial/routes/discovery suites: 372 passed.
- `npm test` (using `without-proxy` for the existing network mocks): 60 files, 1360 passed, including the final log-export assertions.
- `npm run check`: passed typechecks, build, client rebuild and restart smoke.
- `npm run test:compat` (using `without-proxy`): 14 passed against the real pnpm matrix.
- `node scripts/preflight.mjs` and `git diff --check`: passed.
- Downstream regressions exercise built-in bundle composition, override provenance, core inventory, ordering, trial validation, exported logs, registry host version, discovery verdicts and pre-update refusal. Conflicting versions keep compatibility unknown and do not manufacture a refusal.

## Evidence And Limits

The rc.12 layout is a report-derived filesystem fixture, not an extracted installer or a Windows desktop run. No trusted corresponding installer was obtained. The public desktop source history inspected starts with a different version/layout; current upstream uses a separate `resources/dsh` runtime and is not historical evidence for rc.12.

`app.asar` tests use ordinary directories with a mocked `process.resourcesPath`, not Electron's virtual filesystem. `npm run test:web` passed its capture guard but skipped all 40 tests because no dsh CLI was available. No Windows/Electron execution or upstream CI is claimed.

This change does not add support for the newer separate `resources/dsh` runtime, cross-root split-ASAR arrangements, or other Desktop distributions. It does not change installation protocols, fresh-install policy, dependencies, package versions or client source.

## Checklist

- [x] Unit tests and `npm run check` pass locally.
- [x] Regression tests fail without the fix.
- [x] No package version bump or dependency changes.
- [x] Client rebuild produces no tracked client changes.
- [x] Runtime and installer verification limits disclosed.
