### PR TITLE
fix: do not read the manifest for a spec that names its own source (#548)

### DIFF
--- a/src/profile.ts
+++ b/src/profile.ts
@@ -8,7 +8,7 @@ import { existsSync, readdirSync, readFileSync, realpathSync, renameSync, statSy
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
 import { resolveDshHome } from './home-paths.ts'
-import { githubRemoteIdentities, githubRepoIdentities } from './sources.ts'
+import { githubRemoteIdentities, githubRepoIdentities, isGitHostedSpec } from './sources.ts'
 
 /**
  * Whether a profile name follows DSH's own directory-name contract.
@@ -432,16 +432,29 @@ export interface InstalledRepoEvidence {
  * package.json repository declaration is authoritative; Git origin is only a
  * disambiguation hint because a checkout may legitimately point at a fork.
  *
- * Read for EVERY spec kind, not only `link:`/`file:` (#544 by @QinYupan).
- * Two same-named catalog entries and an ordinary npm install: the manifest's
- * `repository` — `git+https://github.com/MrmoLabs/dsh-mermaid.git` — is the
- * one fact that says WHICH of the two is installed, and it sits in the same
- * package.json for an npm install as for a local one. This used to return
+ * Read for local AND registry specs, but never for a spec that already names
+ * its own source (#544 by @QinYupan; boundary from @bulingbuling688 in #548).
+ *
+ * The bug: two same-named catalog entries and an ordinary npm install. The
+ * manifest's `repository` — `git+https://github.com/MrmoLabs/dsh-mermaid.git`
+ * — is the one fact that says WHICH of the two is installed, and it sits in
+ * the same package.json for an npm install as for a local one. This returned
  * empty for anything not `link:`/`file:`, so the client fell back to name
- * matching, found two candidates, and matched NEITHER — the Discover card
- * kept showing Install on a plugin that was running. What stays local-only:
- * the git-origin hint (there is no checkout to read) and the local source
- * directory walk.
+ * matching, found two candidates, and matched NEITHER: the Discover card kept
+ * offering Install on a plugin that was running.
+ *
+ * Why a `github:`/URL install must NOT be read the same way: its spec already
+ * states the source, and the manifest can disagree with it. A fork installed
+ * as `github:myfork/plugin` usually still declares the UPSTREAM repository,
+ * because almost nobody edits that field when forking. Adding it as an
+ * identity made the upstream's card read as installed — measured, and the
+ * same mistake as #485: a weaker signal allowed to outvote a definite one.
+ * The first version of this fix widened to every spec kind and had exactly
+ * that hole.
+ *
+ * What stays local-only for the same reason it always was: the git-origin
+ * hint (there is no checkout to read for a registry install) and the local
+ * source directory walk.
  */
 export function readInstalledRepoEvidence(
   profile: string,
@@ -450,8 +463,13 @@ export function readInstalledRepoEvidence(
   explicitDir?: string,
 ): InstalledRepoEvidence {
   if (!PACKAGE_NAME_RE.test(name)) return { identities: [], hints: [] }
+  const local = /^(?:link|file):/i.test(spec)
+  // A spec that names its own source is the authority on it; see above.
+  if (!local && (isGitHostedSpec(spec) || /^https?:/i.test(spec.trim()))) {
+    return { identities: [], hints: [] }
+  }
   const root = profileDir(profile, explicitDir)
-  const sourceDir = /^(?:link|file):/i.test(spec) ? localSpecDirectory(root, spec) : null
+  const sourceDir = local ? localSpecDirectory(root, spec) : null
   const installedDir = installedPackageDirectory(root, name)
   const manifestDir = installedDir ?? sourceDir
   const manifest = manifestDir === null ? readInstalledManifest(profile, name, explicitDir) : manifestAt(manifestDir)

--- a/tests/market-data.spec.ts
+++ b/tests/market-data.spec.ts
@@ -72,6 +72,22 @@ describe('matchInstalledName / isInstalled', () => {
     expect(entryForDep(catalog, 'dsh-mermaid', '^0.4.0', identities['dsh-mermaid'])?.url).toBe(mrmolabs.url)
   })
 
+  it('never lets a fork\'s upstream manifest claim the upstream card (#548)', () => {
+    // The client half of the same boundary: even if evidence for a
+    // git-installed package ever arrived, the upstream's card must not read
+    // as installed. Both sides are guarded because both sides shipped the
+    // hole once — the server stopped producing the evidence, and this pins
+    // what would happen if it came back.
+    const upstream = plugin({ name: 'dsh-plug', url: 'https://github.com/upstream/dsh-plug' })
+    const fork = plugin({ name: 'dsh-plug', url: 'https://github.com/myfork/dsh-plug' })
+    const installed = { 'dsh-plug': 'github:myfork/dsh-plug' }
+
+    // With no manifest evidence — what the server now returns for a git spec
+    // — the fork matches on its own spec and the upstream does not.
+    expect(matchInstalledName(fork, installed, {}, [upstream, fork])).toBe('dsh-plug')
+    expect(matchInstalledName(upstream, installed, {}, [upstream, fork])).toBeNull()
+  })
+
   it('matches through each identity path exclusively; never by prefix', () => {
     // NAME path (scoped, registry npm field unset; url points elsewhere).
     expect(matchInstalledName(

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -223,6 +223,31 @@ describe('readInstalledRepoEvidence (#141)', () => {
       .toEqual({ identities: ['mrmolabs/dsh-mermaid'], hints: [] })
   })
 
+  it('does NOT read the manifest for a spec that already names its source (#544/#548)', () => {
+    // A fork installed as github:myfork/plugin almost always still declares
+    // the UPSTREAM repository, because nobody edits that field when forking.
+    // Trusting it would add the upstream as an identity and mark the
+    // upstream's Discover card as installed — a weaker signal outvoting a
+    // definite one, which is #485's mistake. The first version of the #544
+    // fix widened to every spec kind and had exactly that hole.
+    const dir = writeProfile({ dependencies: { 'dsh-plug': 'github:myfork/dsh-plug' } })
+    const installedDir = join(dir, 'node_modules', 'dsh-plug')
+    mkdirSync(installedDir, { recursive: true })
+    writeFileSync(join(installedDir, 'package.json'), JSON.stringify({
+      name: 'dsh-plug',
+      repository: { type: 'git', url: 'git+https://github.com/upstream/dsh-plug.git' },
+    }))
+
+    expect(readInstalledRepoEvidence('web', 'dsh-plug', 'github:myfork/dsh-plug'))
+      .toEqual({ identities: [], hints: [] })
+    // Same for a Release archive and a raw git+https spec: each states its
+    // own source already.
+    expect(readInstalledRepoEvidence('web', 'dsh-plug', 'https://github.com/myfork/dsh-plug/releases/download/v1/p.tgz'))
+      .toEqual({ identities: [], hints: [] })
+    expect(readInstalledRepoEvidence('web', 'dsh-plug', 'git+https://gitea.example/me/dsh-plug.git'))
+      .toEqual({ identities: [], hints: [] })
+  })
+
   it('reads package.json repository metadata, including monorepo directories', () => {
     const target = mkdtempSync(join(tmpdir(), 'dshm-link-'))
     try {


### PR DESCRIPTION
Adopts @bulingbuling688's boundary from #548, which was right where mine was wrong.

I merged #559 for #544 before reading #548 properly. Mine widened `readInstalledRepoEvidence` to **every** spec kind; theirs widened it to registry specs and deliberately kept **explicit Git/URL sources excluded**. That distinction is load-bearing, and I measured the hole mine left:

```
installed:  dsh-plug → github:myfork/dsh-plug
manifest:   repository → git+https://github.com/upstream/dsh-plug.git   ← normal for a fork
→ matchInstalledName(upstreamCard, …) returned 'dsh-plug'      ✗ upstream card reads installed
```

`depRepoIds` unions the spec-derived ids with the manifest identities, so the upstream id entered the set, `sameSourceConflict` stopped excluding the upstream's card, and a plugin the user never installed showed as installed. **A weaker signal outvoting a definite one — #485's mistake, reintroduced three days after closing it.**

The rule now: **a spec that names its own source is the authority on it.**

| spec | manifest read? | why |
|---|---|---|
| `link:` / `file:` | yes | the only identity available (#141, #429) |
| registry version / range / tag / alias | yes | the only identity available (#544) |
| `github:`, `git+`, `ssh:`, scp, codeload, any `http(s):` | **no** | the spec already says, and the manifest can disagree |

Tests on both sides, because both sides shipped the hole once: the server returns no evidence for a fork spec, a Release archive and a raw `git+https` remote; the client keeps matching the fork while leaving the upstream unmatched, so if evidence for a git spec ever reappears the consequence is pinned rather than silent.

1328 tests.

@bulingbuling688 — #548 is superseded by this, but the boundary in it is the part that mattered and it is credited in the code comment and commit. Thank you for getting it right; I'd have shipped the fork bug otherwise.
