### PR TITLE
fix(pnpm-compat): give ERR_PNPM_NO_MATCHING_VERSION its own code and wording

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -112,7 +112,7 @@ export async function withHoistRecovery(
       logEvent('warn', 'install', `a too-young release blocks pnpm's lockfile verification (#39) — retrying once with ${RELEASE_AGE_OVERRIDE}`)
       result = await run(profile, [pluginArgs[0], RELEASE_AGE_OVERRIDE, ...pluginArgs.slice(1)])
     } else if (
-      failure?.code === 'fetch-404'
+      (failure?.code === 'fetch-404' || failure?.code === 'no-matching-version')
       && isUnpublishedHostPeer(failure.pkg, profile, profileDirectory)
       && (pluginArgs[0] === 'add' || pluginArgs[0] === 'remove')
       && !pluginArgs.includes(AUTO_INSTALL_PEERS_OFF)

--- a/src/pnpm-compat.ts
+++ b/src/pnpm-compat.ts
@@ -46,7 +46,7 @@ export const HOST_NAMESPACE_RE = /^@deepseek-ai\//
 export interface PnpmFailure {
   code: 'adding-to-root' | 'not-a-workspace' | 'hoist-pattern-diff' | 'pnpm-missing' | 'release-age-violation'
     | 'ignored-builds' | 'git-prepare-not-allowed' | 'git-prepare-failed' | 'tarball-url-mismatch'
-    | 'fetch-404' | 'transient-network' | 'fetch-timeout'
+    | 'fetch-404' | 'no-matching-version' | 'transient-network' | 'fetch-timeout'
     | 'unexpected-store' | 'patch-failed' | 'missing-tarball-integrity' | 'windows-file-locked'
     | 'pnpm-unusable' | 'missing-local-dependency'
   /** Bilingual, actionable message shown to the user instead of the raw wall of text. */
@@ -376,6 +376,29 @@ export function classifyPnpmFailure(output: string, exitCode?: number | null): P
       recoverable: false,
       pkg,
       message: `有一个依赖在 registry 上不存在${zh}，pnpm 因此拒绝任何安装操作。它可能是之前失败操作残留在 profile package.json 里的幽灵依赖（可手动删除该行），也可能是需要登录的私有包 / a dependency cannot be resolved from the registry${en}; pnpm refuses every install while it is present. It may be a ghost entry left in the profile's package.json by an earlier failed operation (remove that line by hand), or a private package needing registry credentials`,
+    }
+  }
+  // #569: a host peer that only ever published pre-releases (e.g.
+  // `@deepseek-ai/dsh-tools` with nothing above `-rc.*`) resolves to NO
+  // stable version, and pnpm reports ERR_PNPM_NO_MATCHING_VERSION — the
+  // package exists, the requested range matches nothing. This is the same
+  // unpublished-host-peer shape #289 recovers from, just with a different
+  // error code, so the classifier names it separately and the #289 retry
+  // shares it via install.ts's gate. Real output (pnpm 12.4.1): see
+  // tests/pnpm-compat.spec.ts, which pins this wording.
+  if (output.includes('ERR_PNPM_NO_MATCHING_VERSION')) {
+    const pkg = /No matching version found for\s+((?:@[^/\s]+\/)?[^@\s]+)@/.exec(output)?.[1]
+      ?? /GET\s+\S*\/([^/\s]+):/.exec(output)?.[1].replace(/%2[Ff]/g, '/')
+    const zh = pkg === undefined ? '' : `（${pkg}）`
+    const en = pkg === undefined ? '' : ` (${pkg})`
+    const hostPeer = pkg !== undefined && HOST_NAMESPACE_RE.test(pkg)
+    return {
+      code: 'no-matching-version',
+      recoverable: false,
+      pkg,
+      message: hostPeer
+        ? `插件声明依赖的宿主包${zh}在 registry 上没有满足其版本范围的发布版（宿主运行时会自带它，npm 上不会出现这个版本）。市场会自动重试一次，放行这条 peer 依赖 / a plugin's declared host peer${en} has no published version satisfying its range — the runtime provides it, so npm carries no such version. The market retries once with that peer exempted from auto-install`
+        : `插件声明的一个依赖版本范围在 registry 上没有可满足的版本${zh}，通常是该版本被弃用或从未发布 / a dependency of this plugin declared a version range with no matching release on the registry${en} — the range resolves to nothing (withdrawn or never published)`,
     }
   }
   // #389 by @qq1054435284: on Windows, pnpm stages the new version in a

--- a/tests/pnpm-compat.spec.ts
+++ b/tests/pnpm-compat.spec.ts
@@ -305,6 +305,59 @@ The lockfile contains entries that the active policies reject.`)
   })
 })
 
+describe('ERR_PNPM_NO_MATCHING_VERSION — host peer with only pre-releases (#569)', () => {
+  // Verbatim pnpm 12.4.1 output for:
+  //   pnpm add @deepseek-ai/dsh-tools@'>=0.1.0'
+  // where every published version of the package is a pre-release. Kept
+  // word-for-word (including the wrapped URL) per the house rule for
+  // classifier fixtures: if pnpm rewraps or rewords, a test breaks instead
+  // of a user-facing message.
+  const OUTPUT = [
+    'Error: ERR_PNPM_NO_MATCHING_VERSION',
+    '',
+    '  × adding a new package',
+    '  ╰─▶ Failed to resolve dependency tree: No matching version found for',
+    '      @deepseek-ai/dsh-tools@>=0.1.0 while fetching it from https://',
+    '      registry.npmjs.org/',
+    '  help: The latest release of @deepseek-ai/dsh-tools is "0.0.1-rc.1".',
+    '        ',
+    '        Other releases are:',
+    '          * alpha: 0.1.5-alpha.2',
+    '          * next: 0.1.5-rc.2',
+    '        ',
+    '        If you need the full list of all 21 published versions run "pnpm view',
+    '        @deepseek-ai/dsh-tools versions".',
+  ].join('\n')
+
+  it('gets its own code, not fetch-404', () => {
+    const failure = classifyPnpmFailure(OUTPUT)
+    expect(failure?.code).toBe('no-matching-version')
+    expect(failure?.code).not.toBe('fetch-404')
+  })
+
+  it('extracts the scoped host peer through the wrapped output', () => {
+    const failure = classifyPnpmFailure(OUTPUT)
+    expect(failure?.pkg).toBe('@deepseek-ai/dsh-tools')
+  })
+
+  it('explains the host-provided provision and the automatic retry', () => {
+    const failure = classifyPnpmFailure(OUTPUT)
+    expect(failure?.message).toContain('宿主包（@deepseek-ai/dsh-tools）')
+    expect(failure?.message).toContain('自动重试')
+  })
+
+  it('degrades to the unnamed wording when the package name cannot be read', () => {
+    const failure = classifyPnpmFailure('Error: ERR_PNPM_NO_MATCHING_VERSION\n  × adding a new package')
+    expect(failure?.code).toBe('no-matching-version')
+    expect(failure?.message).toContain('没有可满足的版本')
+    expect(failure?.message).not.toContain('宿主包（')
+  })
+
+  it('still names the plain-404 shape as fetch-404 (unchanged)', () => {
+    expect(classifyPnpmFailure('[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/ghost: Not Found - 404')?.code).toBe('fetch-404')
+  })
+})
+
 describe('provisionHint (#142 / #108 / #32)', () => {
   it('names the actual cause instead of a generic failure', async () => {
     const { provisionHint } = await import('../src/dsh-cli.ts')


### PR DESCRIPTION
## Problem

Fixes #569: a host peer that only ever published pre-releases (the issue's example: `@deepseek-ai/dsh-tools`, where every published version is `-rc.*`/`-alpha.*`) makes pnpm fail with **`ERR_PNPM_NO_MATCHING_VERSION`** — but `classifyPnpmFailure` only knows `ERR_PNPM_FETCH_404`, so the #289 one-shot `AUTO_INSTALL_PEERS_OFF` retry never fired: no retry, and the raw pnpm wall of text (whose "The latest release of … is 0.0.1-rc.1" line reads like "you picked the wrong version") was shown instead.

This also addresses the two review points fkysly left on #528 (closed with unmerged commits):

1. **Give the shape its own code and its own sentence, don't reuse fetch-404's.** The fetch-404 copy ("a dependency does not exist on the registry … it may be a ghost entry left in the profile's package.json") is wrong for this shape — the package exists; the *requested range* matches nothing.
2. **No version bump in the PR.** This PR does not touch `package.json`.

## What changed

- `src/pnpm-compat.ts`: new `no-matching-version` failure code with its own bilingual message. For `@deepseek-ai/dsh-*` peers it names the host-provided provision ("the runtime provides it, so npm carries no such version"); for other packages it says the declared range resolves to nothing. `pkg` extraction keeps #528's fallback regex (the `No matching version found for <pkg>@<range>` shape) and adds the existing `GET …/:` shape as a fallback.
- `src/install.ts`: the #289 retry gate now also accepts `no-matching-version` — `isUnpublishedHostPeer` (host-namespace + absent from the profile manifest) still decides, exactly as the review asked ("isUnpublishedHostPeer 那条重试逻辑照旧共用就行，只要把新 code 一起加进判断里").

## Testing

`tests/pnpm-compat.spec.ts` gains five cases whose fixture is **verbatim pnpm 12.4.1 output** captured from `pnpm add @deepseek-ai/dsh-tools@'>=0.1.0'` against the live registry — the exact prerelease-only-host-peer shape of #569, word-for-word including the wrapped URL, per the house rule of pinning real wording in classifier fixtures:

- own code `no-matching-version` (not `fetch-404`);
- scoped host peer extracted through the wrapped output (`@deepseek-ai/dsh-tools`);
- message names the host-provided provision and the automatic retry;
- degrades to the unnamed wording when the package name is unreadable;
- the plain-404 shape still classifies as `fetch-404` (unchanged).

Full suite: 1331/1331 pass (60 files). `tsc -p tsconfig.json --noEmit` clean. Patch applies as a normal source edit (no vendored code involved).
