### PR TITLE
feat: the market's nav entry wears the block mark, not the shell's gear

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -2542,6 +2542,78 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 			"warnLine": "nUhMVa_warnLine"
 		};
 		//#endregion
+		//#region src/client/market-mark.ts
+		/**
+		* The market's block mark as geometry rather than as a component.
+		*
+		* Two consumers draw this mark and they must not drift:
+		*
+		* - `MarketLogo` (MarketSection.tsx) renders it inside the section as an
+		*   ordinary React SVG in `currentColor`, including the animated variant;
+		* - `settings-nav-icon.ts` serialises it into a CSS mask for the settings
+		*   navigation glyph, which cannot use `currentColor` (a mask is an
+		*   independent image) and so needs it as standalone markup.
+		*
+		* Keeping the numbers here means a change to the mark is one edit, and the
+		* suite can hold both renderings to the same source.
+		*
+		* The mark is the brand asset in `assets/logo.svg`: an 8-cell grid plus the
+		* block being plugged into its empty corner, offset and tilted 9°.
+		*/
+		/** Side of one block, and its corner radius. */
+		const MARK_BLOCK_SIZE = 3.3;
+		const MARK_BLOCK_RADIUS = .53;
+		/** The eight grid cells, row-major. The ninth slot stays empty on purpose. */
+		const MARK_GRID_BLOCKS = [
+			{
+				x: 1.96,
+				y: 3.36
+			},
+			{
+				x: 5.71,
+				y: 3.36
+			},
+			{
+				x: 1.96,
+				y: 7.11
+			},
+			{
+				x: 5.71,
+				y: 7.11
+			},
+			{
+				x: 9.46,
+				y: 7.11
+			},
+			{
+				x: 1.96,
+				y: 10.86
+			},
+			{
+				x: 5.71,
+				y: 10.86
+			},
+			{
+				x: 9.46,
+				y: 10.86
+			}
+		];
+		/**
+		* The block being plugged in: OUTSIDE the grid's empty corner, offset
+		* (+1.28, -1.27) and tilted 9deg, exactly as in assets/logo.svg. The earlier
+		* icon sat it neatly in the empty slot, which reads as one crooked tile
+		* rather than a block arriving — the whole idea of the mark, and the reason
+		* it no longer matched the GitHub logo.
+		*/
+		const MARK_PLUG_BLOCK = {
+			x: 10.74,
+			y: 2.09,
+			degrees: 9,
+			/** Rotation origin: the plug block's own centre. */
+			originX: 12.39,
+			originY: 3.74
+		};
+		//#endregion
 		//#region src/client/comments.ts
 		/**
 		* giscus wiring for the in-market comment thread.
@@ -5875,86 +5947,36 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 		* Official-style market glyph: the shared block-grid brand mark converted to
 		* the official monochrome icon form (16×16, fill="currentColor") so it
 		* follows the active theme. Mirrors the settings-nav glyph used for the
-		* "market" section id.
+		* "market" section id — both now draw the geometry in market-mark.ts, so the
+		* nav entry and the section it opens cannot drift apart.
 		*/
 		function MarketLogo({ size = 16, style, animated = false }) {
 			return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("svg", {
 				width: size,
 				height: size,
-				viewBox: "0 0 16 16",
+				viewBox: `0 0 16 16`,
 				fill: "none",
 				xmlns: "http://www.w3.org/2000/svg",
 				"aria-hidden": "true",
 				style,
-				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("g", {
+				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("g", {
 					fill: "currentColor",
-					children: [
-						/* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
-							x: "1.96",
-							y: "3.36",
-							width: "3.3",
-							height: "3.3",
-							rx: "0.53"
-						}),
-						/* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
-							x: "5.71",
-							y: "3.36",
-							width: "3.3",
-							height: "3.3",
-							rx: "0.53"
-						}),
-						/* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
-							x: "1.96",
-							y: "7.11",
-							width: "3.3",
-							height: "3.3",
-							rx: "0.53"
-						}),
-						/* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
-							x: "5.71",
-							y: "7.11",
-							width: "3.3",
-							height: "3.3",
-							rx: "0.53"
-						}),
-						/* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
-							x: "9.46",
-							y: "7.11",
-							width: "3.3",
-							height: "3.3",
-							rx: "0.53"
-						}),
-						/* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
-							x: "1.96",
-							y: "10.86",
-							width: "3.3",
-							height: "3.3",
-							rx: "0.53"
-						}),
-						/* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
-							x: "5.71",
-							y: "10.86",
-							width: "3.3",
-							height: "3.3",
-							rx: "0.53"
-						}),
-						/* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
-							x: "9.46",
-							y: "10.86",
-							width: "3.3",
-							height: "3.3",
-							rx: "0.53"
-						})
-					]
+					children: MARK_GRID_BLOCKS.map((block) => /* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
+						x: block.x,
+						y: block.y,
+						width: MARK_BLOCK_SIZE,
+						height: MARK_BLOCK_SIZE,
+						rx: MARK_BLOCK_RADIUS
+					}, `${block.x},${block.y}`))
 				}), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("rect", {
 					className: animated ? Market_module_css_default.logoPlug : void 0,
-					x: "10.74",
-					y: "2.09",
-					width: "3.3",
-					height: "3.3",
-					rx: "0.53",
+					x: MARK_PLUG_BLOCK.x,
+					y: MARK_PLUG_BLOCK.y,
+					width: MARK_BLOCK_SIZE,
+					height: MARK_BLOCK_SIZE,
+					rx: MARK_BLOCK_RADIUS,
 					fill: "currentColor",
-					transform: animated ? void 0 : "rotate(9 12.39 3.74)"
+					transform: animated ? void 0 : `rotate(${MARK_PLUG_BLOCK.degrees} ${MARK_PLUG_BLOCK.originX} ${MARK_PLUG_BLOCK.originY})`
 				})]
 			});
 		}
@@ -11090,6 +11112,141 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 			}, (0, react.createElement)("div", { className: Market_module_css_default.setHeadText }, (0, react.createElement)("div", { className: Market_module_css_default.setName }, t("nav"), version !== null ? (0, react.createElement)("span", { className: Market_module_css_default.version }, ` v${version}`) : null, prerelease ? (0, react.createElement)("span", { className: Market_module_css_default.setBetaTag }, t("setChannelBeta")) : null), (0, react.createElement)("div", { className: Market_module_css_default.setDesc }, t("setCardDesc"))), (0, react.createElement)("span", { className: open ? `${Market_module_css_default.setChevron} ${Market_module_css_default.setChevronOpen}` : Market_module_css_default.setChevron }, (0, react.createElement)(_deepseek_ai_dsh_client_ui_primitives.IconChevronDownOutline14, { size: 14 }))), open ? (0, react.createElement)("div", { className: Market_module_css_default.setBody }, body) : null);
 		}
 		//#endregion
+		//#region src/client/settings-nav-icon.ts
+		/**
+		* The market's block mark in the settings navigation.
+		*
+		* The settings shell picks nav glyphs from a closed list of section ids
+		* (`models`, `agent-presets`, `plugins`) and falls back to its own gear for
+		* every other id; `settings.section` projects only `id` / `order` / `label`,
+		* so a registrant has no icon to pass — the slot contract in
+		* `@deepseek-ai/dsh-client-ui-settings` and the runtime slot inventory both
+		* list exactly those three options. Every third-party section therefore wears
+		* the gear, the market included.
+		*
+		* So the market claims its own row once the dialog is mounted and swaps the
+		* fallback gear for the block mark — the same mark `MarketLogo` draws inside
+		* the section (see market-mark.ts), which is what makes the nav entry read as
+		* the same thing as the page it opens. `dsh-better-sidebar` and
+		* `dsh-skill-mcp-panel` solve it the same way.
+		*
+		* Scope, deliberately narrow:
+		*
+		* - only the row whose visible text equals this plugin's own localized
+		*   section label is marked; no shell structure is touched;
+		* - the marker and the injected stylesheet belong to a `ctx.effect`, so they
+		*   are removed with the fiber;
+		* - a locale switch re-claims the row through the MutationObserver, so the
+		*   label and the glyph never disagree.
+		*
+		* Delete this module (and its call in index.ts) the day `settings.section`
+		* grows an `icon` field.
+		*/
+		/** Marks the one nav row this plugin owns. */
+		const NAV_ICON_MARKER = "data-dsh-market-nav-icon";
+		/**
+		* The nav rows of the settings dialog. The shell renders each
+		* `settings.section` entry as a `<button>` inside the panel's `<nav>`
+		* (SettingsPanel in dsh-client-ui-settings-general).
+		*/
+		const NAV_ROW_SELECTOR = "[role=\"dialog\"] nav button";
+		/**
+		* The mark as standalone SVG for a CSS `mask-image`.
+		*
+		* Painted pure black on purpose: a mask reads alpha only, and the visible
+		* colour comes from the element's `background-color: currentColor`. The
+		* plug block carries its tilt without the animated variant's transform
+		* classes — a mask cannot animate through CSS-module classes.
+		*/
+		function marketMaskSvg() {
+			const blocks = MARK_GRID_BLOCKS.map((block) => `<rect x="${block.x}" y="${block.y}" width="${MARK_BLOCK_SIZE}" height="${MARK_BLOCK_SIZE}" rx="${MARK_BLOCK_RADIUS}"/>`).join("");
+			const plug = MARK_PLUG_BLOCK;
+			return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="#000"><g>${blocks}</g><rect x="${plug.x}" y="${plug.y}" width="${MARK_BLOCK_SIZE}" height="${MARK_BLOCK_SIZE}" rx="${MARK_BLOCK_RADIUS}" transform="rotate(${plug.degrees} ${plug.originX} ${plug.originY})"/></svg>`;
+		}
+		/** The mask URL for the mark (encoded at runtime, never hand-escaped). */
+		function marketMaskUrl(svg = marketMaskSvg()) {
+			return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+		}
+		/**
+		* Whether a nav row is this plugin's own.
+		*
+		* Pure, and the only decision this feature makes: the row whose visible text
+		* is the section label the shell is currently projecting. An empty label
+		* matches nothing — a locale that has not resolved yet must not mark the
+		* whole nav.
+		*/
+		function isOwnNavRow(rowText, wantedLabel) {
+			const wanted = String(wantedLabel ?? "").trim();
+			if (wanted.length === 0) return false;
+			return String(rowText ?? "").trim() === wanted;
+		}
+		/** Stylesheet for the marked row: hide the shell's gear, draw the mark. */
+		function navIconCss(maskUrl) {
+			return [
+				`[${NAV_ICON_MARKER}] > svg { display: none; }`,
+				`[${NAV_ICON_MARKER}]::before {`,
+				`  content: '';`,
+				`  flex: none;`,
+				`  width: 16px;`,
+				`  height: 16px;`,
+				`  background-color: currentColor;`,
+				`  -webkit-mask-image: url("${maskUrl}");`,
+				`  mask-image: url("${maskUrl}");`,
+				`  -webkit-mask-repeat: no-repeat;`,
+				`  mask-repeat: no-repeat;`,
+				`  -webkit-mask-position: center;`,
+				`  mask-position: center;`,
+				`  -webkit-mask-size: 16px 16px;`,
+				`  mask-size: 16px 16px;`,
+				`}`
+			].join("\n");
+		}
+		/**
+		* Install the nav glyph.
+		*
+		* @param ctx - client context, for effect ownership.
+		* @param resolveLabel - this plugin's current section label (the same thunk
+		*   the `settings.section` registration passes), re-read on every sync so a
+		*   locale switch is picked up without re-registering.
+		*/
+		function installSettingsNavIcon(ctx, resolveLabel) {
+			if (typeof document === "undefined") return;
+			ctx.effect(() => {
+				const tag = document.createElement("style");
+				tag.dataset.plugin = "dshmarket";
+				tag.dataset.pluginCss = "dshmarket/settings-nav-icon";
+				tag.textContent = navIconCss(marketMaskUrl());
+				document.head.appendChild(tag);
+				let disposed = false;
+				let scheduled = false;
+				const sync = () => {
+					scheduled = false;
+					if (disposed) return;
+					const wanted = resolveLabel();
+					for (const row of document.querySelectorAll(NAV_ROW_SELECTOR)) if (isOwnNavRow(row.textContent, wanted)) row.setAttribute(NAV_ICON_MARKER, "");
+					else row.removeAttribute(NAV_ICON_MARKER);
+				};
+				const schedule = () => {
+					if (scheduled || disposed) return;
+					scheduled = true;
+					queueMicrotask(sync);
+				};
+				sync();
+				const observer = new MutationObserver(schedule);
+				observer.observe(document.body, {
+					childList: true,
+					subtree: true,
+					characterData: true
+				});
+				return () => {
+					disposed = true;
+					observer.disconnect();
+					for (const row of document.querySelectorAll(`[${NAV_ICON_MARKER}]`)) row.removeAttribute(NAV_ICON_MARKER);
+					tag.remove();
+				};
+			}, "dsh-market: settings nav icon");
+		}
+		//#endregion
 		//#region src/client/index.ts
 		/**
 		* dsh-market client: registers a "Market" settings section rendering the
@@ -11132,6 +11289,7 @@ window.__ModuleLoader__.load({ id: "dshmarket", factory: (require) => {
 				en
 			}), "dsh-market: dictionaries");
 			const t = ctx.locale.bind(NS);
+			installSettingsNavIcon(ctx, () => t("nav"));
 			let retireSection = null;
 			ctx.slots.inject("settings.section", () => {
 				const off = ctx.slots.register({

--- a/src/client/MarketSection.tsx
+++ b/src/client/MarketSection.tsx
@@ -35,6 +35,7 @@ import {
   type MenuEntry,
 } from '@deepseek-ai/dsh-client-ui-primitives'
 import css from './Market.module.css'
+import { MARK_BLOCK_RADIUS, MARK_BLOCK_SIZE, MARK_GRID_BLOCKS, MARK_PLUG_BLOCK, MARK_VIEW_BOX } from './market-mark.ts'
 import { CommentsModal } from './CommentsModal.tsx'
 import { OperationsPanel } from './OperationsPanel.tsx'
 import { clearSettled, drop, enqueue, patch as patchRecord, recordForUrl } from './operations.ts'
@@ -980,20 +981,16 @@ export function resetMarketPortalHost(): void {
  * Official-style market glyph: the shared block-grid brand mark converted to
  * the official monochrome icon form (16×16, fill="currentColor") so it
  * follows the active theme. Mirrors the settings-nav glyph used for the
- * "market" section id.
+ * "market" section id — both now draw the geometry in market-mark.ts, so the
+ * nav entry and the section it opens cannot drift apart.
  */
 function MarketLogo({ size = 16, style, animated = false }: { size?: number; style?: CSSProperties; animated?: boolean }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={style}>
+    <svg width={size} height={size} viewBox={`0 0 ${MARK_VIEW_BOX} ${MARK_VIEW_BOX}`} fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={style}>
       <g fill="currentColor">
-        <rect x="1.96" y="3.36" width="3.3" height="3.3" rx="0.53" />
-        <rect x="5.71" y="3.36" width="3.3" height="3.3" rx="0.53" />
-        <rect x="1.96" y="7.11" width="3.3" height="3.3" rx="0.53" />
-        <rect x="5.71" y="7.11" width="3.3" height="3.3" rx="0.53" />
-        <rect x="9.46" y="7.11" width="3.3" height="3.3" rx="0.53" />
-        <rect x="1.96" y="10.86" width="3.3" height="3.3" rx="0.53" />
-        <rect x="5.71" y="10.86" width="3.3" height="3.3" rx="0.53" />
-        <rect x="9.46" y="10.86" width="3.3" height="3.3" rx="0.53" />
+        {MARK_GRID_BLOCKS.map(block => (
+          <rect key={`${block.x},${block.y}`} x={block.x} y={block.y} width={MARK_BLOCK_SIZE} height={MARK_BLOCK_SIZE} rx={MARK_BLOCK_RADIUS} />
+        ))}
       </g>
       {/* The block being plugged in: OUTSIDE the grid's empty corner, offset
           (+1.28, -1.27) and tilted 9deg, exactly as in assets/logo.svg. The
@@ -1002,8 +999,8 @@ function MarketLogo({ size = 16, style, animated = false }: { size?: number; sty
           mark, and the reason it no longer matched the GitHub logo. */}
       <rect
         className={animated ? css.logoPlug : undefined}
-        x="10.74" y="2.09" width="3.3" height="3.3" rx="0.53" fill="currentColor"
-        transform={animated ? undefined : 'rotate(9 12.39 3.74)'}
+        x={MARK_PLUG_BLOCK.x} y={MARK_PLUG_BLOCK.y} width={MARK_BLOCK_SIZE} height={MARK_BLOCK_SIZE} rx={MARK_BLOCK_RADIUS} fill="currentColor"
+        transform={animated ? undefined : `rotate(${MARK_PLUG_BLOCK.degrees} ${MARK_PLUG_BLOCK.originX} ${MARK_PLUG_BLOCK.originY})`}
       />
     </svg>
   )

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,6 +13,7 @@ import { MarketErrorBoundary } from './ErrorBoundary.tsx'
 import { MarketSection } from './MarketSection.tsx'
 import { exportMarketLog } from './self-check.ts'
 import { SettingsCard } from './SettingsCard.tsx'
+import { installSettingsNavIcon } from './settings-nav-icon.ts'
 import type { ThemeSnapshot, Translate } from './market-data.ts'
 
 const NS = 'dsh-market'
@@ -95,6 +96,13 @@ export function apply(ctx: MarketClientContext): void {
 
   ctx.effect(() => ctx.locale.register(NS, { zh, en }), 'dsh-market: dictionaries')
   const t = ctx.locale.bind(NS)
+
+  // The section's nav glyph. The shell picks nav icons from its own built-in
+  // ids and falls back to the settings gear, and a settings.section
+  // registration has no icon to pass — so the market claims its own row and
+  // swaps the gear for the block mark. Same label thunk as the registration
+  // below, so the row is re-claimed when the locale changes.
+  installSettingsNavIcon(ctx, () => t('nav'))
 
   // Kept so the removal flow can retire the market's own nav entry the
   // moment the package is gone: leaving "插件市场" in the left menu after

--- a/src/client/market-mark.ts
+++ b/src/client/market-mark.ts
@@ -1,0 +1,47 @@
+/**
+ * The market's block mark as geometry rather than as a component.
+ *
+ * Two consumers draw this mark and they must not drift:
+ *
+ * - `MarketLogo` (MarketSection.tsx) renders it inside the section as an
+ *   ordinary React SVG in `currentColor`, including the animated variant;
+ * - `settings-nav-icon.ts` serialises it into a CSS mask for the settings
+ *   navigation glyph, which cannot use `currentColor` (a mask is an
+ *   independent image) and so needs it as standalone markup.
+ *
+ * Keeping the numbers here means a change to the mark is one edit, and the
+ * suite can hold both renderings to the same source.
+ *
+ * The mark is the brand asset in `assets/logo.svg`: an 8-cell grid plus the
+ * block being plugged into its empty corner, offset and tilted 9°.
+ */
+
+/** Side of one block, and its corner radius. */
+export const MARK_BLOCK_SIZE = 3.3
+export const MARK_BLOCK_RADIUS = 0.53
+
+/** The square every coordinate in the mark is expressed in. */
+export const MARK_VIEW_BOX = 16
+
+/** The eight grid cells, row-major. The ninth slot stays empty on purpose. */
+export const MARK_GRID_BLOCKS: readonly { readonly x: number; readonly y: number }[] = [
+  { x: 1.96, y: 3.36 }, { x: 5.71, y: 3.36 },
+  { x: 1.96, y: 7.11 }, { x: 5.71, y: 7.11 }, { x: 9.46, y: 7.11 },
+  { x: 1.96, y: 10.86 }, { x: 5.71, y: 10.86 }, { x: 9.46, y: 10.86 },
+]
+
+/**
+ * The block being plugged in: OUTSIDE the grid's empty corner, offset
+ * (+1.28, -1.27) and tilted 9deg, exactly as in assets/logo.svg. The earlier
+ * icon sat it neatly in the empty slot, which reads as one crooked tile
+ * rather than a block arriving — the whole idea of the mark, and the reason
+ * it no longer matched the GitHub logo.
+ */
+export const MARK_PLUG_BLOCK = {
+  x: 10.74,
+  y: 2.09,
+  degrees: 9,
+  /** Rotation origin: the plug block's own centre. */
+  originX: 12.39,
+  originY: 3.74,
+} as const

--- a/src/client/settings-nav-icon.ts
+++ b/src/client/settings-nav-icon.ts
@@ -1,0 +1,174 @@
+/**
+ * The market's block mark in the settings navigation.
+ *
+ * The settings shell picks nav glyphs from a closed list of section ids
+ * (`models`, `agent-presets`, `plugins`) and falls back to its own gear for
+ * every other id; `settings.section` projects only `id` / `order` / `label`,
+ * so a registrant has no icon to pass — the slot contract in
+ * `@deepseek-ai/dsh-client-ui-settings` and the runtime slot inventory both
+ * list exactly those three options. Every third-party section therefore wears
+ * the gear, the market included.
+ *
+ * So the market claims its own row once the dialog is mounted and swaps the
+ * fallback gear for the block mark — the same mark `MarketLogo` draws inside
+ * the section (see market-mark.ts), which is what makes the nav entry read as
+ * the same thing as the page it opens. `dsh-better-sidebar` and
+ * `dsh-skill-mcp-panel` solve it the same way.
+ *
+ * Scope, deliberately narrow:
+ *
+ * - only the row whose visible text equals this plugin's own localized
+ *   section label is marked; no shell structure is touched;
+ * - the marker and the injected stylesheet belong to a `ctx.effect`, so they
+ *   are removed with the fiber;
+ * - a locale switch re-claims the row through the MutationObserver, so the
+ *   label and the glyph never disagree.
+ *
+ * Delete this module (and its call in index.ts) the day `settings.section`
+ * grows an `icon` field.
+ */
+import {
+  MARK_BLOCK_RADIUS,
+  MARK_BLOCK_SIZE,
+  MARK_GRID_BLOCKS,
+  MARK_PLUG_BLOCK,
+  MARK_VIEW_BOX,
+} from './market-mark.ts'
+
+/** Marks the one nav row this plugin owns. */
+export const NAV_ICON_MARKER = 'data-dsh-market-nav-icon'
+
+/**
+ * The nav rows of the settings dialog. The shell renders each
+ * `settings.section` entry as a `<button>` inside the panel's `<nav>`
+ * (SettingsPanel in dsh-client-ui-settings-general).
+ */
+export const NAV_ROW_SELECTOR = '[role="dialog"] nav button'
+
+/**
+ * Glyph box in px. The shell renders every nav icon at this size and ships no
+ * media query at all; the only thing that ever shrinks those icons is another
+ * plugin's mobile stylesheet, which is not this module's business to
+ * second-guess. So there is deliberately no narrow variant here.
+ */
+export const NAV_ICON_SIZE = 16
+
+/**
+ * The mark as standalone SVG for a CSS `mask-image`.
+ *
+ * Painted pure black on purpose: a mask reads alpha only, and the visible
+ * colour comes from the element's `background-color: currentColor`. The
+ * plug block carries its tilt without the animated variant's transform
+ * classes — a mask cannot animate through CSS-module classes.
+ */
+export function marketMaskSvg(): string {
+  const blocks = MARK_GRID_BLOCKS
+    .map(block => `<rect x="${block.x}" y="${block.y}" width="${MARK_BLOCK_SIZE}" height="${MARK_BLOCK_SIZE}" rx="${MARK_BLOCK_RADIUS}"/>`)
+    .join('')
+  const plug = MARK_PLUG_BLOCK
+  return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 '
+    + `${MARK_VIEW_BOX} ${MARK_VIEW_BOX}" fill="#000">`
+    + `<g>${blocks}</g>`
+    + `<rect x="${plug.x}" y="${plug.y}" width="${MARK_BLOCK_SIZE}" height="${MARK_BLOCK_SIZE}"`
+    + ` rx="${MARK_BLOCK_RADIUS}" transform="rotate(${plug.degrees} ${plug.originX} ${plug.originY})"/>`
+    + '</svg>'
+}
+
+/** The mask URL for the mark (encoded at runtime, never hand-escaped). */
+export function marketMaskUrl(svg: string = marketMaskSvg()): string {
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`
+}
+
+/**
+ * Whether a nav row is this plugin's own.
+ *
+ * Pure, and the only decision this feature makes: the row whose visible text
+ * is the section label the shell is currently projecting. An empty label
+ * matches nothing — a locale that has not resolved yet must not mark the
+ * whole nav.
+ */
+export function isOwnNavRow(rowText: string | null | undefined, wantedLabel: string | null | undefined): boolean {
+  const wanted = String(wantedLabel ?? '').trim()
+  if (wanted.length === 0) return false
+  return String(rowText ?? '').trim() === wanted
+}
+
+/** Stylesheet for the marked row: hide the shell's gear, draw the mark. */
+export function navIconCss(maskUrl: string): string {
+  return [
+    `[${NAV_ICON_MARKER}] > svg { display: none; }`,
+    `[${NAV_ICON_MARKER}]::before {`,
+    `  content: '';`,
+    `  flex: none;`,
+    `  width: ${NAV_ICON_SIZE}px;`,
+    `  height: ${NAV_ICON_SIZE}px;`,
+    `  background-color: currentColor;`,
+    `  -webkit-mask-image: url("${maskUrl}");`,
+    `  mask-image: url("${maskUrl}");`,
+    `  -webkit-mask-repeat: no-repeat;`,
+    `  mask-repeat: no-repeat;`,
+    `  -webkit-mask-position: center;`,
+    `  mask-position: center;`,
+    `  -webkit-mask-size: ${NAV_ICON_SIZE}px ${NAV_ICON_SIZE}px;`,
+    `  mask-size: ${NAV_ICON_SIZE}px ${NAV_ICON_SIZE}px;`,
+    `}`,
+  ].join('\n')
+}
+
+/** The slice of the client context this feature needs (matches index.ts's
+ * structural MarketClientContext, so no monorepo-internal types are pulled in). */
+export interface NavIconContext {
+  effect(callback: () => unknown, label?: string): void
+}
+
+/**
+ * Install the nav glyph.
+ *
+ * @param ctx - client context, for effect ownership.
+ * @param resolveLabel - this plugin's current section label (the same thunk
+ *   the `settings.section` registration passes), re-read on every sync so a
+ *   locale switch is picked up without re-registering.
+ */
+export function installSettingsNavIcon(ctx: NavIconContext, resolveLabel: () => string): void {
+  if (typeof document === 'undefined') return
+
+  ctx.effect(() => {
+    const tag = document.createElement('style')
+    tag.dataset.plugin = 'dshmarket'
+    tag.dataset.pluginCss = 'dshmarket/settings-nav-icon'
+    tag.textContent = navIconCss(marketMaskUrl())
+    document.head.appendChild(tag)
+
+    let disposed = false
+    let scheduled = false
+
+    const sync = () => {
+      scheduled = false
+      if (disposed) return
+      const wanted = resolveLabel()
+      for (const row of document.querySelectorAll(NAV_ROW_SELECTOR)) {
+        if (isOwnNavRow(row.textContent, wanted)) row.setAttribute(NAV_ICON_MARKER, '')
+        else row.removeAttribute(NAV_ICON_MARKER)
+      }
+    }
+
+    // Coalesce a burst of DOM mutations into one sync, and land it before the
+    // next paint so the row never shows the gear first.
+    const schedule = () => {
+      if (scheduled || disposed) return
+      scheduled = true
+      queueMicrotask(sync)
+    }
+
+    sync()
+    const observer = new MutationObserver(schedule)
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true })
+
+    return () => {
+      disposed = true
+      observer.disconnect()
+      for (const row of document.querySelectorAll(`[${NAV_ICON_MARKER}]`)) row.removeAttribute(NAV_ICON_MARKER)
+      tag.remove()
+    }
+  }, 'dsh-market: settings nav icon')
+}

--- a/tests/client/settings-nav-icon.client.spec.ts
+++ b/tests/client/settings-nav-icon.client.spec.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+/**
+ * The market's own glyph in the settings navigation.
+ *
+ * The shell chooses nav icons from its own built-in ids and falls back to the
+ * gear for every other section, and a `settings.section` registration has no
+ * icon to pass — so this module claims the market's row once the dialog is
+ * mounted. What the tests pin is the set of failures that are quiet rather
+ * than loud: claiming a row that belongs to another section (which would take
+ * that section's icon away), keeping a stale claim after a locale switch, and
+ * leaving the marker or the stylesheet behind when the fiber goes away.
+ *
+ * The visual half — does the masked glyph actually look like the mark — is
+ * covered by keeping one source of geometry for both renderings, which the
+ * last two tests hold in place.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  NAV_ICON_MARKER,
+  installSettingsNavIcon,
+  marketMaskUrl,
+  navIconCss,
+} from '../../src/client/settings-nav-icon.ts'
+import { MARK_BLOCK_RADIUS, MARK_BLOCK_SIZE, MARK_GRID_BLOCKS, MARK_PLUG_BLOCK } from '../../src/client/market-mark.ts'
+
+/** The shell's own fallback glyph, as the row receives it. */
+const GEAR = '<svg class="VOzbGW_navIcon" viewBox="0 0 16 16"></svg>'
+
+const STYLESHEET_SELECTOR = 'style[data-plugin-css="dshmarket/settings-nav-icon"]'
+
+/** Let the MutationObserver's queued sync run. */
+const flush = () => new Promise<void>(resolve => { setTimeout(resolve, 0) })
+
+let label = '插件市场'
+let disposers: (() => void)[] = []
+
+/** The shell's panel: role="dialog" > nav > one <button> per section. */
+function mountDialog(...sections: string[]): void {
+  document.querySelector('[role="dialog"]')?.remove()
+  const dialog = document.createElement('div')
+  dialog.setAttribute('role', 'dialog')
+  const nav = document.createElement('nav')
+  for (const section of sections) {
+    const row = document.createElement('button')
+    row.type = 'button'
+    row.className = 'VOzbGW_navCell'
+    row.innerHTML = `${GEAR}<span class="VOzbGW_navLabel">${section}</span>`
+    nav.append(row)
+  }
+  dialog.append(nav)
+  document.body.append(dialog)
+}
+
+const marked = (): string[] =>
+  [...document.querySelectorAll(`[${NAV_ICON_MARKER}]`)].map(row => row.textContent?.trim() ?? '')
+
+const stylesheet = (): HTMLStyleElement | null => document.head.querySelector(STYLESHEET_SELECTOR)
+
+beforeEach(() => {
+  label = '插件市场'
+  disposers = []
+  // The market boots with the client, before any settings dialog exists.
+  installSettingsNavIcon({ effect: (callback) => { disposers.push(callback() as () => void) } }, () => label)
+})
+
+afterEach(() => {
+  for (const dispose of disposers) dispose()
+  disposers = []
+  document.body.innerHTML = ''
+  document.querySelectorAll(STYLESHEET_SELECTOR).forEach(tag => tag.remove())
+})
+
+describe('settings nav glyph', () => {
+  it('claims its own row and nobody else\'s', async () => {
+    mountDialog('通用设置', '手机访问', '插件市场', '模型')
+    await flush()
+
+    // "手机访问" belongs to dsh-pocket, "模型"/"通用设置" to the shell: a
+    // marker on any of them would replace an icon this plugin does not own.
+    expect(marked()).toEqual(['插件市场'])
+  })
+
+  it('claims nothing while the section label has not resolved', async () => {
+    label = ''
+    mountDialog('通用设置', '插件市场')
+    await flush()
+
+    expect(marked()).toEqual([])
+  })
+
+  it('moves the claim when the locale switches', async () => {
+    mountDialog('General', '手机访问', 'Plugin Market')
+    await flush()
+    expect(marked()).toEqual([])
+
+    // The shell re-renders its nav on a locale change, which is what the
+    // observer sees; the module must not need a second registration for it.
+    label = 'Plugin Market'
+    mountDialog('General', '手机访问', 'Plugin Market')
+    await flush()
+
+    expect(marked()).toEqual(['Plugin Market'])
+  })
+
+  it('hides the shell gear and paints the mark through a mask', async () => {
+    mountDialog('插件市场')
+    await flush()
+
+    const row = document.querySelector('[role="dialog"] nav button')
+    expect(row?.querySelector('svg'), 'the row must carry a gear for the stylesheet to hide').not.toBeNull()
+
+    const css = stylesheet()?.textContent ?? ''
+    expect(css).toContain(`[${NAV_ICON_MARKER}] > svg { display: none; }`)
+    // currentColor, so the glyph follows the row's colour in either theme and
+    // in the active state.
+    expect(css).toContain('background-color: currentColor')
+    expect(css).toContain('-webkit-mask-image: url("data:image/svg+xml,')
+    expect(css).toContain('mask-image: url("data:image/svg+xml,')
+    // A mask is an independent image: currentColor inside it would not resolve.
+    expect(css).not.toContain('currentColor);')
+  })
+
+  it('masks the mark the section draws, from the one source of geometry', async () => {
+    mountDialog('插件市场')
+    await flush()
+
+    const svg = decodeURIComponent(marketMaskUrl().replace('data:image/svg+xml,', ''))
+    expect(svg.match(/<rect/g)).toHaveLength(MARK_GRID_BLOCKS.length + 1)
+    for (const block of MARK_GRID_BLOCKS) {
+      expect(svg).toContain(`<rect x="${block.x}" y="${block.y}" width="${MARK_BLOCK_SIZE}" height="${MARK_BLOCK_SIZE}" rx="${MARK_BLOCK_RADIUS}"/>`)
+    }
+    expect(svg).toContain(`x="${MARK_PLUG_BLOCK.x}" y="${MARK_PLUG_BLOCK.y}"`)
+    expect(svg).toContain(`transform="rotate(${MARK_PLUG_BLOCK.degrees} ${MARK_PLUG_BLOCK.originX} ${MARK_PLUG_BLOCK.originY})"`)
+
+    // And the section must not have gone back to carrying its own copy of the
+    // numbers: a second copy is how the nav entry and the page it opens drift.
+    const section = readFileSync(resolve('src/client/MarketSection.tsx'), 'utf8')
+    expect(section).toContain('MARK_GRID_BLOCKS')
+    expect(section).not.toContain('x="1.96"')
+    expect(section).not.toContain('x="10.74"')
+  })
+
+  it('leaves no marker and no stylesheet behind when the fiber goes away', async () => {
+    mountDialog('通用设置', '插件市场')
+    await flush()
+    expect(marked()).toEqual(['插件市场'])
+    expect(stylesheet()).not.toBeNull()
+
+    for (const dispose of disposers) dispose()
+    await flush()
+
+    expect(marked()).toEqual([])
+    expect(stylesheet()).toBeNull()
+  })
+})


### PR DESCRIPTION
### For code changes / 代码改动

- [x] `npm test` and `npm run check` pass locally / 本地通过
- [x] Tests cover the change / 新增测试覆盖改动
- [x] No version bump in `package.json` / 未改版本号
- [x] `client/client.js` rebuilt with `npm run build:client` / 已重建产物

## What changed and why / 改动内容与原因

设置页左栏的「插件市场」一直挂着外壳兜底的齿轮。原因是外壳的导航图标取自一份写死的 id 名单（`models` / `agent-presets` / `plugins`），其余条目一律兜底；而 `settings.section` 由外壳只投影 `id` / `order` / `label`，注册方没有 icon 可传。

`MarketLogo` 的注释里写着它 *"Mirrors the settings-nav glyph used for the 'market' section id"* —— 这个 PR 把那句话变成事实。

**做法**：对话框挂载后，把「可见文案 === 本插件当前本地化 section 文案」的那一行打上 data 标记；一条只认该标记的样式隐藏这一行的外壳 `svg`，并用 CSS mask 画出标志（`background-color: currentColor`，跟随主题与选中态）。标记与样式挂在 `ctx.effect` 上、随 fiber 释放，语言切换由 MutationObserver 重新认行。`dsh-better-sidebar` / `dsh-skill-mcp-panel` 用的是同一套办法。

**顺带一处重构**：标志的几何抽到 `src/client/market-mark.ts`，`MarketLogo` 与导航图标共用同一份来源 —— 否则以后改标志只会改一边，导航项和它打开的页面就长得不一样了。`MarketLogo` 的渲染结果不变（同一批 rect，同样的顺序与属性）。

**图标盒固定 16px**：外壳自身以 `size: 16` 渲染导航图标，且整包没有任何 `@media`；唯一会把这些图标缩小的是别的插件的移动端样式表，那不是这个模块该猜的事。

## 验证 / Verification

- `npm run check` ✓（typecheck + build + restart smoke）
- `npm test` → **1433 passed | 1 skipped (64 files)**（已合并最新 `main`），含新增的 6 个用例
- `git diff --exit-code client/` ✓ —— 提交的产物能被重新构建逐字节复现
- `node scripts/preflight.mjs` / `validate-registry.mjs` / `smoke-spawn.mjs` 本地均通过
- 新用例按 TESTING.md 的要求做了变异校验：让认行恒真 → 4 个用例红；不隐藏齿轮 → 1 个红；释放时不摘样式 → 1 个红
- 在真实 dsh web 里比对过 16px 下的实际效果：与页面标题里的标志形状一致（同一份几何来源）

## 备注 / Notes

- 认行依据是导航行的可见文案，与 `dsh-better-sidebar`、`dsh-skill-mcp-panel` 现状一致。文案本身改动不影响（代码跟着 `t('nav')` 走），但若外壳将来不再按文案渲染导航，需要同步调整认行方式。
- 上游若给 `settings.section` 增加 `icon` 字段，`src/client/settings-nav-icon.ts` 连同 `index.ts` 里那一行调用可以整个删掉。
