### PR TITLE
fix: preserve profile and theme state when plugin activation fails

### DIFF
--- a/src/atomic-write.ts
+++ b/src/atomic-write.ts
@@ -1,0 +1,35 @@
+/** Small profile files must not be truncated by a rejected write. */
+import { accessSync, constants, lstatSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { dirname, join } from 'node:path'
+
+/** Follow an existing file link without replacing the user's link itself. */
+export function writeDestination(path: string): string {
+  let link = false
+  try { link = lstatSync(path).isSymbolicLink() } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  // A dangling link is an error, not permission to replace it with a file.
+  return link ? realpathSync(path) : path
+}
+
+/** Atomic replacement must respect the existing file's write permissions. */
+export function checkWritableFile(path: string): void {
+  try { accessSync(path, constants.W_OK) } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+}
+
+export function writeFileAtomic(path: string, text: string): void {
+  const target = writeDestination(path)
+  checkWritableFile(target)
+  let mode = 0o600
+  try { mode = statSync(target).mode & 0o777 } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  const temporary = join(dirname(target), `.dshm-write-${randomUUID()}`)
+  try {
+    writeFileSync(temporary, text, { flag: 'wx', mode })
+    renameSync(temporary, target)
+  } finally { rmSync(temporary, { force: true }) }
+}

--- a/src/hot.ts
+++ b/src/hot.ts
@@ -18,6 +18,8 @@
 
 import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { writeFileAtomic } from './atomic-write.ts'
+import { waitForLifecycle } from './lifecycle.ts'
 import { pathToFileURL } from 'node:url'
 import { asChannel, type Channel } from './channels.ts'
 import { asRegion, normalizeGithubProxy, type Region } from './regions.ts'
@@ -352,7 +354,7 @@ export function writeMarketState(profileDir: string, state: MarketState): void {
   const githubProxy = Object.prototype.hasOwnProperty.call(state, 'githubProxy')
     ? state.githubProxy
     : onDisk.githubProxy
-  writeFileSync(stateFile(profileDir), JSON.stringify({
+  const text = JSON.stringify({
     disabled: [...state.disabled],
     groups: state.groups,
     groupOrder: state.groupOrder,
@@ -367,7 +369,8 @@ export function writeMarketState(profileDir: string, state: MarketState): void {
     ...(region === undefined ? {} : { region }),
     ...(regionAuto === true ? { regionAuto: true } : {}),
     ...(githubProxy === undefined ? {} : { githubProxy }),
-  }))
+  })
+  writeFileAtomic(stateFile(profileDir), text)
 }
 
 /** Plugins the user switched off; skipped by the boot re-mount. */
@@ -392,7 +395,7 @@ export function writeDisabledThemes(profileDir: string, disabled: Set<string>): 
   writeDisabled(profileDir, disabled)
 }
 
-/** Package names currently live through a market hot mount (patch or shim). */
+/** Tracked market hot mounts, including handles retained after rejected disposal. */
 export function listHotMounts(): string[] {
   return [...hotHandles.keys()]
 }
@@ -400,6 +403,12 @@ export function listHotMounts(): string[] {
 let hotSequence = 0
 
 const hotHandles = new Map<string, PluginHandle>()
+const hotDisposalErrors = new Map<string, string>()
+
+/** A rejected disposal leaves runtime state uncertain until a successful retry. */
+export function hotMountDisposalError(packageName: string): string | undefined {
+  return hotDisposalErrors.get(packageName)
+}
 
 /** Activation did not settle within HOT_MOUNT_TIMEOUT_MS. */
 class ActivationTimeout extends Error {}
@@ -422,29 +431,44 @@ function raceActivationTimeout<T>(awaitable: T | Promise<T>): Promise<T> {
 }
 
 /** Outcome of one hot-mount attempt; `reason` explains non-`ok` results. */
-export interface HotMountResult {
-  ok: boolean
-  /** Bilingual reason shown to the user instead of a bare restart banner. */
-  reason: string | null
-}
+export type HotMountResult =
+  | { ok: true; outcome: 'live'; reason: null }
+  | { ok: false; outcome: 'deferred' | 'failed'; reason: string }
 
 /**
  * Dispose a plugin hot-mounted earlier in this session, removing it from the
  * running composition immediately.
  * @param packageName - package to unmount.
+ * @param strict - retain failed handles for retry and propagate disposal errors.
  * @returns true when a live hot mount was found and disposed.
  */
-export async function hotUnmount(packageName: string): Promise<boolean> {
+export async function hotUnmount(packageName: string, strict = false): Promise<boolean> {
   const handle = hotHandles.get(packageName)
   if (handle === undefined) return false
-  hotHandles.delete(packageName)
-  shimNames.delete(packageName)
+  // Legacy callers retain best-effort removal. Toggle/recovery callers need
+  // a failed disposal to remain addressable for retry, and must see the error.
+  if (!strict) {
+    hotHandles.delete(packageName)
+    shimNames.delete(packageName)
+    hotDisposalErrors.delete(packageName)
+  }
   try {
-    await handle.dispose()
+    if (strict) await waitForLifecycle(handle, () => handle.dispose(), `${packageName}: dispose`)
+    else await handle.dispose()
+    if (strict && hotHandles.get(packageName) === handle) {
+      hotHandles.delete(packageName)
+      shimNames.delete(packageName)
+      hotDisposalErrors.delete(packageName)
+    }
     logEvent('info', 'hot-unmount', `${packageName}: removed live`)
     return true
   } catch (error) {
     logEvent('warn', 'hot-unmount', `${packageName}: dispose failed — ${error instanceof Error ? error.message : String(error)}`)
+    if (strict) {
+      const reason = `${packageName}: dispose failed — ${error instanceof Error ? error.message : String(error)}`
+      hotDisposalErrors.set(packageName, reason)
+      throw new Error(reason)
+    }
     return false
   }
 }
@@ -465,6 +489,7 @@ export async function hotMount(ctx: HotContext, profileDir: string, packageName:
     if (HotTree === null) {
       return {
         ok: false,
+        outcome: 'deferred',
         reason: '宿主不支持热挂载(include 插件不可导入),需重启 / the host cannot hot-mount (include plugin unavailable); restart required',
       }
     }
@@ -483,6 +508,7 @@ export async function hotMount(ctx: HotContext, profileDir: string, packageName:
       if (rows === null) {
         return {
           ok: false,
+          outcome: 'deferred',
           reason: 'bundle patch 含配置行/表达式,热挂载仅支持纯 insert,重启后生效 / the bundle patch contains config/expression rows; hot-mount only supports plain inserts — it activates on restart',
         }
       }
@@ -495,6 +521,7 @@ export async function hotMount(ctx: HotContext, profileDir: string, packageName:
       if (dsh === null || dsh.client === undefined || dsh.bundle !== undefined) {
         return {
           ok: false,
+          outcome: 'deferred',
           reason: '该包无 bundle patch 且未声明 dsh.client,没有可热挂载的内容 / no bundle patch and no dsh.client surface — nothing to hot-mount',
         }
       }
@@ -524,14 +551,24 @@ export async function hotMount(ctx: HotContext, profileDir: string, packageName:
       throw error
     }
     hotHandles.set(packageName, handle)
+    hotDisposalErrors.delete(packageName)
     ctx.logger?.info?.(`[dsh-market] hot-mounted ${packageName}`)
     logEvent('info', 'hot-mount', `${packageName}: live${shimNames.has(packageName) ? ' (client-only shim)' : ''}`)
-    return { ok: true, reason: null }
+    return { ok: true, outcome: 'live', reason: null }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    ctx.logger?.warn(`[dsh-market] hot mount of ${packageName} failed, restart required: ${message}`)
-    logEvent('warn', 'hot-mount', `${packageName}: fell back to restart — ${message}`)
-    return { ok: false, reason: `热挂载失败,重启后生效 — ${message} / hot-mount failed — restart required: ${message}` }
+    // Preserve the established timeout fallback; a rejected import/apply is
+    // different evidence and must not become a durable enable on next boot.
+    const deferred = error instanceof ActivationTimeout
+    ctx.logger?.warn(`[dsh-market] hot mount of ${packageName} failed: ${message}`)
+    logEvent('warn', 'hot-mount', `${packageName}: ${deferred ? 'fell back to restart' : 'activation failed'} — ${message}`)
+    return {
+      ok: false,
+      outcome: deferred ? 'deferred' : 'failed',
+      reason: deferred
+        ? `热挂载超时,需重启 — ${message} / hot-mount timed out — restart required: ${message}`
+        : `热挂载失败 — ${message} / hot-mount failed: ${message}`,
+    }
   }
 }
 

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,0 +1,26 @@
+/** Bound asynchronous loader work without pretending that timeout cancels it. */
+export class LifecycleWaitError extends Error {}
+
+const pending = new WeakMap<object, Promise<unknown>>()
+const WAIT_MS = 10_000
+
+/** Never start a second mutation on a loader object whose earlier work is pending. */
+export async function waitForLifecycle<T>(key: object, start: () => T | Promise<T>, label: string): Promise<T> {
+  if (pending.has(key)) throw new LifecycleWaitError(`${label}: previous operation is still pending`)
+  const operation = Promise.resolve().then(start)
+  pending.set(key, operation)
+  // Both handlers remain attached after timeout, including for late rejection.
+  void operation.then(
+    () => { if (pending.get(key) === operation) pending.delete(key) },
+    () => { if (pending.get(key) === operation) pending.delete(key) },
+  )
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new LifecycleWaitError(`${label}: did not settle within ${WAIT_MS / 1000}s; runtime state is uncertain`)), WAIT_MS)
+      }),
+    ])
+  } finally { clearTimeout(timer) }
+}

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -449,7 +449,7 @@ function appendPatchEntry(patchPath: string, block: string): { ok: boolean; reas
 }
 
 /** Disable one row: append `- id: X` + `disabled: true` (idempotent). */
-export function disableRow(patchPath: string, rowId: string): Promise<{ ok: boolean; reason: string | null }> {
+export function disableRow(patchPath: string, rowId: string, logChange = true): Promise<{ ok: boolean; reason: string | null }> {
   return queuedWrite(async () => {
     if (!ROW_ID_RE.test(rowId)) {
       return { ok: false, reason: `行 id 含特殊字符,不支持写入补丁层 / row id ${rowId} cannot be written to the patch layer` }
@@ -457,14 +457,14 @@ export function disableRow(patchPath: string, rowId: string): Promise<{ ok: bool
     const state = readUserPatchState(patchPath)
     if (state.disables.includes(rowId)) return { ok: true, reason: null }
     const result = appendPatchEntry(patchPath, rowBlock(rowId, true))
-    if (result.ok) logEvent('info', 'patch', `disabled row ${rowId} in ${patchPath}`)
+    if (result.ok && logChange) logEvent('info', 'patch', `disabled row ${rowId} in ${patchPath}`)
     return result
   })
 }
 
 /** Enable one row: remove the `disabled: true` block; force-enable with
  * `disabled: false` when a lower layer (bundle/home patch) holds it down. */
-export function enableRow(patchPath: string, rowId: string): Promise<{ ok: boolean; reason: string | null }> {
+export function enableRow(patchPath: string, rowId: string, logChange = true): Promise<{ ok: boolean; reason: string | null }> {
   return queuedWrite(async () => {
     if (!ROW_ID_RE.test(rowId)) {
       return { ok: false, reason: `行 id 含特殊字符,不支持写入补丁层 / row id ${rowId} cannot be written to the patch layer` }
@@ -476,12 +476,12 @@ export function enableRow(patchPath: string, rowId: string): Promise<{ ok: boole
     })()
     if (blockRe.test(text)) {
       writeFileSync(patchPath, withPlaceholderRestored(text.replace(blockRe, '')))
-      logEvent('info', 'patch', `enabled row ${rowId} in ${patchPath}`)
+      if (logChange) logEvent('info', 'patch', `enabled row ${rowId} in ${patchPath}`)
       return { ok: true, reason: null }
     }
     if (state.forced.includes(rowId)) return { ok: true, reason: null }
     const result = appendPatchEntry(patchPath, rowBlock(rowId, false))
-    if (result.ok) logEvent('info', 'patch', `force-enabled row ${rowId} in ${patchPath}`)
+    if (result.ok && logChange) logEvent('info', 'patch', `force-enabled row ${rowId} in ${patchPath}`)
     return result
   })
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,6 +18,7 @@ import {
   cleanHotDir, hotMount, hotUnmount, listHotMounts, MAX_FAVORITES, MAX_NOTE,
   mountClientOnlyDeps, purgeMarketState, readMarketState, writeMarketState,
 } from './hot.ts'
+import { prepareToggleWrites } from './toggle-state.ts'
 import { createGroup, deleteGroup, removeFromGroups, renameGroup, setGroupMembers } from './groups.ts'
 import { dshHostInfo } from './dsh-install.ts'
 import { deriveHostCompatibility, DiscoveryManifestIndex } from './discovery-compatibility.ts'
@@ -377,12 +378,15 @@ export function mountMarketRoutes(
    */
   function refreshMarketState(): void {
     const fresh = readMarketState(activeProfileDir)
+    const nextDisabled = [...fresh.disabled]
+    const nextGroups = { ...fresh.groups }
+    const nextOrder = [...fresh.groupOrder]
     disabled.clear()
-    for (const name of fresh.disabled) disabled.add(name)
+    for (const name of nextDisabled) disabled.add(name)
     for (const key of Object.keys(groups)) delete groups[key]
-    Object.assign(groups, fresh.groups)
+    Object.assign(groups, nextGroups)
     groupOrder.length = 0
-    groupOrder.push(...fresh.groupOrder)
+    groupOrder.push(...nextOrder)
     // The three above are aliased objects other closures hold, so they are
     // mutated in place. These three are read off `marketState` itself and
     // were not being refreshed at all — which is #435: a note written
@@ -409,7 +413,7 @@ export function mountMarketRoutes(
     // in-memory, so the disable never persists on its own). Client-only
     // shims for disabled plugins were already skipped by mountClientOnlyDeps.
     for (const name of disabled) {
-      if (await themes.setEntryDisabled(name, true)) logEvent('info', 'boot', `plugin kept off: ${name}`)
+      if (!themes.isChanging(name) && await themes.setEntryDisabled(name, true)) logEvent('info', 'boot', `plugin kept off: ${name}`)
     }
   })
 
@@ -418,7 +422,7 @@ export function mountMarketRoutes(
   // up for a plugin the user switched off, put it back down.
   host.on?.('internal/plugin', (fiber) => {
     const name = fiber.entry?.options?.name
-    if (name !== undefined && disabled.has(name)) void themes.setEntryDisabled(name, true)
+    if (name !== undefined && disabled.has(name) && !themes.isChanging(name)) void themes.setEntryDisabled(name, true)
   })
   let installing = false
   let restarting = false
@@ -486,44 +490,56 @@ export function mountMarketRoutes(
     return { changed: [...changed], partial: changed.size > 0 }
   }
 
-  /**
-   * Apply one enable/disable request: persist the choice in state.json, then
-   * drive the live composition. Covers every mount form — hot mounts and
-   * client-only shims go through hotUnmount/hotMount, bundle-layer entries
-   * through setEntryDisabled. Enabling a THEME goes through the caller's
-   * activateTheme instead so the Themes tab's exclusivity stays intact.
-   */
-  async function setPluginEnabled(name: string, enabled: boolean): Promise<{ ok: boolean; reason?: string }> {
-    const dir = activeProfileDir
-    if (enabled) disabled.delete(name)
-    else disabled.add(name)
-    let ok: boolean
-    let reason: string | undefined
-    if (enabled) {
-      if (listHotMounts().includes(name)) {
-        ok = true
-      } else if (await themes.setEntryDisabled(name, false)) {
-        ok = true
-      } else {
-        const result = await hotMount(host, dir, name)
-        ok = result.ok
-        reason = result.reason ?? undefined
-        // A mount that succeeded imported the module as it is on disk NOW,
-        // so whatever was replaced under the old instance is no longer what
-        // this process is serving. Off-and-on is a real way out of the
-        // restart notice, and holding it after that would be wrong.
-        if (result.ok) replacedWhileLive.delete(name)
+  /** All entry points share the same runtime and durable toggle operation. */
+  async function setPluginEnabled(name: string, enabled: boolean, themeNames = new Set<string>()) {
+    const patchRows = rowIdsForPackage(host, activeProfileDir, name)
+    const carrier = carrierDisableIds(activeProfileDir, name)
+    let choices: { name: string; enabled: boolean }[] = []
+    const success = { ok: true, reason: null } as { ok: boolean; reason: string | null }
+    const base = { patchRows, carrier, patchWrite: success, bundleSwitch: success, restart: false, refresh: false }
+    let prepared: Awaited<ReturnType<typeof prepareToggleWrites>>
+    try {
+      const statePath = join(activeProfileDir, '.dsh-market', 'state.json')
+      if (existsSync(statePath)) {
+        // Validate before refreshing: readMarketState deliberately tolerates
+        // broken files, but a toggle must not replace one with empty defaults.
+        const saved: unknown = JSON.parse(readFileSync(statePath, 'utf8'))
+        if (saved === null || typeof saved !== 'object' || Array.isArray(saved)) throw new Error('invalid market state')
+        refreshMarketState()
       }
-    } else {
-      ok = await hotUnmount(name) || await themes.setEntryDisabled(name, true)
-      if (!ok) {
-        // Nothing was live (boot-skipped client shim, user-patch-managed
-        // entry, or already off): the persisted flag is the contract.
-        ok = true
+      choices = enabled && themeNames.has(name)
+        ? [...themeNames].filter(other => other !== name && (!disabled.has(other) || themes.isLive(other)))
+          .map(other => ({ name: other, enabled: false }))
+        : []
+      choices.push({ name, enabled })
+      for (const choice of choices) {
+        if (isProtectedModule(choice.name) || choice.name === 'dshmarket' || choice.name === 'dsh-market') {
+          throw new Error(`${choice.name}: protected module cannot be toggled`)
+        }
       }
+      prepared = await prepareToggleWrites(activeProfileDir, userPatchPath, choices.map(choice => ({
+        ...choice,
+        rows: rowIdsForPackage(host, activeProfileDir, choice.name),
+        carrier: carrierDisableIds(activeProfileDir, choice.name).length > 0,
+      })))
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      return { ...base, ok: false, accepted: false, reason, patchWrite: { ok: false, reason } }
     }
-    writeMarketState(dir, { disabled, groups, groupOrder })
-    return { ok, reason }
+    try {
+      const result = await themes.changeEnabled(choices, next => {
+        prepared.commit(() => writeMarketState(activeProfileDir, { disabled: next, groups, groupOrder }))
+      })
+      const accepted = result.outcome !== 'failed'
+      if (result.ok && enabled) replacedWhileLive.delete(name)
+      return {
+        ...base, ok: result.ok, accepted, reason: result.reason ?? undefined,
+        restart: accepted && (carrier.length > 0 || (enabled ? !themes.isLive(name) : themes.isLive(name))),
+        refresh: accepted && choices.some(choice => packageHasClientPart(activeProfileDir, choice.name)),
+      }
+    } catch (error) {
+      return { ...base, ok: false, accepted: false, reason: error instanceof Error ? error.message : String(error) }
+    } finally { prepared.dispose() }
   }
 
   /**
@@ -1980,18 +1996,21 @@ export function mountMarketRoutes(
           return
         }
         try {
-          const body = (await readJsonBody(request)) as { name?: unknown }
-          const name = typeof body.name === 'string' ? body.name : ''
-          const installed = readInstalled(config.profile, activeProfileDir)
-          const themeNames = await themes.installedThemeNames()
-          if (installed[name] === undefined || !themeNames.has(name)) {
-            sendJson(response, 400, { error: 'not an installed theme' })
-            return
-          }
-          pendingRollbacks.clear()
-          const activated = await themes.activateTheme(name)
-          logEvent(activated ? 'info' : 'error', 'use-skin', `${name}: ${activated ? 'active' : 'failed'}`)
-          sendJson(response, activated ? 200 : 502, { ok: activated, live: listHotMounts() })
+          await withMutationLock(response, 'write', async () => {
+            const body = (await readJsonBody(request)) as { name?: unknown }
+            const name = typeof body.name === 'string' ? body.name : ''
+            const installed = readInstalled(config.profile, activeProfileDir)
+            const themeNames = await themes.installedThemeNames()
+            if (installed[name] === undefined || !themeNames.has(name)) {
+              sendJson(response, 400, { error: 'not an installed theme' })
+              return
+            }
+            pendingRollbacks.clear()
+            const result = await setPluginEnabled(name, true, themeNames)
+            const activated = result.ok
+            logEvent(activated ? 'info' : 'error', 'use-skin', `${name}: ${activated ? 'active' : 'failed'}`)
+            sendJson(response, activated ? 200 : 502, { ok: activated, live: listHotMounts(), reason: result.reason, restart: result.restart })
+          })
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
           logEvent('error', 'use-skin', `route error: ${message}`)
@@ -2036,78 +2055,11 @@ export function mountMarketRoutes(
             return
           }
           pendingRollbacks.clear()
-          let ok: boolean
-          let reason: string | undefined
-          if (enabled && (await themes.installedThemeNames()).has(name)) {
-            // Theme exclusivity stays a Themes-page concern: enabling a theme
-            // deactivates the previously active one, so only the last-enabled
-            // theme is live (same semantics as use-skin).
-            ok = await themes.activateTheme(name)
-            if (!ok) reason = 'theme activation failed — restart required / 主题启用失败，需要重启'
-          } else {
-            const result = await setPluginEnabled(name, enabled)
-            ok = result.ok
-            reason = result.reason
-          }
-          // Durable patch-layer write (port of dsh-plugin-hub): the package's
-          // bundle rows get 'disabled: true|false' in the user patch layer,
-          // which DSH's HMR applies within ~1s AND the loader re-applies on
-          // every boot. Client-only packages have no bundle rows — the
-          // market's own state.json replay covers those.
-          const patchRows = rowIdsForPackage(host, activeProfileDir, name)
-          // Disable-carrier (#224): a bundle whose patch DISABLES a plugin it
-          // does not own (dsh-postgres-backends disables session-persistence-jsonl).
-          // Disabling only its inserted rows leaves that foreign disable applying
-          // on every boot — the bundle stays in the stack — so drop it from
-          // dsh.profile.bundles entirely, which stops its whole patch at once
-          // (including any config side effects it carries). Enabling re-adds it.
-          // A bundle that merely reconfigures a neighbour (config without
-          // disabled) is NOT dropped: #147 requires disabling it to leave the
-          // neighbour live, and the e2e fixture-cross re-enable breaks otherwise.
-          const disablesOthers = carrierDisableIds(activeProfileDir, name)
-          const isCarrier = disablesOthers.length > 0
-          let bundleSwitch: { ok: boolean; reason: string | null } = { ok: true, reason: null }
-          if (isCarrier) {
-            try {
-              if (enabled) addProfileBundle(activeProfileDir, name)
-              else removeProfileBundle(activeProfileDir, name)
-              logEvent('info', 'toggle', `${name}: disable-carrier ${enabled ? 're-added to' : 'removed from'} dsh.profile.bundles (disables: ${disablesOthers.join(', ')})`)
-            } catch (error) {
-              bundleSwitch = { ok: false, reason: error instanceof Error ? error.message : String(error) }
-              logEvent('warn', 'toggle', `${name}: carrier bundle switch failed — ${bundleSwitch.reason}`)
-            }
-          }
-          let patchWrite: { ok: boolean; reason: string | null } | null = null
-          if (patchRows.length > 0) {
-            for (const rowId of patchRows) {
-              const result = enabled ? await enableRow(userPatchPath, rowId) : await disableRow(userPatchPath, rowId)
-              if (!result.ok && patchWrite === null) patchWrite = result
-            }
-            if (patchWrite === null) {
-              logEvent('info', 'toggle', `${name}: patch layer ${enabled ? 'enabled' : 'disabled'} rows ${patchRows.join(', ')}`)
-            } else {
-              logEvent('warn', 'toggle', `${name}: patch layer write refused — ${patchWrite.reason}`)
-            }
-          }
-          logEvent(ok ? 'info' : 'error', 'toggle', `${name}: ${enabled ? 'on' : 'off'} ok=${String(ok)}`)
-          // Activation reads the post-write truth: the switch state OR the
-          // patch layer, so a disabled plugin never reports "restart to
-          // apply".
+          const result = await setPluginEnabled(name, enabled, await themes.installedThemeNames())
+          const { ok, reason, patchRows, patchWrite, carrier: disablesOthers, bundleSwitch, restart, refresh } = result
           const patchNow = readUserPatchState(userPatchPath)
           const offNow = disabled.has(name) || patchRows.some(id => patchNow.disables.includes(id))
-          // When the live composition does not match the requested state
-          // (enable failed to hot-mount / disable left the fiber up), the
-          // change lands on the next boot via the patch layer + state.json —
-          // the client reuses the market's pending-restart banner for it.
-          const liveAfter = liveNames().has(name)
-          // A carrier toggle moves the bundle in/out of dsh.profile.bundles,
-          // which only takes effect on the next composition — always a restart.
-          // Non-carrier plugins keep the live-mount based decision.
-          const restart = isCarrier ? true : enabled ? !liveAfter : liveAfter
-          // A client-part plugin's UI is in the page already — toggling it
-          // needs a browser refresh to show the change (same signal the
-          // install flow uses for the hot banner).
-          const refresh = packageHasClientPart(activeProfileDir, name)
+          logEvent(ok ? 'info' : 'error', 'toggle', `${name}: ${enabled ? 'on' : 'off'} ok=${String(ok)}`)
             sendJson(response, ok ? 200 : 502, {
               ok,
               name,
@@ -2117,7 +2069,7 @@ export function mountMarketRoutes(
               activation: { [name]: verifyActivation(config.profile, name, liveNames(), activeProfileDir, offNow) },
               reason,
               patchRows,
-              patchWrite: patchWrite ?? { ok: true, reason: null },
+              patchWrite,
               carrier: disablesOthers,
               bundleSwitch,
               restart,
@@ -2237,76 +2189,76 @@ export function mountMarketRoutes(
           return
         }
         try {
-          const body = (await readJsonBody(request)) as {
-            action?: unknown
-            name?: unknown
-            newName?: unknown
-            members?: unknown
-            enabled?: unknown
-          }
-          const action = typeof body.action === 'string' ? body.action : ''
-          const known = action === 'create' || action === 'rename' || action === 'delete'
-            || action === 'set-members' || action === 'toggle'
-          if (!known) {
-            sendJson(response, 400, { ok: false, error: 'unknown group action' })
-            return
-          }
-          const installed = new Set(Object.keys(readInstalled(config.profile, activeProfileDir)))
-          // Theme members follow the global one-active-theme rule: a group
-          // holds at most one, and enabling one deactivates every other.
-          const themeNames = await themes.installedThemeNames()
-          let ok = true
-          let error: string | undefined
-          let restartMembers: string[] = []
-          let refreshMembers: string[] = []
-          if (action === 'toggle') {
-            const name = typeof body.name === 'string' ? body.name : ''
-            const enabled = body.enabled === true
-            if (groups[name] === undefined) {
-              sendJson(response, 400, { ok: false, error: 'group not found / 分组不存在' })
+          await withMutationLock(response, 'write', async () => {
+            const body = (await readJsonBody(request)) as {
+              action?: unknown
+              name?: unknown
+              newName?: unknown
+              members?: unknown
+              enabled?: unknown
+            }
+            const action = typeof body.action === 'string' ? body.action : ''
+            const known = action === 'create' || action === 'rename' || action === 'delete'
+              || action === 'set-members' || action === 'toggle'
+            if (!known) {
+              sendJson(response, 400, { ok: false, error: 'unknown group action' })
               return
             }
-            pendingRollbacks.clear()
-            // Batch toggle: on = every installed member enabled, off = every
-            // member disabled. Each member keeps its own persisted flag, so
-            // later individual toggles still work (the group switch itself is
-            // derived state and never stored).
-            const failures: string[] = []
-            for (const member of groups[name]) {
-              if (!installed.has(member)) continue
-              const result = enabled && themeNames.has(member)
-                ? { ok: await themes.activateTheme(member), reason: undefined }
-                : await setPluginEnabled(member, enabled)
-              if (!result.ok) failures.push(member)
-              // Same live-mismatch signal as the single toggle: a member
-              // whose fiber did not follow the switch needs a boot.
-              const liveAfter = liveNames().has(member)
-              if ((enabled && !liveAfter) || (!enabled && liveAfter)) restartMembers.push(member)
-              // Client-part members need a page refresh to show the change.
-              if (packageHasClientPart(activeProfileDir, member)) refreshMembers.push(member)
+            const installed = new Set(Object.keys(readInstalled(config.profile, activeProfileDir)))
+            // Theme members follow the global one-active-theme rule: a group
+            // holds at most one, and enabling one deactivates every other.
+            const themeNames = await themes.installedThemeNames()
+            let ok = true
+            let error: string | undefined
+            let restartMembers: string[] = []
+            let refreshMembers: string[] = []
+            if (action === 'toggle') {
+              const name = typeof body.name === 'string' ? body.name : ''
+              const enabled = body.enabled === true
+              if (groups[name] === undefined) {
+                sendJson(response, 400, { ok: false, error: 'group not found / 分组不存在' })
+                return
+              }
+              pendingRollbacks.clear()
+              // Batch toggle: on = every installed member enabled, off = every
+              // member disabled. Each member keeps its own persisted flag, so
+              // later individual toggles still work (the group switch itself is
+              // derived state and never stored).
+              const failures: string[] = []
+              for (const member of groups[name]) {
+                if (!installed.has(member)) continue
+                const result = await setPluginEnabled(member, enabled, themeNames)
+                if (!result.ok) failures.push(result.reason ? `${member}: ${result.reason}` : member)
+                if (!result.accepted) continue
+                // Same live-mismatch signal as the single toggle: a member
+                // whose fiber did not follow the switch needs a boot.
+                if (result.restart) restartMembers.push(member)
+                // Client-part members need a page refresh to show the change.
+                if (result.refresh) refreshMembers.push(member)
+              }
+              ok = failures.length === 0
+              if (!ok) error = `failed to ${enabled ? 'enable' : 'disable'}: ${failures.join(', ')}`
+            } else {
+              const state = { groups, groupOrder }
+              const result = action === 'create' ? createGroup(state, body.name)
+                : action === 'rename' ? renameGroup(state, body.name, body.newName)
+                : action === 'delete' ? deleteGroup(state, body.name)
+                : setGroupMembers(state, body.name, body.members, installed, themeNames)
+              ok = result.ok
+              error = result.error
             }
-            ok = failures.length === 0
-            if (!ok) error = `failed to ${enabled ? 'enable' : 'disable'}: ${failures.join(', ')}`
-          } else {
-            const state = { groups, groupOrder }
-            const result = action === 'create' ? createGroup(state, body.name)
-              : action === 'rename' ? renameGroup(state, body.name, body.newName)
-              : action === 'delete' ? deleteGroup(state, body.name)
-              : setGroupMembers(state, body.name, body.members, installed, themeNames)
-            ok = result.ok
-            error = result.error
-          }
-          if (ok) writeMarketState(activeProfileDir, { disabled, groups, groupOrder })
-          logEvent(ok ? 'info' : 'warn', 'groups',
-            `${action}${typeof body.name === 'string' ? ' ' + body.name : ''}${ok ? '' : ` — ${error ?? ''}`}`)
-          sendJson(response, ok ? 200 : 400, {
-            ok,
-            error,
-            groups,
-            groupOrder,
-            disabled: [...disabled],
-            restartMembers,
-            refreshMembers,
+            if (ok && action !== 'toggle') writeMarketState(activeProfileDir, { disabled, groups, groupOrder })
+            logEvent(ok ? 'info' : 'warn', 'groups',
+              `${action}${typeof body.name === 'string' ? ' ' + body.name : ''}${ok ? '' : ` — ${error ?? ''}`}`)
+            sendJson(response, ok ? 200 : 400, {
+              ok,
+              error,
+              groups,
+              groupOrder,
+              disabled: [...disabled],
+              restartMembers,
+              refreshMembers,
+            })
           })
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -6,10 +6,12 @@
  */
 
 import { loadRegistry, pluginCategories } from './registry.ts'
-import { hotMount, hotUnmount, listHotMounts, writeDisabled } from './hot.ts'
+import { hotMount, hotMountDisposalError, hotUnmount, listHotMounts, writeDisabled, type HotMountResult } from './hot.ts'
 import { logEvent } from './log.ts'
 import { profileDir, readInstalled } from './profile.ts'
+import { rowIdsForPackage } from './patch.ts'
 import { repoOf } from './sources.ts'
+import { LifecycleWaitError, waitForLifecycle } from './lifecycle.ts'
 
 /** The slice of a cordis loader entry the market needs for live enable/disable. */
 export interface LoaderEntry {
@@ -27,8 +29,11 @@ export interface ThemeHost {
 /** Manages theme exclusivity for one profile. */
 export interface ThemeManager {
   installedThemeNames(): Promise<Set<string>>
-  setEntryDisabled(name: string, disabledFlag: boolean): Promise<boolean>
+  setEntryDisabled(name: string, disabledFlag: boolean, requireLive?: boolean): Promise<boolean>
   activateTheme(name: string): Promise<boolean>
+  changeEnabled(choices: readonly { name: string; enabled: boolean }[], commit: (next: Set<string>) => void): Promise<HotMountResult>
+  isChanging(name: string): boolean
+  isLive(name: string): boolean
 }
 
 /**
@@ -65,61 +70,158 @@ export function createThemeManager(
     return names
   }
 
+  function matchingEntries(name: string): LoaderEntry[] {
+    const ids = new Set(rowIdsForPackage(host, activeProfileDir, name))
+    return [...host.loader.entries()].filter(entry => entry.options.name === name
+      || (entry.options.id !== undefined && (ids.has(entry.options.id) || ids.has(entry.options.id.split(':').pop()!))))
+  }
+
+  const uncertainEntries = new WeakSet<LoaderEntry>()
+  async function updateEntry(entry: LoaderEntry, disabled: boolean | null, restoring = false): Promise<void> {
+    if (!disabled && !restoring && uncertainEntries.has(entry)) {
+      throw new LifecycleWaitError('loader entry: runtime state is uncertain; retry disabling before enabling')
+    }
+    try {
+      await waitForLifecycle(entry, () => entry.update({ disabled }, false, true), `${entry.options.name ?? entry.options.id ?? 'entry'}: loader update`)
+      uncertainEntries.delete(entry)
+    } catch (error) {
+      uncertainEntries.add(entry)
+      throw error
+    }
+  }
+
   /**
    * Live-toggle a bundle-layer plugin through its loader entry. Bundle trees
    * are in-memory (write is a no-op), so this never touches any file — the
    * market persists the choice itself and replays it at boot.
    * @returns true when a matching live entry was found and updated.
    */
-  async function setEntryDisabled(name: string, disabledFlag: boolean): Promise<boolean> {
-    let found = false
-    for (const entry of host.loader.entries()) {
-      if (entry.options.name !== name) continue
-      // A disable can land while the entry's init is still in flight: the
-      // options flip but the finishing init brings the fiber up anyway, and a
-      // plain re-update no-ops on the empty diff. Force the update and verify
-      // the live state, retrying until reality matches the flag.
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          await entry.update({ disabled: disabledFlag ? true : null }, false, true)
-          found = true
-        } catch (error) {
-          logEvent('warn', 'toggle', `${name}: entry update failed — ${error instanceof Error ? error.message : String(error)}`)
-          break
+  async function setEntryDisabled(name: string, disabledFlag: boolean, requireLive = false, rejectPending = false): Promise<boolean> {
+    // Strict requests require the requested fiber state. The legacy theme and
+    // disable paths retain their existing best-effort semantics.
+    const previous: { entry: LoaderEntry; disabled: boolean | null | undefined; live: boolean }[] = []
+    try {
+      let found = false
+      for (const entry of matchingEntries(name)) {
+        if (!disabledFlag && uncertainEntries.has(entry)) throw new LifecycleWaitError('loader entry: runtime state is uncertain; retry disabling before enabling')
+        if (requireLive) previous.push({ entry, disabled: entry.options.disabled, live: entry.fiber !== undefined })
+        // A disable can land while the entry's init is still in flight: the
+        // options flip but the finishing init brings the fiber up anyway, and a
+        // plain re-update no-ops on the empty diff. Force the update and verify
+        // the live state, retrying until reality matches the flag.
+        for (let attempt = 0; attempt < 3; attempt++) {
+          try {
+            await updateEntry(entry, disabledFlag ? true : null)
+            found = true
+          } catch (error) {
+            if (requireLive || (rejectPending && error instanceof LifecycleWaitError)) throw error
+            logEvent('warn', 'toggle', `${name}: entry update failed — ${error instanceof Error ? error.message : String(error)}`)
+            break
+          }
+          const live = entry.fiber !== undefined
+          if (live !== disabledFlag) break
+          await new Promise(resolvePromise => setTimeout(resolvePromise, 200))
         }
-        const live = entry.fiber !== undefined
-        if (live !== disabledFlag) break
-        await new Promise(resolvePromise => setTimeout(resolvePromise, 200))
+        if (requireLive && (entry.fiber !== undefined) === disabledFlag) throw new Error(`${name}: loader entry ${disabledFlag ? 'did not stop' : 'did not become live'}`)
+        logEvent('info', 'toggle',
+          `${name} -> ${disabledFlag ? 'off' : 'on'}: fiber=${String(entry.fiber !== undefined)}`)
       }
-      logEvent('info', 'toggle',
-        `${name} -> ${disabledFlag ? 'off' : 'on'}: fiber=${String(entry.fiber !== undefined)}`)
+      if (!found) logEvent('info', 'toggle', `${name}: no loader entry matched`)
+      return found
+    } catch (error) {
+      const rollbackErrors: string[] = []
+      for (const { entry, disabled, live } of previous.reverse()) {
+        try {
+          await updateEntry(entry, disabled ?? null, true)
+          if (disabled === undefined) delete entry.options.disabled
+          if ((entry.fiber !== undefined) !== live) throw new Error(`${name}: loader entry did not restore its previous live state`)
+        } catch (rollbackError) {
+          rollbackErrors.push(rollbackError instanceof Error ? rollbackError.message : String(rollbackError))
+        }
+      }
+      if (rollbackErrors.length) {
+        throw new Error(`${error instanceof Error ? error.message : String(error)}; entry restoration failed: ${rollbackErrors.join('; ')}`)
+      }
+      throw error
     }
-    if (!found) logEvent('info', 'toggle', `${name}: no loader entry matched`)
-    return found
   }
 
-  /**
-   * Make `name` the one active theme: deactivate every other installed theme
-   * (market hot mounts unmount; bundle-layer entries live-disable) and bring
-   * it up. The choice persists in state.json and is replayed at boot.
-   */
+  const changing = new Set<string>()
+  const isLive = (name: string) => listHotMounts().includes(name) || matchingEntries(name).some(entry => entry.fiber !== undefined)
+
+  /** Restore only the loader entries/hot mounts touched by this request. */
+  async function changeEnabled(
+    choices: readonly { name: string; enabled: boolean }[],
+    commit: (next: Set<string>) => void,
+  ): Promise<HotMountResult> {
+    const names = new Set(choices.map(choice => choice.name))
+    const hotBefore = new Set(listHotMounts().filter(name => names.has(name)))
+    const entries = [...new Set([...names].flatMap(matchingEntries))]
+      .map(entry => ({ entry, disabled: entry.options.disabled, live: entry.fiber !== undefined }))
+    const restore = async () => {
+      const errors: string[] = []
+      for (const name of names) {
+        try {
+          if (!hotBefore.has(name) && listHotMounts().includes(name)) await hotUnmount(name, true)
+          if (hotBefore.has(name) && !listHotMounts().includes(name)) {
+            const restored = await hotMount(host, activeProfileDir, name)
+            if (!restored.ok) throw new Error(restored.reason ?? 'could not restore hot mount')
+          }
+        } catch (error) { errors.push(`${name}: ${String(error)}`) }
+      }
+      for (const { entry, disabled, live } of entries.reverse()) {
+        try {
+          if (entry.options.disabled !== disabled || (entry.fiber !== undefined) !== live) {
+            await updateEntry(entry, disabled ?? null, true)
+            if (disabled === undefined) delete entry.options.disabled
+            if ((entry.fiber !== undefined) !== live) throw new Error('previous live state was not restored')
+          }
+        } catch (error) { errors.push(`${entry.options.name ?? ''}: ${String(error)}`) }
+      }
+      if (errors.length) throw new Error(`runtime restoration failed: ${errors.join('; ')}`)
+    }
+    for (const name of names) changing.add(name)
+    try {
+      const next = new Set(disabledThemes)
+      let result: HotMountResult = { ok: true, outcome: 'live', reason: null }
+      for (const { name, enabled } of choices) {
+        if (enabled) {
+          const disposalError = hotMountDisposalError(name)
+          if (disposalError) throw new Error(`${disposalError}; runtime state is uncertain; retry disabling before enabling`)
+          if (!listHotMounts().includes(name) && !await setEntryDisabled(name, false, true)) {
+            result = await hotMount(host, activeProfileDir, name)
+            if (result.outcome === 'failed') throw new Error(result.reason)
+          }
+          next.delete(name)
+        } else {
+          // Theme replacement requires the old entry to stop. Ordinary disables
+          // preserve the existing deferred fallback, but never swallow a hung update.
+          await hotUnmount(name, true)
+          await setEntryDisabled(name, true, choices.length > 1, true)
+          next.add(name)
+        }
+      }
+      commit(next)
+      disabledThemes.clear()
+      for (const name of next) disabledThemes.add(name)
+      return result
+    } catch (error) {
+      let reason = error instanceof Error ? error.message : String(error)
+      try { await restore() } catch (restoreError) { reason += `; ${String(restoreError)}` }
+      return { ok: false, outcome: 'failed', reason }
+    } finally {
+      for (const name of names) changing.delete(name)
+    }
+  }
+
+  /** Installation callers retain a boolean API; failed switches keep the old theme. */
   async function activateTheme(name: string): Promise<boolean> {
-    const themes = await installedThemeNames()
-    for (const other of themes) {
-      if (other === name) continue
-      if (listHotMounts().includes(other)) {
-        await hotUnmount(other)
-        disabledThemes.add(other)
-      } else if (await setEntryDisabled(other, true)) {
-        disabledThemes.add(other)
-      }
-    }
-    disabledThemes.delete(name)
-    writeDisabled(activeProfileDir, disabledThemes)
-    if (listHotMounts().includes(name)) return true
-    if (await setEntryDisabled(name, false)) return true
-    return (await hotMount(host, activeProfileDir, name)).ok
+    const choices = [...await installedThemeNames()]
+      .filter(other => other !== name && (!disabledThemes.has(other) || isLive(other)))
+      .map(other => ({ name: other, enabled: false }))
+    choices.push({ name, enabled: true })
+    return (await changeEnabled(choices, next => writeDisabled(activeProfileDir, next))).ok
   }
 
-  return { installedThemeNames, setEntryDisabled, activateTheme }
+  return { installedThemeNames, setEntryDisabled, activateTheme, changeEnabled, isChanging: name => changing.has(name), isLive }
 }

--- a/src/toggle-state.ts
+++ b/src/toggle-state.ts
@@ -1,0 +1,123 @@
+/** Prepare one plugin/theme choice before touching its live composition. */
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { dirname, join } from 'node:path'
+import { checkWritableFile, writeDestination, writeFileAtomic } from './atomic-write.ts'
+import { parsePatchText } from './check.ts'
+import { disableRow, enableRow } from './patch.ts'
+import { addProfileBundle, removeProfileBundle } from './profile.ts'
+
+export interface ToggleChoice {
+  name: string
+  enabled: boolean
+  rows: string[]
+  carrier: boolean
+}
+
+function readOptional(path: string): string | null {
+  try { return readFileSync(path, 'utf8') } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+}
+
+export interface PreparedToggle {
+  /** Synchronous publication; state is written last, before yielding to this host's watchers. */
+  commit(writeState: () => void): void
+  dispose(): void
+}
+
+/**
+ * Validate all rows on a scratch copy, then publish the entire patch once.
+ * These are toggle-specific compensating writes, not crash-atomic commits
+ * across files. Restore only bytes this operation wrote; never overwrite an
+ * external edit encountered while activation was pending or during recovery.
+ */
+export async function prepareToggleWrites(
+  profileDir: string, patchPath: string, choices: readonly ToggleChoice[],
+): Promise<PreparedToggle> {
+  const aliases = [patchPath, join(profileDir, 'package.json'), join(profileDir, '.dsh-market', 'state.json')]
+    .map(path => ({ path, destination: writeDestination(path) }))
+  patchPath = aliases[0].destination
+  const statePath = aliases[2].destination
+  checkWritableFile(statePath)
+  const stateBefore = readOptional(statePath)
+  if (stateBefore !== null) JSON.parse(stateBefore)
+  const patchBefore = readOptional(patchPath)
+  if (choices.some(choice => choice.rows.length > 0) && patchBefore?.replace(/^[ \t]*#.*$/gmu, '').trim() && parsePatchText(patchBefore) === null) {
+    throw new Error('the patch layer is not a valid entry list; fix the YAML before toggling / 补丁层无效，请先修正 YAML')
+  }
+  const manifestPath = aliases[1].destination
+  const manifestBefore = readOptional(manifestPath)
+  const marketDir = join(profileDir, '.dsh-market')
+  mkdirSync(marketDir, { recursive: true, mode: 0o700 })
+  const scratch = mkdtempSync(join(marketDir, 'toggle-'))
+  const files: { path: string; before: string | null; after: string; staged: string }[] = []
+  const dispose = () => {
+    for (const file of files) rmSync(file.staged, { force: true })
+    rmSync(scratch, { recursive: true, force: true })
+  }
+  try {
+    const patchCopy = join(scratch, 'cordis.patch.yml')
+    if (patchBefore !== null) writeFileSync(patchCopy, patchBefore)
+    if (manifestBefore !== null) writeFileSync(join(scratch, 'package.json'), manifestBefore)
+    for (const choice of choices) {
+      for (const row of choice.rows) {
+        const result = await (choice.enabled ? enableRow(patchCopy, row, false) : disableRow(patchCopy, row, false))
+        if (!result.ok) throw new Error(result.reason ?? 'patch write refused')
+      }
+      if (choice.carrier) {
+        if (choice.enabled) addProfileBundle(scratch, choice.name)
+        else removeProfileBundle(scratch, choice.name)
+      }
+    }
+    for (const [path, copy, before] of [
+      [patchPath, patchCopy, patchBefore],
+      [manifestPath, join(scratch, 'package.json'), manifestBefore],
+    ] as const) {
+      const after = readOptional(copy)
+      if (after === null || after === before) continue
+      if (path === patchPath && parsePatchText(after) === null) throw new Error('toggle would produce an invalid patch')
+      checkWritableFile(path)
+      const staged = join(dirname(path), `.dshm-toggle-${randomUUID()}`)
+      files.push({ path, before, after, staged })
+      writeFileSync(staged, after, { flag: 'wx', mode: before === null ? 0o600 : statSync(path).mode & 0o777 })
+    }
+    return {
+      dispose,
+      commit(writeState) {
+        const published: typeof files = []
+        try {
+          // Even unchanged patch/manifest inputs matter: an external edit can
+          // invalidate the activation decision made against the original file.
+          for (const alias of aliases) {
+            if (writeDestination(alias.path) !== alias.destination) throw new Error(`profile link changed during activation: ${alias.path}`)
+          }
+          for (const [path, before] of [[statePath, stateBefore], [patchPath, patchBefore], [manifestPath, manifestBefore]] as const) {
+            if (readOptional(path) !== before) throw new Error(`profile changed during activation: ${path}`)
+          }
+          checkWritableFile(statePath)
+          for (const file of files) checkWritableFile(file.path)
+          for (const file of files) {
+            renameSync(file.staged, file.path)
+            published.push(file)
+          }
+          writeState()
+        } catch (error) {
+          const failures: string[] = []
+          for (const file of published.reverse()) {
+            try {
+              if (readOptional(file.path) !== file.after) throw new Error('file changed after publication; refusing to overwrite it')
+              if (file.before === null) rmSync(file.path, { force: true })
+              else writeFileAtomic(file.path, file.before)
+            } catch (restoreError) {
+              failures.push(`${file.path}: ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`)
+            }
+          }
+          if (failures.length) throw new Error(`${String(error)}; profile restoration failed: ${failures.join('; ')}`)
+          throw error
+        } finally { dispose() }
+      },
+    }
+  } catch (error) { dispose(); throw error }
+}

--- a/tests/failed-enable.flows.spec.ts
+++ b/tests/failed-enable.flows.spec.ts
@@ -1,0 +1,629 @@
+/** Real routes, hotMount and profile files; only the registry and loader boundary are controlled. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chmodSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mountMarketRoutes, type MarketHost } from '../src/routes.ts'
+import { hotUnmount, listHotMounts, readMarketState, writeMarketState } from '../src/hot.ts'
+import type { LoaderEntry } from '../src/themes.ts'
+
+const ioFault = vi.hoisted(() => ({ suffix: '', remaining: 0, onFailure: undefined as (() => void) | undefined }))
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return { ...actual, renameSync: (from: string, to: string) => {
+    if (ioFault.remaining > 0 && String(to).endsWith(ioFault.suffix)) {
+      ioFault.remaining--
+      ioFault.onFailure?.()
+      throw Object.assign(new Error('injected publication failure'), { code: 'EACCES' })
+    }
+    return actual.renameSync(from, to)
+  } }
+})
+const catalog = vi.hoisted(() => ({ themes: [] as string[] }))
+vi.mock('../src/registry.ts', async importOriginal => ({
+  ...await importOriginal<typeof import('../src/registry.ts')>(),
+  loadRegistry: async () => ({ plugins: catalog.themes.map(name => ({ name, url: `https://github.com/o/${name}`, category: 'theme' })), categories: {}, count: 0, updated: '' }),
+}))
+vi.mock('@deepseek-ai/cordis-plugin-include', () => ({ Include: class { write() {} } }))
+
+let dir: string
+let dispose: () => void
+let dispatch: (path: string, body?: unknown) => Promise<{ status: number; json: any }>
+let stop: (() => Promise<void>) | undefined
+let rejectDispose: boolean
+let reject: boolean
+let activate: (() => Promise<void>) | undefined
+let pluginEvent: Parameters<NonNullable<MarketHost['on']>>[1]
+let entries: LoaderEntry[]
+const patch = '- id: bad\n  disabled: true\n- id: child\n  disabled: true\n# keep this setting\n- id: neighbour\n  config:\n    limit: 7\n'
+function boot() {
+  const routes = new Map<string, Parameters<MarketHost['webServer']['register']>[0]['handler']>()
+  const host: MarketHost = {
+    webServer: { register: route => { routes.set(route.path, route.handler); return () => {} } },
+    loader: { entries: () => entries },
+    plugin: () => ({ await: async () => { await activate?.(); if (reject) throw new Error('loader entries failed to apply') }, dispose: () => { if (rejectDispose) throw new Error('dispose rejected'); return stop?.() } }),
+    on: (_event, callback) => { pluginEvent = callback; return () => {} },
+  }
+  dispose = mountMarketRoutes(host, { profile: 'web', profileDirectory: dir, region: 'global' })
+  dispatch = async (path, body) => {
+    let status = 0
+    let json: any
+    await routes.get(`/dsh-market/${path}`)!({
+      method: body === undefined ? 'GET' : 'POST', url: `/dsh-market/${path}`,
+      headers: { host: 'localhost:3080', origin: 'http://localhost:3080' },
+      socket: { remoteAddress: '127.0.0.1' },
+      async *[Symbol.asyncIterator]() { if (body !== undefined) yield Buffer.from(JSON.stringify(body)) },
+    } as never, {
+      writeHead(code: number) { status = code }, end(text: string) { json = JSON.parse(text) },
+    } as never)
+    return { status, json }
+  }
+}
+function seed(off = ['bad']) {
+  writeMarketState(dir, { disabled: new Set(off), groups: { work: ['bad', 'good'] }, groupOrder: ['work'], notes: { bad: 'retain' }, favorites: ['https://github.com/o/good'], channel: 'beta' })
+}
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'dshm-575-'))
+  stop = undefined
+  rejectDispose = false
+  reject = true
+  activate = undefined
+  ioFault.remaining = 0
+  ioFault.suffix = ''
+  ioFault.onFailure = undefined
+  catalog.themes = []
+  entries = []
+  for (const name of ['bad', 'good']) {
+    mkdirSync(join(dir, 'node_modules', name), { recursive: true })
+    writeFileSync(join(dir, 'node_modules', name, 'package.json'), JSON.stringify({ name, version: '1.0.0', dsh: { bundle: { patch: './cordis.patch.yml' } } }))
+    writeFileSync(join(dir, 'node_modules', name, 'cordis.patch.yml'), `- insert:\n    - id: ${name}\n      name: ${name}\n${name === 'bad' ? '    - id: child\n      name: child\n' : ''}`)
+  }
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { bad: '1.0.0', good: '1.0.0' }, dsh: { profile: { bundles: ['bad', 'good'] } } }))
+  writeFileSync(join(dir, 'cordis.patch.yml'), patch)
+  seed()
+  boot()
+  // Let the boot disable replay settle before injecting entries.
+  await new Promise(resolve => setTimeout(resolve, 0))
+})
+afterEach(async () => {
+  vi.useRealTimers()
+  dispose()
+  stop = undefined
+  rejectDispose = false
+  for (const name of listHotMounts()) await hotUnmount(name)
+  rmSync(dir, { recursive: true, force: true })
+})
+const toggle = (enabled = true) => dispatch('toggle', { name: 'bad', enabled })
+const stateText = () => readFileSync(join(dir, '.dsh-market', 'state.json'), 'utf8')
+
+describe('failed enable preserves the requested profile (#575)', () => {
+  it('keeps the multi-row patch and market state unchanged after loader rejection, including a fresh service', async () => {
+    const before = stateText()
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(result.json.disabled).toContain('bad')
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    expect(result.json.restart).toBe(false)
+    expect(result.json.refresh).toBe(false)
+    dispose(); boot()
+    const listed = await dispatch('installed')
+    expect(listed.json.disabled).toContain('bad')
+    expect(listed.json.activation.bad.state).toBe('disabled')
+    reject = false
+    expect((await toggle()).status).toBe(200) // failed request released the lock
+  })
+
+  it('preserves absence from the market set when only the patch disabled the plugin', async () => {
+    dispose(); seed([]); boot()
+    const before = stateText()
+    expect((await toggle()).status).toBe(502)
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    expect((await dispatch('installed')).json.activation.bad.state).toBe('disabled')
+  })
+
+  it('commits a successful live enable, preserves unrelated fields, and makes repeat requests idempotent', async () => {
+    reject = false
+    expect((await toggle()).status).toBe(200)
+    expect(readMarketState(dir).disabled.has('bad')).toBe(false)
+    expect(readMarketState(dir).notes).toEqual({ bad: 'retain' })
+    expect(readMarketState(dir).channel).toBe('beta')
+    const after = readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')
+    expect(after).not.toContain('disabled: true')
+    expect(after).toContain('limit: 7')
+    expect((await toggle()).status).toBe(200)
+    // enableRow may add an explicit override after removing a disable block;
+    // subsequent requests must not append duplicate overrides.
+    const forced = readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')
+    expect(forced.match(/- id: bad\n/g)).toHaveLength(1)
+    expect((await toggle()).status).toBe(200)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(forced)
+    expect((await toggle(false)).status).toBe(200)
+    expect(readMarketState(dir).disabled.has('bad')).toBe(true)
+  })
+
+  it('retains deferred activation for complex carrier patches', async () => {
+    writeFileSync(join(dir, 'node_modules/bad/cordis.patch.yml'), '- insert:\n    - id: bad\n      name: bad\n- id: neighbour\n  disabled: true\n')
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    manifest.dsh.profile.bundles = ['good']
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest))
+    const result = await toggle()
+    expect(result.status).toBe(502) // existing public ok=false means not live
+    expect(result.json.restart).toBe(true)
+    expect(readMarketState(dir).disabled.has('bad')).toBe(false)
+    expect(JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')).dsh.profile.bundles).toContain('bad')
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).not.toContain('- id: bad\n  disabled: true')
+  })
+
+  it('rolls back entry options and a partially created fiber after entry.update rejects', async () => {
+    const entry: LoaderEntry = {
+      options: { name: 'bad', disabled: true },
+      update: async options => {
+        entry.options.disabled = options.disabled
+        entry.fiber = options.disabled ? undefined : {}
+        if (!options.disabled) throw new Error('entry apply rejected')
+      },
+    }
+    entries.push(entry)
+    const before = stateText()
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(entry.options.disabled).toBe(true)
+    expect(entry.fiber).toBeUndefined()
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+  })
+
+  it('keeps failed group members disabled while committing successful members', async () => {
+    dispose(); seed(['bad', 'good']); boot()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    const good: LoaderEntry = { options: { name: 'good', disabled: true }, update: async options => { good.options.disabled = options.disabled; good.fiber = options.disabled ? undefined : {} } }
+    entries.push(good)
+    const result = await dispatch('groups', { action: 'toggle', name: 'work', enabled: true })
+    expect(result.status).toBe(400)
+    expect(readMarketState(dir).disabled).toEqual(new Set(['bad']))
+    expect(result.json.restartMembers).not.toContain('bad')
+    const after = readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')
+    expect(after).toContain(patch.trim())
+    expect(after).toContain('- id: good\n  disabled: false')
+  })
+  it('does not re-add a carrier whose existing entry fails activation', async () => {
+    writeFileSync(join(dir, 'node_modules/bad/cordis.patch.yml'), '- insert:\n    - id: bad\n      name: bad\n- id: neighbour\n  disabled: true\n')
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    manifest.dsh.profile.bundles = ['good']
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest))
+    entries.push({ options: { name: 'bad', disabled: true }, update: async options => { if (!options.disabled) throw new Error('cannot apply carrier') } })
+    const before = readFileSync(join(dir, 'package.json'), 'utf8')
+    expect((await toggle()).status).toBe(502)
+    expect(readFileSync(join(dir, 'package.json'), 'utf8')).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+  })
+
+  it('reports invalid patch input without claiming complete success', async () => {
+    reject = false
+    const invalid = '- insert: [unterminated\n'
+    writeFileSync(join(dir, 'cordis.patch.yml'), invalid)
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(result.json.ok).toBe(false)
+    expect(result.json.patchWrite.ok).toBe(false)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(invalid)
+  })
+
+  it('reports state write errors and keeps the shared disable set unchanged', async () => {
+    reject = false
+    const statePath = join(dir, '.dsh-market/state.json')
+    rmSync(statePath)
+    mkdirSync(statePath) // deterministic write rejection, including when tests run as root
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(result.json.reason).toBeTruthy()
+    expect(listHotMounts()).not.toContain('bad')
+    expect((await dispatch('installed')).json.disabled).toContain('bad')
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    rmSync(statePath, { recursive: true })
+    expect((await toggle(false)).status).toBe(200)
+  })
+
+  it('allows the requested activation past the self-healing disable guard, then restores the guard after failure', async () => {
+    const updates: (boolean | null)[] = []
+    const entry: LoaderEntry = {
+      options: { name: 'bad', disabled: true },
+      update: async options => {
+        updates.push(options.disabled)
+        entry.options.disabled = options.disabled
+        entry.fiber = options.disabled ? undefined : {}
+        if (!options.disabled) pluginEvent({ entry })
+      },
+    }
+    entries.push(entry)
+    expect((await toggle()).status).toBe(200)
+    expect(updates).toEqual([null])
+    expect(entry.fiber).toBeDefined()
+    expect((await toggle(false)).status).toBe(200)
+    entry.update = async options => {
+      entry.options.disabled = options.disabled
+      entry.fiber = options.disabled ? undefined : {}
+      if (!options.disabled) throw new Error('apply rejected')
+    }
+    expect((await toggle()).status).toBe(502)
+    entry.fiber = {}
+    pluginEvent({ entry })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(entry.options.disabled).toBe(true)
+    expect(entry.fiber).toBeUndefined()
+  })
+
+  it('preflights invalid patch data before activating or persisting anything', async () => {
+    reject = false
+    writeFileSync(join(dir, 'cordis.patch.yml'), '- insert: [unterminated\n')
+    const before = stateText()
+    expect((await toggle()).json.ok).toBe(false)
+    expect(listHotMounts()).not.toContain('bad')
+    expect(stateText()).toBe(before)
+  })
+
+  it('persists group disables to the same patch layer as individual toggles', async () => {
+    const result = await dispatch('groups', { action: 'toggle', name: 'work', enabled: false })
+    expect(result.status).toBe(200)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toContain('- id: good\n  disabled: true')
+    reject = false
+    expect((await dispatch('groups', { action: 'toggle', name: 'work', enabled: true })).status).toBe(200)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).not.toContain('disabled: true')
+  })
+
+  it.each(['toggle', 'use-skin', 'groups'])('restores the old theme when activation fails through %s', async path => {
+    catalog.themes = ['bad', 'good']
+    const good: LoaderEntry = { options: { name: 'good', disabled: null }, fiber: {}, update: async options => { good.options.disabled = options.disabled; good.fiber = options.disabled ? undefined : {} } }
+    entries.push(good)
+    const before = stateText()
+    const body = path === 'groups' ? { action: 'toggle', name: 'work', enabled: true } : { name: 'bad', enabled: true }
+    // The group only targets the failing theme; the other is globally active.
+    if (path === 'groups') {
+      await dispatch('groups', { action: 'set-members', name: 'work', members: ['bad'] })
+    }
+    const snapshot = stateText()
+    const result = await dispatch(path, body)
+    expect(result.json.ok).toBe(false)
+    expect(good.fiber).toBeDefined()
+    expect(good.options.disabled).toBeNull()
+    expect(stateText()).toBe(path === 'groups' ? snapshot : before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+  })
+
+  it('writes old/new theme patch choices together on a successful switch', async () => {
+    catalog.themes = ['bad', 'good']
+    reject = false
+    const good: LoaderEntry = { options: { name: 'good', disabled: null }, fiber: {}, update: async options => { good.options.disabled = options.disabled; good.fiber = options.disabled ? undefined : {} } }
+    entries.push(good)
+    expect((await dispatch('use-skin', { name: 'bad' })).status).toBe(200)
+    expect(good.fiber).toBeUndefined()
+    expect(readMarketState(dir).disabled).toEqual(new Set(['good']))
+    const text = readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')
+    expect(text).toContain('- id: good\n  disabled: true')
+    expect(text).not.toContain('- id: bad\n  disabled: true')
+  })
+
+  it('restores patch and runtime when state publication fails after live activation', async () => {
+    reject = false
+    const before = stateText()
+    ioFault.suffix = 'state.json'; ioFault.remaining = 1
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(result.json.reason).toContain('publication failure')
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    expect(listHotMounts()).not.toContain('bad')
+    expect(readdirSync(join(dir, '.dsh-market')).filter(name => name.startsWith('toggle-') || name.endsWith('.tmp'))).toEqual([])
+    expect(readdirSync(dir).filter(name => name.startsWith('.dshm-toggle-'))).toEqual([])
+  })
+
+  it('restores carrier membership and every patch row after a late state failure', async () => {
+    writeFileSync(join(dir, 'node_modules/bad/cordis.patch.yml'), '- insert:\n    - id: bad\n      name: bad\n- id: neighbour\n  disabled: true\n')
+    const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    manifest.dsh.profile.bundles = ['good']
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest))
+    const before = readFileSync(join(dir, 'package.json'), 'utf8')
+    ioFault.suffix = 'state.json'; ioFault.remaining = 1
+    expect((await toggle()).status).toBe(502)
+    expect(readFileSync(join(dir, 'package.json'), 'utf8')).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    expect(readMarketState(dir).disabled.has('bad')).toBe(true)
+  })
+
+  it('preserves an external edit made while activation is pending and unwinds the new mount', async () => {
+    reject = false
+    const edited = patch + '# edited externally while loading\n'
+    activate = async () => { writeFileSync(join(dir, 'cordis.patch.yml'), edited) }
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(result.json.reason).toContain('profile changed during activation')
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(edited)
+    expect(readMarketState(dir).disabled.has('bad')).toBe(true)
+    expect(listHotMounts()).not.toContain('bad')
+  })
+
+  it('restores the old theme when committing its replacement fails', async () => {
+    catalog.themes = ['bad', 'good']
+    reject = false
+    const good: LoaderEntry = { options: { name: 'good', disabled: null }, fiber: {}, update: async options => { good.options.disabled = options.disabled; good.fiber = options.disabled ? undefined : {} } }
+    entries.push(good)
+    const before = stateText()
+    ioFault.suffix = 'state.json'; ioFault.remaining = 1
+    const result = await dispatch('use-skin', { name: 'bad' })
+    expect(result.status).toBe(502)
+    expect(good.fiber).toBeDefined()
+    expect(good.options.disabled).toBeNull()
+    expect(listHotMounts()).not.toContain('bad')
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+  })
+
+  it.each(['groups', 'use-skin'])('serializes %s with ordinary toggles', async path => {
+    reject = false
+    let release!: () => void
+    let entered!: () => void
+    const waiting = new Promise<void>(resolve => { entered = resolve })
+    const gate = new Promise<void>(resolve => { release = resolve })
+    activate = async () => { entered(); await gate }
+    const pending = toggle()
+    await waiting
+    try {
+      expect((await dispatch(path, path === 'groups' ? { action: 'toggle', name: 'work', enabled: false } : { name: 'good' })).status).toBe(409)
+    } finally { release() }
+    expect((await pending).status).toBe(200)
+  })
+
+  it('preserves unrelated choices saved externally before the next request', async () => {
+    reject = false
+    writeMarketState(dir, { ...readMarketState(dir), disabled: new Set(['bad', 'unrelated']), groups: { external: ['good'] }, groupOrder: ['external'] })
+    expect((await toggle()).status).toBe(200)
+    const saved = readMarketState(dir)
+    expect(saved.disabled).toEqual(new Set(['unrelated']))
+    expect(saved.groups).toEqual({ external: ['good'] })
+    expect(saved.groupOrder).toEqual(['external'])
+  })
+
+  it('validates and restores owned bundle children whose loader names differ from the package', async () => {
+    reject = false
+    const first: LoaderEntry = { options: { id: 'bundle:bad', name: 'file:///first.js', disabled: true }, update: async options => { first.options.disabled = options.disabled; first.fiber = options.disabled ? undefined : {} } }
+    const child: LoaderEntry = { options: { id: 'bundle:child', name: 'child-package', disabled: true }, update: async options => { child.options.disabled = options.disabled; child.fiber = options.disabled ? undefined : {}; if (!options.disabled) throw new Error('child apply rejected') } }
+    entries.push(first, child)
+    const before = stateText()
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(result.json.reason).toContain('child apply rejected')
+    for (const entry of entries) {
+      expect(entry.fiber).toBeUndefined()
+      expect(entry.options.disabled).toBe(true)
+    }
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+  })
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0).each(['cordis.patch.yml', '.dsh-market/state.json', 'package.json'])('rejects a read-only %s before activation', async file => {
+    reject = false
+    if (file === 'package.json') {
+      writeFileSync(join(dir, 'node_modules/bad/cordis.patch.yml'), '- insert:\n    - id: bad\n      name: bad\n- id: neighbour\n  disabled: true\n')
+      const manifest = JSON.parse(readFileSync(join(dir, file), 'utf8'))
+      manifest.dsh.profile.bundles = ['good']
+      writeFileSync(join(dir, file), JSON.stringify(manifest))
+    }
+    const before = stateText()
+    const original = readFileSync(join(dir, file), 'utf8')
+    activate = vi.fn(async () => {})
+    chmodSync(join(dir, file), 0o400)
+    try {
+      const result = await toggle()
+      expect(result.status).toBe(502)
+      expect(result.json.reason).toContain('EACCES')
+      expect(activate).not.toHaveBeenCalled()
+      expect(stateText()).toBe(before)
+      expect(readFileSync(join(dir, file), 'utf8')).toBe(original)
+      expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+      expect(listHotMounts()).not.toContain('bad')
+    } finally { chmodSync(join(dir, file), 0o600) }
+  })
+
+  it('rejects a disable whose hot handle cannot stop and permits a later retry', async () => {
+    reject = false
+    expect((await toggle()).status).toBe(200)
+    const before = stateText()
+    const patchBefore = readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')
+    rejectDispose = true
+    const result = await toggle(false)
+    expect(result.status).toBe(502)
+    expect(result.json.reason).toContain('dispose rejected')
+    expect(listHotMounts()).toContain('bad')
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patchBefore)
+    expect((await toggle()).json.reason).toContain('runtime state is uncertain')
+    rejectDispose = false
+    expect((await toggle(false)).status).toBe(200)
+    expect(listHotMounts()).not.toContain('bad')
+  })
+
+  it('does not start a replacement theme when the old hot theme cannot stop', async () => {
+    reject = false
+    expect((await dispatch('toggle', { name: 'good', enabled: true })).status).toBe(200)
+    catalog.themes = ['good', 'bad']
+    const before = stateText()
+    rejectDispose = true
+    activate = vi.fn(async () => {})
+    const result = await dispatch('use-skin', { name: 'bad' })
+    expect(result.status).toBe(502)
+    expect(result.json.reason).toContain('dispose rejected')
+    expect(activate).not.toHaveBeenCalled()
+    expect(listHotMounts()).toContain('good')
+    expect(listHotMounts()).not.toContain('bad')
+    expect(stateText()).toBe(before)
+  })
+
+  it('reports a failed hot-handle cleanup during persistence recovery', async () => {
+    reject = false
+    rejectDispose = true
+    const before = stateText()
+    ioFault.suffix = 'state.json'; ioFault.remaining = 1
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(result.json.reason).toContain('runtime restoration failed')
+    expect(result.json.reason).toContain('dispose rejected')
+    expect(listHotMounts()).toContain('bad')
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    expect((await toggle()).json.reason).toContain('runtime state is uncertain')
+    rejectDispose = false
+    expect((await toggle(false)).status).toBe(200)
+    expect(listHotMounts()).not.toContain('bad')
+  })
+
+  it.each(['fulfill', 'reject'])('bounds a hung hot disposal, releases the lock, and handles late %s', async outcome => {
+    reject = false
+    expect((await toggle()).status).toBe(200)
+    let finish!: () => void
+    stop = vi.fn(() => new Promise<void>((resolve, reject) => { finish = () => outcome === 'fulfill' ? resolve() : reject(new Error('late disposal rejection')) }))
+    const before = stateText()
+    vi.useFakeTimers()
+    let result: Awaited<ReturnType<typeof toggle>> | undefined
+    const pending = toggle(false).then(value => { result = value })
+    await vi.advanceTimersByTimeAsync(10_001)
+    expect(result?.status).toBe(502)
+    expect(result?.json.reason).toContain('did not settle')
+    expect(stateText()).toBe(before)
+    expect((await toggle(false)).json.reason).toContain('still pending')
+    expect(stop).toHaveBeenCalledTimes(1)
+    finish()
+    await pending
+    await vi.advanceTimersByTimeAsync(0)
+    stop = undefined
+    expect((await toggle(false)).status).toBe(200)
+  })
+
+  it('bounds a hung entry enable and rejects overlapping updates until it settles', async () => {
+    let finish!: () => void
+    const entry: LoaderEntry = { options: { name: 'bad', disabled: true }, update: vi.fn(() => new Promise<void>(resolve => { finish = resolve })) }
+    entries.push(entry)
+    const before = stateText()
+    vi.useFakeTimers()
+    let result: Awaited<ReturnType<typeof toggle>> | undefined
+    const pending = toggle().then(value => { result = value })
+    await vi.advanceTimersByTimeAsync(10_001)
+    expect(result?.status).toBe(502)
+    expect(result?.json.reason).toContain('did not settle')
+    expect(stateText()).toBe(before)
+    expect((await toggle()).status).toBe(502)
+    expect(entry.update).toHaveBeenCalledTimes(1)
+    finish()
+    await pending
+    await vi.advanceTimersByTimeAsync(0)
+    expect((await toggle()).json.reason).toContain('runtime state is uncertain')
+    entry.update = async options => { entry.options.disabled = options.disabled; entry.fiber = options.disabled ? undefined : {} }
+    expect((await toggle(false)).status).toBe(200)
+    expect((await toggle()).status).toBe(200)
+  })
+
+  it('bounds hung entry restoration and leaves the next route usable', async () => {
+    const entry: LoaderEntry = { options: { name: 'bad', disabled: true }, update: async options => {
+      entry.options.disabled = options.disabled
+      entry.fiber = {}
+      if (!options.disabled) throw new Error('apply failed')
+      return new Promise<void>(() => {})
+    } }
+    entries.push(entry)
+    const before = stateText()
+    vi.useFakeTimers()
+    let result: Awaited<ReturnType<typeof toggle>> | undefined
+    void toggle().then(value => { result = value })
+    await vi.advanceTimersByTimeAsync(10_001)
+    expect(result?.status).toBe(502)
+    expect(result?.json.reason).toContain('restoration failed')
+    expect(result?.json.reason).toContain('did not settle')
+    expect(stateText()).toBe(before)
+    expect((await toggle()).status).toBe(502)
+  })
+
+  it('bounds a hung explicit entry disable without persisting an off choice', async () => {
+    seed([])
+    const entry: LoaderEntry = { options: { name: 'bad', disabled: null }, fiber: {}, update: async () => new Promise<void>(() => {}) }
+    entries.push(entry)
+    const before = stateText()
+    vi.useFakeTimers()
+    let result: Awaited<ReturnType<typeof toggle>> | undefined
+    void toggle(false).then(value => { result = value })
+    await vi.advanceTimersByTimeAsync(10_001)
+    expect(result?.status).toBe(502)
+    expect(result?.json.reason).toContain('did not settle')
+    expect(stateText()).toBe(before)
+    expect((await toggle(false)).status).toBe(502)
+  })
+
+  it('bounds hot cleanup during write recovery without leaving the route locked', async () => {
+    reject = false
+    stop = () => new Promise<void>(() => {})
+    const before = stateText()
+    ioFault.suffix = 'state.json'; ioFault.remaining = 1
+    vi.useFakeTimers()
+    let result: Awaited<ReturnType<typeof toggle>> | undefined
+    void toggle().then(value => { result = value })
+    await vi.advanceTimersByTimeAsync(10_001)
+    expect(result?.status).toBe(502)
+    expect(result?.json.reason).toContain('runtime restoration failed')
+    expect(result?.json.reason).toContain('did not settle')
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    expect((await toggle(false)).json.reason).toContain('still pending')
+  })
+
+  it('preserves file symlinks while publishing the chosen state', async () => {
+    reject = false
+    const patchPath = join(dir, 'cordis.patch.yml')
+    const statePath = join(dir, '.dsh-market/state.json')
+    const patchTarget = join(dir, 'linked-patch.yml')
+    const stateTarget = join(dir, 'linked-state.json')
+    writeFileSync(patchTarget, readFileSync(patchPath))
+    writeFileSync(stateTarget, readFileSync(statePath))
+    rmSync(patchPath); rmSync(statePath)
+    symlinkSync(patchTarget, patchPath, 'file'); symlinkSync(stateTarget, statePath, 'file')
+    expect((await toggle()).status).toBe(200)
+    expect(lstatSync(patchPath).isSymbolicLink()).toBe(true)
+    expect(lstatSync(statePath).isSymbolicLink()).toBe(true)
+    expect(readFileSync(patchTarget, 'utf8')).not.toContain('disabled: true')
+    expect(JSON.parse(readFileSync(stateTarget, 'utf8')).disabled).not.toContain('bad')
+  })
+
+  it('reports restoration failure without overwriting an edit made after publication', async () => {
+    reject = false
+    const patchPath = join(dir, 'cordis.patch.yml')
+    let edited = ''
+    ioFault.suffix = 'state.json'; ioFault.remaining = 1
+    ioFault.onFailure = () => {
+      edited = readFileSync(patchPath, 'utf8') + '# external edit after publication\n'
+      writeFileSync(patchPath, edited)
+    }
+    const result = await toggle()
+    expect(result.status).toBe(502)
+    expect(result.json.reason).toContain('profile restoration failed')
+    expect(readFileSync(patchPath, 'utf8')).toBe(edited)
+    expect(readMarketState(dir).disabled.has('bad')).toBe(true)
+    expect(listHotMounts()).not.toContain('bad')
+  })
+
+  it('exposes failed old-theme restoration through the group response', async () => {
+    catalog.themes = ['bad', 'good']
+    const good: LoaderEntry = { options: { name: 'good', disabled: null }, fiber: {}, update: async options => {
+      good.options.disabled = options.disabled
+      good.fiber = undefined
+      if (!options.disabled) throw new Error('old theme could not be restored')
+    } }
+    entries.push(good)
+    expect((await dispatch('groups', { action: 'set-members', name: 'work', members: ['bad'] })).status).toBe(200)
+    const before = stateText()
+    const result = await dispatch('groups', { action: 'toggle', name: 'work', enabled: true })
+    expect(result.status).toBe(400)
+    expect(result.json.error).toContain('runtime restoration failed')
+    expect(stateText()).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+  })
+
+})

--- a/tests/flows.spec.ts
+++ b/tests/flows.spec.ts
@@ -381,6 +381,7 @@ const hot = vi.hoisted(() => ({
   failNext: false,
 }))
 vi.mock('../src/hot.ts', () => ({
+  hotMountDisposalError: () => undefined,
   MAX_NOTE: 200,
   MAX_FAVORITES: 500,
   cleanHotDir: () => {},
@@ -418,7 +419,7 @@ vi.mock('../src/hot.ts', () => ({
   hotMount: (_ctx: unknown, _dir: string, name: string) => {
     if (hot.failNext) {
       hot.failNext = false
-      return Promise.resolve({ ok: false, reason: 'test: host cannot hot-mount' })
+      return Promise.resolve({ ok: false, outcome: 'deferred', reason: 'test: host cannot hot-mount' })
     }
     hot.mounts.push(name)
     return Promise.resolve({ ok: true, reason: null })

--- a/tests/hot.spec.ts
+++ b/tests/hot.spec.ts
@@ -82,6 +82,7 @@ describe('hotMount activation timeout guard', () => {
       const assertion = pending.then(result => {
         expect(result.ok).toBe(false)
         expect(result.reason).toContain('did not settle')
+        expect(result.outcome).toBe('deferred')
         expect(disposed).toBe(true)
         expect(listHotMounts()).not.toContain('dsh-wedged-plugin')
       })
@@ -235,5 +236,25 @@ describe('parseSimplePatch — hot-mountable or restart-only', () => {
     expect(parseSimplePatch('')).toBeNull()
     expect(parseSimplePatch('# only a comment\n\n')).toBeNull()
     expect(parseSimplePatch('- insert:\n')).toBeNull()
+  })
+})
+
+// Test the production classification, with failure injected at handle.await.
+describe('hotMount outcomes (#575)', () => {
+  it('distinguishes a rejected apply from a live mount and restart-only patch', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dshm-hot-'))
+    try {
+      clientOnlyPkg(dir, 'dsh-outcome')
+      const rejected = await hotMount({ plugin: () => ({ await: async () => { throw new Error('apply rejected') }, dispose: () => {} }) }, dir, 'dsh-outcome')
+      expect(rejected).toMatchObject({ ok: false, outcome: 'failed' })
+      expect(rejected.reason).not.toContain('restart required')
+      expect(listHotMounts()).not.toContain('dsh-outcome')
+      expect(await hotMount(ctx, dir, 'dsh-outcome')).toMatchObject({ ok: true, outcome: 'live' })
+      await hotUnmount('dsh-outcome')
+      writeFileSync(join(dir, 'node_modules/dsh-outcome/cordis.patch.yml'), '- id: other\n  config:\n    limit: 7\n')
+      expect(await hotMount(ctx, dir, 'dsh-outcome')).toMatchObject({ ok: false, outcome: 'deferred' })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/themes.spec.ts
+++ b/tests/themes.spec.ts
@@ -113,3 +113,54 @@ describe('installedThemeNames', () => {
     expect(await names()).toEqual([])
   })
 })
+
+describe('strict entry enable for ordinary plugins (#575)', () => {
+  it('restores every touched entry if a later entry rejects, without touching other packages', async () => {
+    const entries = [true, true].map((disabled, i) => {
+      const entry = {
+        options: { name: 'ordinary', disabled: disabled as boolean | null },
+        fiber: undefined as unknown,
+        update: async (options: { disabled: boolean | null }) => {
+          entry.options.disabled = options.disabled
+          entry.fiber = options.disabled ? undefined : {}
+          if (!options.disabled && i === 1) throw new Error('second entry rejected')
+        },
+      }
+      return entry
+    })
+    const other = { options: { name: 'unrelated', disabled: true }, update: vi.fn() }
+    const manager = createThemeManager({ ...host, loader: { entries: () => [...entries, other] } }, 'web', new Set())
+    await expect(manager.setEntryDisabled('ordinary', false, true)).rejects.toThrow('second entry rejected')
+    for (const entry of entries) {
+      expect(entry.options.disabled).toBe(true)
+      expect(entry.fiber).toBeUndefined()
+    }
+    expect(other.update).not.toHaveBeenCalled()
+  })
+
+  it('reports failed restoration instead of claiming runtime rollback', async () => {
+    const entry = { options: { name: 'ordinary', disabled: true }, update: async () => { throw new Error('loader broken') } }
+    const manager = createThemeManager({ ...host, loader: { entries: () => [entry] } }, 'web', new Set())
+    await expect(manager.setEntryDisabled('ordinary', false, true)).rejects.toThrow('entry restoration failed: loader broken')
+  })
+
+  it('refuses a fulfilled update that never produced a live fiber', async () => {
+    const entry = { options: { name: 'ordinary', disabled: true as boolean | null }, update: async (options: { disabled: boolean | null }) => { entry.options.disabled = options.disabled } }
+    const manager = createThemeManager({ ...host, loader: { entries: () => [entry] } }, 'web', new Set())
+    await expect(manager.setEntryDisabled('ordinary', false, true)).rejects.toThrow('did not become live')
+    expect(entry.options.disabled).toBe(true)
+  })
+  it('bounds background disable replay without rejecting its best-effort caller', async () => {
+    const entry = { options: { name: 'ordinary', disabled: true }, update: () => new Promise<void>(() => {}) }
+    const manager = createThemeManager({ ...host, loader: { entries: () => [entry] } }, 'web', new Set())
+    vi.useFakeTimers()
+    try {
+      let result: boolean | undefined
+      const pending = manager.setEntryDisabled('ordinary', true).then(value => { result = value })
+      await vi.advanceTimersByTimeAsync(10_001)
+      expect(result).toBe(false)
+      await pending
+    } finally { vi.useRealTimers() }
+  })
+
+})

--- a/tests/web/failed-enable.e2e.ts
+++ b/tests/web/failed-enable.e2e.ts
@@ -1,0 +1,146 @@
+/** #575: an import failure must not become an enabled plugin on the next boot. */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer, type Server } from 'node:http'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { dshAvailable, launchMarketScaffold, type WebScaffold } from './scaffold.ts'
+
+const BAD = 'dshm-e2e-failed-enable'
+const GOOD = 'dshm-e2e-deferred-enable'
+describe.skipIf(!dshAvailable()).sequential('web e2e: failed enable survives restart (#575)', () => {
+  let scaffold: WebScaffold
+  let dir: string
+  let catalogServer: Server
+  let themeMode = false
+  const request = (path: string, body?: unknown) => fetch(`${scaffold.baseUrl}/dsh-market/${path}`, {
+    method: body === undefined ? 'GET' : 'POST',
+    headers: { origin: scaffold.baseUrl, 'content-type': 'application/json' },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  })
+  beforeAll(async () => {
+    catalogServer = createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({ updated: '2026-09-12', count: 2, categories: {}, plugins: [BAD, GOOD].map(name => ({
+        name, owner: 'dshm-e2e', url: `https://github.com/dshm-e2e/${name}`, category: themeMode ? 'theme' : 'testing',
+        description: { en: name }, install: name, added: '2026-09-12',
+      })) }))
+    })
+    await new Promise<void>(resolve => catalogServer.listen(0, '127.0.0.1', resolve))
+    const address = catalogServer.address()
+    if (address === null || typeof address === 'string') throw new Error('catalog address unavailable')
+    const previous = process.env.DSHM_REGISTRY_URL
+    process.env.DSHM_REGISTRY_URL = `http://127.0.0.1:${address.port}/catalog`
+    try { scaffold = await launchMarketScaffold() } finally {
+      if (previous === undefined) delete process.env.DSHM_REGISTRY_URL
+      else process.env.DSHM_REGISTRY_URL = previous
+    }
+    dir = join(scaffold.home, 'profiles/web')
+    // Put the disables down BEFORE adding either package to the composition.
+    // Every write and restart is confined to this scaffold's throwaway home.
+    const userPatch = join(dir, 'cordis.patch.yml')
+    writeFileSync(userPatch, readFileSync(userPatch, 'utf8').replace(/^\[\]\s*$/m, '') + `\n- id: ${BAD}\n  disabled: true\n- id: ${GOOD}\n  disabled: true\n`)
+    for (const name of [BAD, GOOD]) {
+      const pkg = join(dir, 'node_modules', name)
+      mkdirSync(pkg, { recursive: true })
+      writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name, version: '1.0.0', type: 'module', main: 'index.js', dsh: { bundle: { patch: './cordis.patch.yml' } } }))
+      writeFileSync(join(pkg, 'index.js'), name === BAD
+        ? "import { missingExport575 } from './exports.js'; export function apply() { missingExport575() }\n"
+        : "import { writeFileSync, rmSync } from 'node:fs'; import { join } from 'node:path'; export function apply(ctx) { ctx.effect(() => { const file = join(process.env.DSH_HOME, 'deferred-575.alive'); writeFileSync(file, 'live'); return () => rmSync(file, {force:true}) }) }\n")
+      writeFileSync(join(pkg, 'exports.js'), 'export const available = true\n')
+      // Absolute names let the host import the exact fixture. The good patch
+      // carries config, so the market must defer it instead of hot-mounting.
+      writeFileSync(join(pkg, 'cordis.patch.yml'), `- insert:\n    - id: ${name}\n      name: '${pathToFileURL(join(pkg, 'index.js')).href}'\n${name === GOOD ? `      config:\n        enabled: true\n- id: ${BAD}\n  disabled: true\n` : ''}`)
+    }
+    const manifestFile = join(dir, 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestFile, 'utf8'))
+    for (const name of [BAD, GOOD]) manifest.dependencies[name] = '1.0.0'
+    manifest.dsh.profile.bundles.push(BAD) // GOOD is a disabled carrier; enable must re-add its bundle
+    writeFileSync(manifestFile, JSON.stringify(manifest, null, 2))
+    writeFileSync(join(dir, '.dsh-market/state.json'), JSON.stringify({ disabled: [BAD, GOOD], groups: {}, groupOrder: [], region: 'global' }))
+    await scaffold.restart()
+  }, 600_000)
+  afterAll(async () => {
+    try { await scaffold?.close() } finally {
+      if (catalogServer) await new Promise<void>((resolve, reject) => catalogServer.close(error => error ? reject(error) : resolve()))
+    }
+  })
+
+  it('rejects a real missing-export import and preserves disk state across restart', async () => {
+    const patch = readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')
+    const state = readFileSync(join(dir, '.dsh-market/state.json'), 'utf8')
+    const response = await request('toggle', { name: BAD, enabled: true })
+    const result = await response.json() as { ok: boolean; restart: boolean; reason?: string }
+    expect(response.status, JSON.stringify(result)).toBe(502)
+    expect(result.ok).toBe(false)
+    expect(result.restart).toBe(false)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    expect(readFileSync(join(dir, '.dsh-market/state.json'), 'utf8')).toBe(state)
+    await scaffold.restart()
+    expect((await request('status')).status).toBe(200)
+    const installed = await (await request('installed')).json() as { activation: Record<string, { state: string }> }
+    expect(installed.activation[BAD].state).toBe('disabled')
+  })
+
+  it('still commits a normal deferred enable that really activates after restart', async () => {
+    expect(existsSync(join(scaffold.home, 'deferred-575.alive'))).toBe(false)
+    const response = await request('toggle', { name: GOOD, enabled: true })
+    const result = await response.json() as { ok: boolean; restart: boolean }
+    expect(response.status, JSON.stringify(result)).toBe(502)
+    expect(result.ok).toBe(false)
+    expect(result.restart).toBe(true)
+    const state = JSON.parse(readFileSync(join(dir, '.dsh-market/state.json'), 'utf8'))
+    expect(state.disabled).not.toContain(GOOD)
+    expect(state.disabled).toContain(BAD)
+    await scaffold.restart()
+    expect((await request('status')).status).toBe(200)
+    expect(readFileSync(join(scaffold.home, 'deferred-575.alive'), 'utf8')).toBe('live')
+  })
+  it('persists a group carrier disable and deferred re-enable across real restarts', async () => {
+    expect((await request('groups', { action: 'create', name: 'work' })).status).toBe(200)
+    expect((await request('groups', { action: 'set-members', name: 'work', members: [GOOD] })).status).toBe(200)
+    expect((await request('groups', { action: 'toggle', name: 'work', enabled: false })).status).toBe(200)
+    expect(JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')).dsh.profile.bundles).not.toContain(GOOD)
+    rmSync(join(scaffold.home, 'deferred-575.alive'), { force: true })
+    await scaffold.restart()
+    expect(existsSync(join(scaffold.home, 'deferred-575.alive'))).toBe(false)
+    const response = await request('groups', { action: 'toggle', name: 'work', enabled: true })
+    const result = await response.json() as { restartMembers: string[] }
+    expect(response.status, JSON.stringify(result)).toBe(400) // not live yet; accepted deferred member
+    expect(result.restartMembers).toContain(GOOD)
+    await scaffold.restart()
+    expect(readFileSync(join(scaffold.home, 'deferred-575.alive'), 'utf8')).toBe('live')
+  })
+
+  it('restores a boot-loaded theme when its replacement really fails to import', async () => {
+    themeMode = true
+    const before = readFileSync(join(dir, '.dsh-market/state.json'), 'utf8')
+    const patch = readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')
+    const result = await request('use-skin', { name: BAD })
+    expect(result.status, await result.text()).toBe(502)
+    expect(readFileSync(join(scaffold.home, 'deferred-575.alive'), 'utf8')).toBe('live')
+    expect(readFileSync(join(dir, '.dsh-market/state.json'), 'utf8')).toBe(before)
+    expect(readFileSync(join(dir, 'cordis.patch.yml'), 'utf8')).toBe(patch)
+    await scaffold.restart()
+    expect(readFileSync(join(scaffold.home, 'deferred-575.alive'), 'utf8')).toBe('live')
+  })
+
+  it('persists a successful theme replacement once the fixture export is repaired', async () => {
+    writeFileSync(join(dir, 'node_modules', BAD, 'exports.js'), "import { writeFileSync } from 'node:fs'; import { join } from 'node:path'; export function missingExport575() { writeFileSync(join(process.env.DSH_HOME, 'replacement-575.alive'), 'live') }\n")
+    // Start a new module cache while the repaired fixture is still disabled.
+    await scaffold.restart()
+    expect(existsSync(join(scaffold.home, 'replacement-575.alive'))).toBe(false)
+    const response = await request('use-skin', { name: BAD })
+    expect(response.status, await response.text()).toBe(200)
+    expect(existsSync(join(scaffold.home, 'deferred-575.alive'))).toBe(false)
+    expect(readFileSync(join(scaffold.home, 'replacement-575.alive'), 'utf8')).toBe('live')
+    const state = JSON.parse(readFileSync(join(dir, '.dsh-market/state.json'), 'utf8'))
+    expect(state.disabled).toContain(GOOD)
+    expect(state.disabled).not.toContain(BAD)
+    rmSync(join(scaffold.home, 'replacement-575.alive'))
+    await scaffold.restart()
+    expect(existsSync(join(scaffold.home, 'deferred-575.alive'))).toBe(false)
+    expect(readFileSync(join(scaffold.home, 'replacement-575.alive'), 'utf8')).toBe('live')
+  })
+
+})


### PR DESCRIPTION
A failed plugin import/apply could still remove disable rows and persist an enabled choice, so the next boot loaded the plugin that the toggle had rejected. Theme replacement could leave the previous theme stopped, and group toggles did not persist the same patch/carrier choices as individual toggles.

### Changes

- Classify hot-mount results as live, deferred, or failed. Commit installed-plugin enable choices only after live or explicitly deferred activation, preserving the existing non-live HTTP/ok contract.
- Share validation and persistence across individual toggles, groups, and theme selection. Stage patch/carrier changes before activation, publish state last, and retain per-member partial success for groups under the mutation lock.
- Restore touched loader entries and previous themes on failure, including owned bundle children whose loader names differ from the package name. Report restoration failures instead of claiming success.
- Compensate late file-write failures only while files still contain this operation's output. Detect intervening edits, preserve file symlinks and permission bits, and respect read-only files.
- Keep failed hot-disposal handles available for retry. Bound asynchronous disposal, entry updates, and recovery waits to 10 seconds per operation; block overlapping work on still-pending objects and handle late rejections. A timeout releases the request lock but does not cancel the underlying plugin operation.

### Compatibility and scope

Normal deferred activation remains available for unsupported hot loading, complex patches, and activation timeouts. Ordinary completed disables that leave a fiber up retain the existing restart fallback; theme replacement requires the old theme to stop.

This does not duplicate #550's module resolution or failed-load handle/temp-file cleanup, or depend on #551's desktop acknowledgement bridge. Failed loads can still leave partial runtime resources. File compensation is not crash-atomic across files and cannot undo arbitrary plugin side effects. Whole install transactions, uninstall orphan rows, and historical damaged-profile repair remain outside scope.

### Validation

- Full local unit/component suite: **1372 passed**, none skipped.
- `npm run check`, final typecheck, preflight, smoke-spawn, and diff checks passed; no dependency, version, or generated client changes.
- Real pnpm compatibility matrix: **14 passed**.
- Complete web suites on Linux/WSL, Node 24.20.0, with DSH **0.1.0-rc.8** and **0.1.5-rc.2**: **45 passed each**, none skipped (`DSHM_E2E_REQUIRED=1`).
- Five real isolated-host scenarios verify missing-export rejection with unchanged files and a serviceable restart, normal deferred activation, durable group carrier toggles, failed theme replacement recovery, and successful theme replacement across restart.
- Regressions failed on the original baseline and before the deeper fixes. Independent local mutations removing rejection, file compensation, theme restoration, strict disposal, or the lifecycle wait bound make the corresponding regressions fail again.
- Pending/late-rejection cases use the production routes and real temporary files with controlled loader promises and virtual clocks. Windows, alpha, and Desktop acknowledgement environments were not tested locally. POSIX read-only permission cases explicitly skip Windows/root.

### Code-change checklist

- [x] `npm test` and `npm run check` pass locally.
- [x] Regression tests fail without the relevant fix.
- [x] No version bump in `package.json`.
- [x] Client source unchanged; rebuild produces no `client/client.js` diff.

Refs #575
