### PR TITLE
fix(discovery): read dsh.engines.dsh as well as the top-level engines.dsh

### DIFF
--- a/src/discovery-compatibility.ts
+++ b/src/discovery-compatibility.ts
@@ -79,6 +79,12 @@ function record(value: unknown): Record<string, unknown> | null {
 export function manifestFacts(value: unknown): NpmManifestFacts {
   const manifest = record(value) ?? {}
   const engines = record(manifest.engines)
+  // #577: the ecosystem declares the host requirement in BOTH shapes —
+  // top-level `engines.dsh` and `dsh.engines.dsh` under the manifest's own
+  // `dsh` field (the natural home, and what e.g. @linxin666/dsh-web-all
+  // publishes). Neither position is authoritative, so read both; when a
+  // manifest carries both, the top-level declaration wins.
+  const dshEngines = record(record(manifest.dsh)?.engines)
   const peers = record(manifest.peerDependencies)
   const peerDependencies: Record<string, string> = {}
   for (const [name, raw] of Object.entries(peers ?? {})) {
@@ -88,7 +94,7 @@ export function manifestFacts(value: unknown): NpmManifestFacts {
   }
   return {
     version: range(manifest.version),
-    enginesDsh: range(engines?.dsh),
+    enginesDsh: range(engines?.dsh) ?? range(dshEngines?.dsh),
     peerDependencies,
   }
 }

--- a/tests/discovery-compatibility.spec.ts
+++ b/tests/discovery-compatibility.spec.ts
@@ -107,6 +107,42 @@ describe('manifestFacts', () => {
   })
 })
 
+describe('manifestFacts reads both host-requirement shapes (#577)', () => {
+  it('reads dsh.engines.dsh when the top-level engines field is absent', () => {
+    expect(manifestFacts({
+      version: '0.3.20',
+      dsh: { engines: { dsh: ' >=0.1.5-rc.1 ' } },
+    })).toEqual({
+      version: '0.3.20',
+      enginesDsh: '>=0.1.5-rc.1',
+      peerDependencies: {},
+    })
+  })
+
+  it('prefers the top-level engines.dsh when a manifest carries both shapes', () => {
+    expect(manifestFacts({
+      version: '1.0.0',
+      engines: { dsh: '^0.1.2-alpha.2' },
+      dsh: { engines: { dsh: '>=0.1.5-rc.1' } },
+    })).toEqual({
+      version: '1.0.0',
+      enginesDsh: '^0.1.2-alpha.2',
+      peerDependencies: {},
+    })
+  })
+
+  it('stays null when neither shape declares a host requirement', () => {
+    expect(manifestFacts({
+      version: '1.0.0',
+      dsh: { engines: { node: '>=20' } },
+    })).toEqual({
+      version: '1.0.0',
+      enginesDsh: null,
+      peerDependencies: {},
+    })
+  })
+})
+
 describe('DiscoveryManifestIndex', () => {
   const directories: string[] = []
   afterEach(() => {


### PR DESCRIPTION
## Problem

Fixes #577: `manifestFacts()` read the host requirement only from the top-level `engines.dsh`, while a large part of the ecosystem (including `@linxin666/dsh-web-all` and several other packages) declares it as `dsh.engines.dsh` under the manifest's own `dsh` field. For those packages `enginesDsh` was always `null`, so the #404/#522 install-time preflight, the #473 filter, and the #520 catalog split all saw "no declaration".

Both shapes are in active use — this is not one side writing it wrong, it is the field position never having a single convention, and the market only reading one half.

## What changed

`src/discovery-compatibility.ts` — `manifestFacts` now reads both positions: top-level `engines.dsh` remains authoritative, and `dsh.engines.dsh` (under the manifest's own `dsh` field) is the fallback when the top-level declaration is absent. The output shape is unchanged (`NpmManifestFacts`), so the discovery cache (`discovery-compatibility-v1.json`) and every downstream consumer keep working as-is.

## Testing

`tests/discovery-compatibility.spec.ts` — three new cases in a dedicated describe block:

- nested `dsh.engines.dsh` alone → `enginesDsh` picked up (the #577 shape, with the reporter's actual range `>=0.1.5-rc.1` and whitespace normalization);
- both shapes present → the top-level declaration wins;
- neither shape → still `null`.

Full suite: 1334/1334 pass (60 files). `tsc -p tsconfig.json --noEmit` clean.
